### PR TITLE
Fix bug in Zero Unit and add non default value test

### DIFF
--- a/lib/rules/zero-unit.js
+++ b/lib/rules/zero-unit.js
@@ -32,14 +32,16 @@ module.exports = {
           }
         }
         else {
-          if (parser.options.include) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'severity': parser.severity,
-              'line': item.end.line,
-              'column': item.end.column,
-              'message': 'Unit required for values of 0'
-            });
+          if (parent.type === 'value') {
+            if (parser.options.include) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'severity': parser.severity,
+                'line': item.end.line,
+                'column': item.end.column,
+                'message': 'Unit required for values of 0'
+              });
+            }
           }
         }
       }

--- a/tests/main.js
+++ b/tests/main.js
@@ -347,7 +347,9 @@ describe('rule', function () {
   //////////////////////////////
   // Zero Unit
   //////////////////////////////
-  it('zero unit - default - [include: false]', function (done) {
+
+  // Default
+  it('zero unit - [include: false]', function (done) {
     lintFile('zero-unit.scss', {
       'rules': {
         'zero-unit': 1

--- a/tests/main.js
+++ b/tests/main.js
@@ -347,13 +347,24 @@ describe('rule', function () {
   //////////////////////////////
   // Zero Unit
   //////////////////////////////
-  it('zero unit', function (done) {
+  it('zero unit - default - [include: false]', function (done) {
     lintFile('zero-unit.scss', {
       'rules': {
         'zero-unit': 1
       }
     }, function (data) {
       assert.equal(4, data.warningCount);
+      done();
+    });
+  });
+
+  it('zero unit - [include: true]', function (done) {
+    lintFile('zero-unit.scss', {
+      'rules': {
+        'zero-unit': [1, { 'include': true }]
+      }
+    }, function (data) {
+      assert.equal(2, data.warningCount);
       done();
     });
   });


### PR DESCRIPTION
Adds another test to Zero Unit which tests when `include` is set to `true`. Also fixes a bug by ensuring that when this option is set, it only reports a warning that a unit should be included when the unitless 0 is of value type.

Fixes #75

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com