### PR TITLE
Adds a rule for no @extend

### DIFF
--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -9,6 +9,7 @@ rules:
   # Require an empty line between blocks
   empty-line-between-blocks: 1
   no-empty-rulesets: 1
+  no-extend: 1
   final-newline: 1
   no-ids: 1
   indentation: 1

--- a/lib/rules/no-extend.js
+++ b/lib/rules/no-extend.js
@@ -10,7 +10,6 @@ module.exports = {
     var result = [];
 
     ast.traverseByType('block', function(block) {
-
       block.traverse(function (item) {
         if (item.type === 'extend') {
           result = helpers.addUnique(result, {

--- a/lib/rules/no-extend.js
+++ b/lib/rules/no-extend.js
@@ -9,17 +9,13 @@ module.exports = {
   'detect': function(ast, parser) {
     var result = [];
 
-    ast.traverseByType('block', function(block) {
-      block.traverse(function (item) {
-        if (item.type === 'extend') {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': item.start.line,
-            'column': item.start.column,
-            'message': '@extend not allowed',
-            'severity': parser.severity
-          });
-        }
+    ast.traverseByType('extend', function(item) {
+      result = helpers.addUnique(result, {
+        'ruleId': parser.rule.name,
+        'line': item.start.line,
+        'column': item.start.column,
+        'message': '@extend not allowed',
+        'severity': parser.severity
       });
     });
 

--- a/lib/rules/no-extend.js
+++ b/lib/rules/no-extend.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var gonzales = require('gonzales-pe'),
+    helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-extend',
+  'defaults': {},
+  'detect': function(ast, parser) {
+    var result = [];
+
+    ast.traverseByType('block', function(block) {
+
+      block.traverse(function (item) {
+        if (item.type === 'extend') {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': item.start.line,
+            'column': item.start.column,
+            'message': '@extend not allowed',
+            'severity': parser.severity
+          });
+        }
+      });
+    });
+
+    return result;
+  }
+}

--- a/tests/sass/no-extend.scss
+++ b/tests/sass/no-extend.scss
@@ -1,0 +1,8 @@
+%foo {
+  color: red;
+}
+
+.bar {
+  @extend foo;
+  content: 'baz';
+}


### PR DESCRIPTION
This pull requests adds a rule for no `@extend`. It traverses all style blocks and checks if any of it's items are  `@extend`. This closes #19 (Request for rule)

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>