### PR TITLE
Add Zero Unit rule

### DIFF
--- a/docs/rules/zero-unit.md
+++ b/docs/rules/zero-unit.md
@@ -1,0 +1,33 @@
+# Zero Unit
+
+Rule `zero-unit` will enforce whether or not values of `0` used for length should be unitless.
+
+## Options
+
+* `include`: `true`/`false` (defaults to `false`)
+
+## Examples
+
+When `include: false`, the following are allowed. When `include: true`, the following are disallowed:
+
+```scss
+.foo {
+  margin: 0;
+}
+
+.bar {
+  padding: 5px 0 0;
+}
+```
+
+When `include: true`, the following are allowed. When `include: false`, the following are disallowed:
+
+```scss
+.foo {
+  margin: 0px;
+}
+
+.bar {
+  padding: 5px 0px 0px;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -29,6 +29,7 @@ rules:
   nesting-depth: 1
   property-sort-order: 1
   quotes: 1
+  zero-unit: 1
 
   # Inner Spacing
   space-after-comma: 1

--- a/lib/rules/zero-unit.js
+++ b/lib/rules/zero-unit.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var units = ['em', 'ex', 'ch', 'rem', 'vh', 'vw', 'vmin', 'vmax',
+            'px', 'mm', 'cm', 'in', 'pt', 'pc'];
+
+module.exports = {
+  'name': 'zero-unit',
+  'defaults': {
+    'include': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('number', function (item, i, parent) {
+
+      if (item.content === '0') {
+        if (parent.type === 'dimension') {
+          var next = parent.content[i + 1] || false;
+
+          if (units.indexOf(next.content) !== -1) {
+            if (!parser.options.include) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'severity': parser.severity,
+                'line': item.end.line,
+                'column': item.end.column,
+                'message': 'No unit allowed for values of 0'
+              });
+            }
+          }
+        }
+        else {
+          if (parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'severity': parser.severity,
+              'line': item.end.line,
+              'column': item.end.column,
+              'message': 'Unit required for values of 0'
+            });
+          }
+        }
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -117,7 +117,11 @@ describe('rule', function () {
   // Property Sort Order
   //////////////////////////////
   it('property sort order', function (done) {
-    lintFile('property-sort-order.scss', function (data) {
+    lintFile('property-sort-order.scss', {
+      'rules': {
+        'zero-unit': 0
+      }
+    }, function (data) {
       assert.equal(6, data.warningCount);
       done();
     });
@@ -167,7 +171,11 @@ describe('rule', function () {
   // Leading Zero
   //////////////////////////////
   it('leading zero', function (done) {
-    lintFile('leading-zero.scss', function (data) {
+    lintFile('leading-zero.scss', {
+      'rules': {
+        'zero-unit': 0
+      }
+    }, function (data) {
       assert.equal(1, data.warningCount);
       done();
     });
@@ -332,6 +340,20 @@ describe('rule', function () {
   it('quotes', function (done) {
     lintFile('quotes.scss', function (data) {
       assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Zero Unit
+  //////////////////////////////
+  it('zero unit', function (done) {
+    lintFile('zero-unit.scss', {
+      'rules': {
+        'zero-unit': 1
+      }
+    }, function (data) {
+      assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/zero-unit.scss
+++ b/tests/sass/zero-unit.scss
@@ -1,0 +1,25 @@
+.baz {
+  border-right-width: 0px;
+}
+
+.foo {
+  margin: 0px;
+  padding: 0;
+}
+
+.bar {
+  padding: 5px 0 0px;
+}
+
+$foo: 0px;
+$bar: '0px';
+
+.foo {
+  @if $bar == 0 {
+    content: 'bar';
+  }
+
+  @if $foo == '0px' {
+    content: 'foo';
+  }
+}


### PR DESCRIPTION
Add a rule to allow us to enforce the stripping of unnecessary, or the use of, length units on values of `0`.

Closes #68 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>