### PR TITLE
Fix issue with one declaration per line and named parameters

### DIFF
--- a/lib/rules/one-declaration-per-line.js
+++ b/lib/rules/one-declaration-per-line.js
@@ -9,15 +9,18 @@ module.exports = {
     var result = [],
         lastLine = {};
 
-    ast.traverseByType('declaration', function (declaration) {
+    ast.traverseByType('declaration', function (declaration, i, parent) {
+
       if (declaration.start.line === lastLine.start || declaration.start.line === lastLine.end) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': declaration.start.line,
-          'column': declaration.start.column,
-          'message': 'Only one declaration allowed per line',
-          'severity': parser.severity
-        });
+        if (parent.type !== 'arguments') {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': declaration.start.line,
+            'column': declaration.start.column,
+            'message': 'Only one declaration allowed per line',
+            'severity': parser.severity
+          });
+        }
       }
 
       lastLine.start = declaration.start.line;

--- a/tests/main.js
+++ b/tests/main.js
@@ -198,7 +198,7 @@ describe('rules', function () {
   //////////////////////////////
   it('one declaration per line', function (done) {
     lintFile('one-declaration-per-line.scss', function (data) {
-      assert.equal(1, data.warningCount);
+      assert.equal(2, data.warningCount);
       done();
     });
   });

--- a/tests/sass/one-declaration-per-line.scss
+++ b/tests/sass/one-declaration-per-line.scss
@@ -1,5 +1,25 @@
+// Should cause issue
+.foo {
+  content: 'baz'; content: 'qux';
+}
+
+.bar { color: red; content: 'bar'; }
+
+// Should be ok
 .foo {
   content: 'bar';
+}
 
-  content: 'baz'; content: 'qux';
+$foo: adjust-color(rgb(255, 0, 0), $lightness: -20%);
+
+.bar {
+  color: adjust-color(rgb(255, 0, 0), $blue: 5);
+}
+
+.baz {
+  color: scale-color(hsl(120, 70%, 80%), $lightness: 50%);
+}
+
+.qux {
+  color: change-color(hsl(25, 100%, 80%), $lightness: 40%, $alpha: .8);
 }


### PR DESCRIPTION
This pull request fixes an issue where the one line per declaration rule incorrectly caused an error/warning when checking named parameters. The fix checks if the declaration is an argument, and if so, ignores it.

Fixes #51 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>