### PR TITLE
Fix issue with leading zero rule

### DIFF
--- a/lib/rules/leading-zero.js
+++ b/lib/rules/leading-zero.js
@@ -2,6 +2,10 @@
 
 var helpers = require('../helpers');
 
+
+var leadingZeroRegex = /^0\.\d+$/;
+var noLeadingZeroRegex = /^\.\d+$/;
+
 module.exports = {
   'name': 'leading-zero',
   'defaults': {
@@ -11,25 +15,29 @@ module.exports = {
     var result = [];
 
     ast.traverseByType('number', function (num) {
-      if (num.content.match(/^[0]([0-9]|.[0-9])/)) {
-        if (!parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': num.start.line,
-            'column': num.start.column,
-            'message': 'Don\'t include leading zeros on numbers',
-            'severity': parser.severity
-          });
+      if (num.content.match(/^-?(0?\.\d+)/)) {
+        if (num.content.match(leadingZeroRegex)) {
+          if (!parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': num.start.line,
+              'column': num.start.column,
+              'message': 'Don\'t include leading zeros on numbers',
+              'severity': parser.severity
+            });
+          }
         }
-      }
-      else if (parser.options.include) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': num.start.line,
-          'column': num.start.column - 1,
-          'message': 'Include leading zeros on numbers',
-          'severity': parser.severity
-        });
+        if (num.content.match(noLeadingZeroRegex)) {
+          if (parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': num.start.line,
+              'column': num.start.column - 1,
+              'message': 'Include leading zeros on numbers',
+              'severity': parser.severity
+            });
+          }
+        }
       }
     });
 

--- a/lib/rules/leading-zero.js
+++ b/lib/rules/leading-zero.js
@@ -2,9 +2,8 @@
 
 var helpers = require('../helpers');
 
-
-var leadingZeroRegex = /^0\.\d+$/;
-var noLeadingZeroRegex = /^\.\d+$/;
+var leadingZeroRegex = /^0\.\d+$/,
+    noLeadingZeroRegex = /^\.\d+$/;
 
 module.exports = {
   'name': 'leading-zero',

--- a/tests/sass/leading-zero.scss
+++ b/tests/sass/leading-zero.scss
@@ -1,5 +1,9 @@
 .foo {
   border-radius: .5em 0em, 0.5em 1.0em;
-  height: .5em;
+  height: .6em;
   width: 100%;
+}
+
+@if (1 == 0) {
+  $foo: true;
 }


### PR DESCRIPTION
This pull request fixes a major issue with the leading zero rule when it's set to include a leading zero. Currently when set to include it sass-lint reports all numbers as issues. This fix includes more specific regex to target either numbers with leading zero or those without depending on the settings.

Closes #49 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>