### PR TITLE
Add Clean Import Paths rule

### DIFF
--- a/docs/rules/clean-import-paths.md
+++ b/docs/rules/clean-import-paths.md
@@ -1,0 +1,32 @@
+# Clean Import Paths
+
+Rule `clean-import-path` will enforce whether or not import paths should have leading underscores, filename extensions or both.
+
+## Options
+
+* `leading-underscore`: `true`/`false` (defaults to false)
+* `filename-extension`: `true`/`false` (defaults to false)
+
+
+## Examples
+
+When neither `leading-underscore` or `filename-extension` are set to `true`, the following are allowed:
+
+```scss
+// Clean paths
+@import 'foo';
+@import 'bar/foo';
+```
+
+When neither `leading-underscore` or `filename-extension` are set to `true`, the following are disallowed:
+
+```scss
+@import 'foo.scss';
+@import 'bar/foo.scss';
+
+@import '_foo';
+@import 'bar/_foo';
+
+@import '_foo.scss';
+@import 'bar/_foo.scss';
+```

--- a/docs/rules/clean-import-paths.md
+++ b/docs/rules/clean-import-paths.md
@@ -1,6 +1,6 @@
 # Clean Import Paths
 
-Rule `clean-import-path` will enforce whether or not import paths should have leading underscores, filename extensions or both.
+Rule `clean-import-paths` will enforce whether or not import paths should have leading underscores and/or filename extensions.
 
 ## Options
 

--- a/docs/rules/clean-import-paths.md
+++ b/docs/rules/clean-import-paths.md
@@ -1,32 +1,44 @@
 # Clean Import Paths
 
-Rule `clean-import-paths` will enforce whether or not import paths should have leading underscores and/or filename extensions.
+Rule `clean-import-paths` will enforce whether or not `@import` paths should have leading underscores and/or filename extensions.
 
 ## Options
 
-* `leading-underscore`: `true`/`false` (defaults to false)
-* `filename-extension`: `true`/`false` (defaults to false)
+* `leading-underscore`: `true`/`false` (defaults to `false`)
+* `filename-extension`: `true`/`false` (defaults to `false`)
 
 
 ## Examples
 
-When neither `leading-underscore` or `filename-extension` are set to `true`, the following are allowed:
+### `leading-underscore`
+
+When `leading-underscore: false`, the following are allowed. When `leading-underscore: true`, the following are disallowed:
 
 ```scss
-// Clean paths
 @import 'foo';
 @import 'bar/foo';
 ```
 
-When neither `leading-underscore` or `filename-extension` are set to `true`, the following are disallowed:
+When `leading-underscore: true`, the following are allowed. When `leading-underscore: false`, the following are disallowed:
+
+```scss
+@import '_foo';
+@import '_bar/foo';
+```
+
+---
+### `filename-extension`
+
+When `filename-extension: false`, the following are allowed. When `filename-extension: true`, the following are disallowed:
+
+```scss
+@import 'foo';
+@import 'bar/foo';
+```
+
+When `filename-extension: true`, the following are allowed. When `filename-extension: false`, the following are disallowed:
 
 ```scss
 @import 'foo.scss';
 @import 'bar/foo.scss';
-
-@import '_foo';
-@import 'bar/_foo';
-
-@import '_foo.scss';
-@import 'bar/_foo.scss';
 ```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -29,6 +29,7 @@ rules:
   nesting-depth: 1
   property-sort-order: 1
   quotes: 1
+  clean-import-paths: 1
 
   # Inner Spacing
   space-after-comma: 1

--- a/lib/rules/clean-import-paths.js
+++ b/lib/rules/clean-import-paths.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var stripQuotes = function (str) {
+  return str.substring(1, str.length - 1);
+};
+
+var getFileExt = function (filename) {
+  return filename.split('.').pop();
+};
+
+var validExtensions = ['scss', 'sass'];
+
+
+module.exports = {
+  'name': 'import-path',
+  'defaults': {
+    'leading-underscore': false,
+    'filename-extension': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('atkeyword', function (keyword, i, parent) {
+      keyword.traverse(function (item) {
+        if (item.content === 'import') {
+
+          var importPath = stripQuotes(parent.first('string').content),
+              importPathArray = importPath.split('/'),
+              filename = importPathArray[importPathArray.length - 1],
+              fileExtension = getFileExt(filename);
+
+          if (fileExtension) {
+            if (validExtensions.indexOf(fileExtension) !== -1) {
+              if (!parser.options['filename-extension']) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': item.start.line,
+                  'column': item.start.column,
+                  'message': 'File extensions are not allowed',
+                  'severity': parser.severity
+                });
+              }
+            }
+          }
+          else {
+            if (parser.options['filename-extension']) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'File extensions are required',
+                'severity': parser.severity
+              });
+            }
+          }
+
+          if (filename.charAt(0) === '_') {
+            if (!parser.options['leading-underscore']) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'Leading underscores are not allowed',
+                'severity': parser.severity
+              });
+            }
+          }
+          else {
+            if (parser.options['leading-underscore']) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'Leading underscores are required',
+                'severity': parser.severity
+              });
+            }
+          }
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/clean-import-paths.js
+++ b/lib/rules/clean-import-paths.js
@@ -6,12 +6,19 @@ var stripQuotes = function (str) {
   return str.substring(1, str.length - 1);
 };
 
-var getFileExt = function (filename) {
-  return filename.split('.').pop();
+var getFilename = function (path) {
+  return path.split('/').pop().split('\\').pop();
 };
 
-var validExtensions = ['scss', 'sass'];
+var getExtension = function (filename) {
+  var lastIndex = filename.lastIndexOf('.');
 
+  if (lastIndex < 1) {
+    return false;
+  }
+
+  return filename.substr(lastIndex + 1);
+};
 
 module.exports = {
   'name': 'import-path',
@@ -27,34 +34,8 @@ module.exports = {
         if (item.content === 'import') {
 
           var importPath = stripQuotes(parent.first('string').content),
-              importPathArray = importPath.split('/'),
-              filename = importPathArray[importPathArray.length - 1],
-              fileExtension = getFileExt(filename);
-
-          if (fileExtension) {
-            if (validExtensions.indexOf(fileExtension) !== -1) {
-              if (!parser.options['filename-extension']) {
-                result = helpers.addUnique(result, {
-                  'ruleId': parser.rule.name,
-                  'line': item.start.line,
-                  'column': item.start.column,
-                  'message': 'File extensions are not allowed',
-                  'severity': parser.severity
-                });
-              }
-            }
-          }
-          else {
-            if (parser.options['filename-extension']) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': item.start.line,
-                'column': item.start.column,
-                'message': 'File extensions are required',
-                'severity': parser.severity
-              });
-            }
-          }
+              filename = getFilename(importPath),
+              fileExtension = getExtension(filename);
 
           if (filename.charAt(0) === '_') {
             if (!parser.options['leading-underscore']) {
@@ -74,6 +55,29 @@ module.exports = {
                 'line': item.start.line,
                 'column': item.start.column,
                 'message': 'Leading underscores are required',
+                'severity': parser.severity
+              });
+            }
+          }
+
+          if (fileExtension) {
+            if (!parser.options['filename-extension']) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'File extensions are not allowed',
+                'severity': parser.severity
+              });
+            }
+          }
+          else {
+            if (parser.options['filename-extension']) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'File extensions are required',
                 'severity': parser.severity
               });
             }

--- a/tests/main.js
+++ b/tests/main.js
@@ -335,4 +335,14 @@ describe('rule', function () {
       done();
     });
   });
+
+  //////////////////////////////
+  // Clean Import Paths
+  //////////////////////////////
+  it('clean import paths', function (done) {
+    lintFile('clean-import-paths.scss', function (data) {
+      assert.equal(8, data.warningCount);
+      done();
+    });
+  });
 });

--- a/tests/sass/clean-import-paths.scss
+++ b/tests/sass/clean-import-paths.scss
@@ -1,0 +1,15 @@
+// Clean paths
+@import 'foo';
+@import 'bar/foo';
+
+// Only filename extensions
+@import 'foo.scss';
+@import 'bar/foo.scss';
+
+// Only leading underscores
+@import '_foo';
+@import 'bar/_foo';
+
+// Both leading underscores and filename extensions
+@import '_foo.scss';
+@import 'bar/_foo.scss';


### PR DESCRIPTION
Adds a rule to manage the formatting of `@import` paths. Has two options that are both set to `false` by default, `leading-underscore` and `filename-extension`.

Closes #29 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>