### PR TITLE
Add No Debug and No Warn rules

### DIFF
--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -1,0 +1,11 @@
+# No Debug
+
+Rule `no-debug` will enforce that `@debug` statements are not allowed to be used.
+
+## Examples
+
+When enabled, the following are disallowed:
+
+```scss
+@debug 'foo';
+```

--- a/docs/rules/no-warn.md
+++ b/docs/rules/no-warn.md
@@ -1,0 +1,11 @@
+# No Warn
+
+Rule `no-warn` will enforce that `@warn` statements are not allowed to be used.
+
+## Examples
+
+When enabled, the following are disallowed:
+
+```scss
+@warn 'foo';
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -32,3 +32,5 @@ rules:
 
   space-between-parens: 1
   trailing-semicolon: 1
+
+  no-debug: 1

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -34,3 +34,4 @@ rules:
   trailing-semicolon: 1
 
   no-debug: 1
+  no-warn: 1

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-debug',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('atkeyword', function (keyword) {
+      keyword.traverse(function (item) {
+        if (item.content === 'debug') {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': item.start.line,
+            'column': item.start.column,
+            'message': '@debug not allowed',
+            'severity': parser.severity
+          });
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/no-warn.js
+++ b/lib/rules/no-warn.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-warn',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('atkeyword', function (keyword) {
+      keyword.traverse(function (item) {
+        if (item.content === 'warn') {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': item.start.line,
+            'column': item.start.column,
+            'message': '@warn not allowed',
+            'severity': parser.severity
+          });
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -311,7 +311,7 @@ describe('rules', function () {
   //////////////////////////////
   it('no debug', function (done) {
     lintFile('no-debug.scss', function (data) {
-      assert.equal(2, data.warningCount);
+      assert.equal(3, data.warningCount);
       done();
     });
   });
@@ -321,7 +321,7 @@ describe('rules', function () {
   //////////////////////////////
   it('no warn', function (done) {
     lintFile('no-warn.scss', function (data) {
-      assert.equal(2, data.warningCount);
+      assert.equal(3, data.warningCount);
       done();
     });
   });

--- a/tests/main.js
+++ b/tests/main.js
@@ -305,4 +305,14 @@ describe('rules', function () {
       done();
     });
   });
+
+  //////////////////////////////
+  // No Debug
+  //////////////////////////////
+  it('no debug', function (done) {
+    lintFile('no-debug.scss', function (data) {
+      assert.equal(2, data.warningCount);
+      done();
+    });
+  });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -315,4 +315,14 @@ describe('rules', function () {
       done();
     });
   });
+
+  //////////////////////////////
+  // No Warn
+  //////////////////////////////
+  it('no warn', function (done) {
+    lintFile('no-warn.scss', function (data) {
+      assert.equal(2, data.warningCount);
+      done();
+    });
+  });
 });

--- a/tests/sass/no-debug.scss
+++ b/tests/sass/no-debug.scss
@@ -1,0 +1,7 @@
+@function foo {
+  @debug 'bar';
+}
+
+@mixin baz {
+  @debug 'qux';
+}

--- a/tests/sass/no-debug.scss
+++ b/tests/sass/no-debug.scss
@@ -1,3 +1,5 @@
+@debug 'foo';
+
 @function foo {
   @debug 'bar';
 }

--- a/tests/sass/no-warn.scss
+++ b/tests/sass/no-warn.scss
@@ -1,0 +1,7 @@
+@function foo {
+  @warn 'bar';
+}
+
+@mixin baz {
+  @warn 'qux';
+}

--- a/tests/sass/no-warn.scss
+++ b/tests/sass/no-warn.scss
@@ -1,3 +1,5 @@
+@warn 'foo';
+
 @function foo {
   @warn 'bar';
 }


### PR DESCRIPTION
This pull request adds 2 rules. One to detect and flag up the use of @debug and another to detect and flag up the use of @warn

Closes #37 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>