### PR TITLE
Fix typo in Quotes doc

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -8,7 +8,7 @@ Rule `quotes` will enforce whether single quotes (`''`) or double quotes (`""`) 
 
 ## Examples
 
-When `style: string`, the following are allowed. When `style: double`, the following are disallowed:
+When `style: single`, the following are allowed. When `style: double`, the following are disallowed:
 
 ```scss
 .foo {


### PR DESCRIPTION
Fixes a single typo in the Quotes rule document.

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>