### PR TITLE
Add hex notation rule

### DIFF
--- a/docs/rules/hex-notation.md
+++ b/docs/rules/hex-notation.md
@@ -1,0 +1,45 @@
+# Hex Notation
+
+Rule `hex-notation` will enforce the case of hexadecimal values
+
+## Options
+
+* `style`: `lowercase`/`uppercase` (defaults to `lowercase`)
+
+## Examples
+
+When `style: lowercase`, the following are allowed. When `style: uppercase`, the following are disallowed:
+
+```scss
+$foo-color: #fff;
+
+.bar {
+  background: linear-gradient(top, #cc2, #44d);
+}
+
+.baz {
+  color: #12a;
+}
+```
+
+When `style: uppercase`, the following are allowed. When `style: lowercase`, the following are disallowed:
+
+```scss
+$foo-color: #FFF;
+
+.bar {
+  background: linear-gradient(top, #CC2, #44D);
+}
+
+.baz {
+  color: #12A;
+}
+```
+
+In both cases the following will be allowed as the values contain only numbers:
+
+```scss
+.qux {
+  color: #123;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -25,6 +25,7 @@ rules:
 
   # Style Guide
   clean-import-paths: 1
+  hex-notation: 1
   indentation: 1
   leading-zero: 1
   nesting-depth: 1

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -74,4 +74,53 @@ helpers.sortDetects = function (a, b) {
   return 0;
 };
 
+helpers.isNumber = function (val) {
+  if (isNaN(parseInt(val, 10))) {
+    return false;
+  }
+  return true;
+};
+
+helpers.isUpperCase = function (str) {
+  var pieces = str.split('');
+  var i;
+  var result = 0;
+
+  for (i = 0; i < pieces.length; i++) {
+    if (!helpers.isNumber(pieces[i])) {
+      if (pieces[i] === pieces[i].toUpperCase() && pieces[i] !== pieces[i].toLowerCase()) {
+        result++;
+      }
+      else {
+        return false;
+      }
+    }
+  }
+  if (result > 0) {
+    return true;
+  }
+  return false;
+};
+
+helpers.isLowerCase = function (str) {
+  var pieces = str.split('');
+  var i;
+  var result = 0;
+
+  for (i = 0; i < pieces.length; i++) {
+    if (!helpers.isNumber(pieces[i])) {
+      if (pieces[i] === pieces[i].toLowerCase() && pieces[i] !== pieces[i].toUpperCase()) {
+        result++;
+      }
+      else {
+        return false;
+      }
+    }
+  }
+  if (result > 0) {
+    return true;
+  }
+  return false;
+};
+
 module.exports = helpers;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -96,7 +96,7 @@ helpers.isUpperCase = function (str) {
       }
     }
   }
-  if (result > 0) {
+  if (result) {
     return true;
   }
   return false;
@@ -117,7 +117,7 @@ helpers.isLowerCase = function (str) {
       }
     }
   }
-  if (result > 0) {
+  if (result) {
     return true;
   }
   return false;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,9 +82,9 @@ helpers.isNumber = function (val) {
 };
 
 helpers.isUpperCase = function (str) {
-  var pieces = str.split('');
-  var i;
-  var result = 0;
+  var pieces = str.split(''),
+      i,
+      result = 0;
 
   for (i = 0; i < pieces.length; i++) {
     if (!helpers.isNumber(pieces[i])) {
@@ -103,9 +103,9 @@ helpers.isUpperCase = function (str) {
 };
 
 helpers.isLowerCase = function (str) {
-  var pieces = str.split('');
-  var i;
-  var result = 0;
+  var pieces = str.split(''),
+      i,
+      result = 0;
 
   for (i = 0; i < pieces.length; i++) {
     if (!helpers.isNumber(pieces[i])) {

--- a/lib/rules/hex-notation.js
+++ b/lib/rules/hex-notation.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
+
     ast.traverseByType('color', function (value) {
       if (value.content.match(/[a-z]/i)) {
         if (parser.options.style === 'lowercase') {

--- a/lib/rules/hex-notation.js
+++ b/lib/rules/hex-notation.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'hex-notation',
+  'defaults': {
+    'style': 'lowercase'
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+    ast.traverseByType('color', function (value) {
+      if (value.content.match(/[a-z]/i)) {
+        if (parser.options.style === 'lowercase') {
+          if (!helpers.isLowerCase(value.content)) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': value.start.line,
+              'column': value.start.column,
+              'message': 'hex notation should all be lower case',
+              'severity': parser.severity
+            });
+          }
+        }
+        else if (parser.options.style === 'uppercase') {
+          if (!helpers.isUpperCase(value.content)) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': value.start.line,
+              'column': value.start.column,
+              'message': 'hex notation should all be upper case',
+              'severity': parser.severity
+            });
+          }
+        }
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -153,7 +153,7 @@ describe('rule', function () {
   //////////////////////////////
   // Hex Notation Uppercase
   //////////////////////////////
-  it('hex length - uppercase', function (done) {
+  it('hex notation - uppercase', function (done) {
     lintFile('hex-notation.scss', {
       'rules': {
         'hex-notation': [

--- a/tests/main.js
+++ b/tests/main.js
@@ -104,6 +104,35 @@ describe('rule', function () {
   });
 
   //////////////////////////////
+  // Hex notation Lowercase - Default
+  //////////////////////////////
+  it('hex notation - lowercase', function (done) {
+    lintFile('hex-notation.scss', function (data) {
+      assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Hex Notation Uppercase
+  //////////////////////////////
+  it('hex length - uppercase', function (done) {
+    lintFile('hex-notation.scss', {
+      'rules': {
+        'hex-notation': [
+          1,
+          {
+            'style': 'uppercase'
+          }
+        ]
+      }
+    }, function (data) {
+      assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
   // Mixins Before DEclarations
   //////////////////////////////
   it('mixins before declarations', function (done) {

--- a/tests/main.js
+++ b/tests/main.js
@@ -108,20 +108,6 @@ describe('rule', function () {
   });
 
   //////////////////////////////
-  // Hex Validation
-  //////////////////////////////
-  it('hex validation', function (done) {
-    lintFile('hex-validation.scss', {
-      'rules': {
-        'hex-length': 0
-      }
-    }, function (data) {
-      assert.equal(16, data.warningCount);
-      done();
-    });
-  });
-
-  //////////////////////////////
   // Hex Length Short - Default
   //////////////////////////////
   it('hex length - short', function (done) {
@@ -160,7 +146,9 @@ describe('rule', function () {
   it('hex notation - lowercase', function (done) {
     lintFile('hex-notation.scss', {
       'rules': {
-        'hex-length': 0
+        'hex-notation': 1,
+        'hex-length': 0,
+        'hex-validation': 0
       }
     }, function (data) {
       assert.equal(6, data.warningCount);
@@ -180,10 +168,27 @@ describe('rule', function () {
             'style': 'uppercase'
           }
         ],
-        'hex-length': 0
+        'hex-length': 0,
+        'hex-validation': 0
       }
     }, function (data) {
       assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Hex Validation
+  //////////////////////////////
+  it('hex validation', function (done) {
+    lintFile('hex-validation.scss', {
+      'rules': {
+        'hex-length': 0,
+        'hex-notation': 0,
+        'hex-validation': 1
+      }
+    }, function (data) {
+      assert.equal(16, data.warningCount);
       done();
     });
   });

--- a/tests/sass/hex-notation.scss
+++ b/tests/sass/hex-notation.scss
@@ -1,0 +1,33 @@
+// numbers only won't match
+$foo-color: #123;
+
+.foo {
+  background: linear-gradient(top, #cc2, #44d);
+  color: #fff;
+}
+
+$bar-color: #123456;
+
+.bar {
+  background: linear-gradient(top, #CC2, #44D);
+  color: #FFF;
+}
+
+.qux {
+  color: #cC2;
+}
+
+$lower-numbers-color: #123cc2;
+$upper-lower-color: #CCCCCc;
+
+$map-vals: (
+  mixed: #123Cde,
+);
+
+// check that only hex colours are being parsed
+
+$literal-color: red;
+$rgb-color: rgb(255, 255, 255);
+$rgba-color: rgba(0, 0, 0, .1);
+$hsl-color: hsl(40, 50%, 50%);
+$hsla-color: hsla(40, 50%, 50%, .3);


### PR DESCRIPTION
Add a rule to enforce the consistency of hexadecimal value cases.

Add 3 new helper functions
* isNumber - check is integer
* isUpperCase - check if string passed is all uppercase
* isLowerCase - check if string passed is all lower case

I kept the case helper functions separate to allow use in other rules to follow (property name case checking?). They allow you to pass many non alphanumeric characters too as part of a string without erroneously flagging them as upper or lower case.

Would like to add tests for all the helper functions too in the future.

Closes #77

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com