### PR TITLE
Add Space Before Bang and Space After Bang rules

### DIFF
--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -28,6 +28,7 @@ rules:
   space-before-brace: 1
 
   space-before-bang: 1
+  space-after-bang: 1
 
   space-between-parens: 1
   trailing-semicolon: 1

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -27,5 +27,7 @@ rules:
 
   space-before-brace: 1
 
+  space-before-bang: 1
+
   space-between-parens: 1
   trailing-semicolon: 1

--- a/lib/rules/space-after-bang.js
+++ b/lib/rules/space-after-bang.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var helpers = require('../helpers.js');
+
+module.exports = {
+  'name': 'space-after-bang',
+  'defaults': {
+    'include': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByTypes(['important'], function (block) {
+      block.traverse(function (item) {
+        if (item.type === 'space') {
+          if (parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': block.start.line,
+              'column': block.start.column + 1,
+              'message': 'Bangs (!) should be followed by a space',
+              'severity': parser.severity
+            });
+          }
+          else {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': block.start.line,
+              'column': block.start.column,
+              'message': 'Bangs (!) should not be followed by a space',
+              'severity': parser.severity
+            });
+          }
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/space-before-bang.js
+++ b/lib/rules/space-before-bang.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var helpers = require('../helpers.js');
+
+var getLastWhitespace = function (node) {
+  if (typeof node !== 'object') {
+    return false;
+  }
+  if (node.is('space')) {
+    return node;
+  }
+
+  return getLastWhitespace(node.last());
+};
+
+module.exports = {
+  'name': 'space-before-bang',
+  'defaults': {
+    'include': true
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByTypes(['important'], function (block, i, parent) {
+      var previous = parent.get(i - 1),
+          whitespace = getLastWhitespace(previous);
+
+      if (whitespace === false) {
+        if (parser.options.include) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': block.start.line,
+            'column': block.start.column - 1,
+            'message': 'Whitespace required before !important',
+            'severity': parser.severity
+          });
+        }
+      }
+      else {
+        if (!parser.options.include) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': whitespace.start.line,
+            'column': whitespace.start.column,
+            'message': 'Whitespace not allowed before !important',
+            'severity': parser.severity
+          });
+        }
+      }
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/space-before-bang.js
+++ b/lib/rules/space-before-bang.js
@@ -2,17 +2,6 @@
 
 var helpers = require('../helpers.js');
 
-var getLastWhitespace = function (node) {
-  if (typeof node !== 'object') {
-    return false;
-  }
-  if (node.is('space')) {
-    return node;
-  }
-
-  return getLastWhitespace(node.last());
-};
-
 module.exports = {
   'name': 'space-before-bang',
   'defaults': {
@@ -22,15 +11,14 @@ module.exports = {
     var result = [];
 
     ast.traverseByTypes(['important'], function (block, i, parent) {
-      var previous = parent.get(i - 1),
-          whitespace = getLastWhitespace(previous);
+      var previous = parent.content[i - 1];
 
-      if (whitespace === false) {
+      if (!previous.is('space')) {
         if (parser.options.include) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': block.start.line,
-            'column': block.start.column - 1,
+            'column': block.start.column,
             'message': 'Whitespace required before !important',
             'severity': parser.severity
           });
@@ -40,8 +28,8 @@ module.exports = {
         if (!parser.options.include) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
-            'line': whitespace.start.line,
-            'column': whitespace.start.column,
+            'line': block.start.line,
+            'column': block.start.column - 1,
             'message': 'Whitespace not allowed before !important',
             'severity': parser.severity
           });

--- a/lib/rules/space-before-bang.js
+++ b/lib/rules/space-before-bang.js
@@ -28,8 +28,8 @@ module.exports = {
         if (!parser.options.include) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
-            'line': block.start.line,
-            'column': block.start.column - 1,
+            'line': previous.start.line,
+            'column': previous.start.column,
             'message': 'Whitespace not allowed before !important',
             'severity': parser.severity
           });

--- a/tests/main.js
+++ b/tests/main.js
@@ -285,7 +285,7 @@ describe('rules', function () {
         'no-important': 0
       }
     }, function (data) {
-      assert.equal(1, data.warningCount);
+      assert.equal(2, data.warningCount);
       done();
     });
   });

--- a/tests/main.js
+++ b/tests/main.js
@@ -262,12 +262,16 @@ describe('rules', function () {
   // No Important
   //////////////////////////////
   it('no important', function (done) {
-    lintFile('no-important.scss', function (data) {
+    lintFile('no-important.scss', {
+      'rules': {
+        'no-important': 1,
+        'space-before-bang': 0
+      }
+    }, function (data) {
       assert.equal(1, data.warningCount);
       done();
     });
   });
-
 
   //////////////////////////////
   // Space Before Bang

--- a/tests/main.js
+++ b/tests/main.js
@@ -267,4 +267,20 @@ describe('rules', function () {
       done();
     });
   });
+
+
+  //////////////////////////////
+  // Space Before Bang
+  //////////////////////////////
+  it('space before bang', function (done) {
+    lintFile('space-before-bang.scss', {
+      'rules': {
+        'space-before-bang': 1,
+        'no-important': 0
+      }
+    }, function (data) {
+      assert.equal(1, data.warningCount);
+      done();
+    });
+  });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -265,7 +265,8 @@ describe('rules', function () {
     lintFile('no-important.scss', {
       'rules': {
         'no-important': 1,
-        'space-before-bang': 0
+        'space-before-bang': 0,
+        'space-after-bang': 0
       }
     }, function (data) {
       assert.equal(1, data.warningCount);
@@ -280,10 +281,27 @@ describe('rules', function () {
     lintFile('space-before-bang.scss', {
       'rules': {
         'space-before-bang': 1,
+        'space-after-bang': 0,
         'no-important': 0
       }
     }, function (data) {
       assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Space After Bang
+  //////////////////////////////
+  it('space after bang', function (done) {
+    lintFile('space-after-bang.scss', {
+      'rules': {
+        'space-after-bang': 1,
+        'space-before-bang': 0,
+        'no-important': 0
+      }
+    }, function (data) {
+      assert.equal(2, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-after-bang.scss
+++ b/tests/sass/space-after-bang.scss
@@ -1,0 +1,15 @@
+.foo {
+  color: orange !important;
+}
+
+.bar {
+  color: orange ! important;
+}
+
+.baz {
+  color: orange!important;
+}
+
+.qux {
+  color: orange! important;
+}

--- a/tests/sass/space-before-bang.scss
+++ b/tests/sass/space-before-bang.scss
@@ -5,3 +5,11 @@
 .bar {
   color: orange !important;
 }
+
+.baz {
+  color: green! important;
+}
+
+.quz {
+  color: pink ! important;
+}

--- a/tests/sass/space-before-bang.scss
+++ b/tests/sass/space-before-bang.scss
@@ -1,0 +1,7 @@
+.foo {
+  color: red!important;
+}
+
+.bar {
+  color: orange !important;
+}


### PR DESCRIPTION
This pull request adds 2 rules. One to manage the whitespace before a bang and another to manage the whitespace after a bang.

Defaults are to allow whitespace before but not after a bang.

Closes #26 (request for rules)


DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>