### PR TITLE
Improve bang whitespace rules to consider default flag

### DIFF
--- a/lib/rules/space-after-bang.js
+++ b/lib/rules/space-after-bang.js
@@ -10,7 +10,7 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByTypes(['important'], function (block) {
+    ast.traverseByTypes(['important', 'default'], function (block) {
       block.traverse(function (item) {
         if (item.type === 'space') {
           if (parser.options.include) {

--- a/lib/rules/space-before-bang.js
+++ b/lib/rules/space-before-bang.js
@@ -10,7 +10,7 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByTypes(['important'], function (block, i, parent) {
+    ast.traverseByTypes(['important', 'default'], function (block, i, parent) {
       var previous = parent.content[i - 1];
 
       if (!previous.is('space')) {

--- a/tests/main.js
+++ b/tests/main.js
@@ -285,7 +285,7 @@ describe('rules', function () {
         'no-important': 0
       }
     }, function (data) {
-      assert.equal(2, data.warningCount);
+      assert.equal(4, data.warningCount);
       done();
     });
   });
@@ -301,7 +301,7 @@ describe('rules', function () {
         'no-important': 0
       }
     }, function (data) {
-      assert.equal(2, data.warningCount);
+      assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-after-bang.scss
+++ b/tests/sass/space-after-bang.scss
@@ -1,3 +1,5 @@
+// Important
+
 .foo {
   color: orange !important;
 }
@@ -13,3 +15,13 @@
 .qux {
   color: orange! important;
 }
+
+// Default
+
+$foo: red!default;
+
+$foo: red !default;
+
+$foo: red! default;
+
+$foo: red ! default;

--- a/tests/sass/space-before-bang.scss
+++ b/tests/sass/space-before-bang.scss
@@ -1,3 +1,5 @@
+// Imporant
+
 .foo {
   color: red!important;
 }
@@ -13,3 +15,13 @@
 .quz {
   color: pink ! important;
 }
+
+// Default
+
+$foo: red!default;
+
+$foo: red !default;
+
+$foo: red! default;
+
+$foo: red ! default;


### PR DESCRIPTION
Consider the `!default` flag as well as the `!important` when checking the `space-before-bang` and `space-after-bang` rules.

Closes #53

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com