### PR TITLE
Add Empty Args rule

### DIFF
--- a/docs/rules/empty-args.md
+++ b/docs/rules/empty-args.md
@@ -1,0 +1,33 @@
+# Empty Args
+
+Rule `empty-args` will enforce whether or not parenthesis should be included if no arguments are defined or used, when declaring or invoking a mixin.
+
+## Options
+
+* `include`: `true`/`false` (defaults to `false`)
+
+## Examples
+
+When `include: false`, the following are allowed. When `include: true`, the following are disallowed:
+
+```scss
+@mixin bar {
+  color: orange;
+}
+
+.bar {
+  @include bar;
+}
+```
+
+When `include: true`, the following are allowed. When `include: false`, the following are disallowed:
+
+```scss
+@mixin foo() {
+  color: red;
+}
+
+.foo {
+  @include foo();
+}
+```

--- a/docs/rules/empty-args.md
+++ b/docs/rules/empty-args.md
@@ -12,7 +12,7 @@ When `include: false`, the following are allowed. When `include: true`, the foll
 
 ```scss
 @mixin bar {
-  color: orange;
+  padding: 10px;
 }
 
 .bar {
@@ -24,7 +24,7 @@ When `include: true`, the following are allowed. When `include: false`, the foll
 
 ```scss
 @mixin foo() {
-  color: red;
+  padding: 10px;
 }
 
 .foo {

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -24,6 +24,7 @@ rules:
   no-warn: 1
 
   # Style Guide
+  empty-args: 1
   indentation: 1
   leading-zero: 1
   nesting-depth: 1

--- a/lib/rules/empty-args.js
+++ b/lib/rules/empty-args.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-empty-args',
+  'defaults': {
+    'include': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByTypes(['mixin', 'include'], function (item) {
+
+      if (item.contains('arguments')) {
+        item.traverse(function (node) {
+          if (node.type === 'arguments') {
+            if (node.content.length === 0) {
+              if (!parser.options.include) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': node.start.line,
+                  'column': node.start.column,
+                  'message': 'Parenthesis should be removed.',
+                  'severity': parser.severity
+                });
+              }
+            }
+          }
+        });
+      }
+      else {
+        if (parser.options.include) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': item.start.line,
+            'column': item.start.column,
+            'message': 'Parenthesis are required.',
+            'severity': parser.severity
+          });
+        }
+      }
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/empty-args.js
+++ b/lib/rules/empty-args.js
@@ -11,7 +11,6 @@ module.exports = {
     var result = [];
 
     ast.traverseByTypes(['mixin', 'include'], function (item) {
-
       if (item.contains('arguments')) {
         item.traverse(function (node) {
           if (node.type === 'arguments') {

--- a/tests/main.js
+++ b/tests/main.js
@@ -335,4 +335,14 @@ describe('rule', function () {
       done();
     });
   });
+
+  //////////////////////////////
+  // Empty Args
+  //////////////////////////////
+  it('empty args', function (done) {
+    lintFile('empty-args.scss', function (data) {
+      assert.equal(2, data.warningCount);
+      done();
+    });
+  });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -339,9 +339,22 @@ describe('rule', function () {
   //////////////////////////////
   // Empty Args
   //////////////////////////////
-  it('empty args', function (done) {
+
+  // Default
+  it('empty args - [include: false]', function (done) {
     lintFile('empty-args.scss', function (data) {
       assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('empty args - [include: true]', function (done) {
+    lintFile('empty-args.scss', {
+      'rules': {
+        'empty-args': [1, { include: true }]
+      }
+    }, function (data) {
+      assert.equal(3, data.warningCount);
       done();
     });
   });

--- a/tests/sass/empty-args.scss
+++ b/tests/sass/empty-args.scss
@@ -1,0 +1,43 @@
+// No arguments with parenthesis
+@mixin foo() {
+  color: red;
+}
+
+.foo {
+  @include foo();
+}
+
+
+
+// No arguments with no parenthesis
+@mixin bar {
+  color: orange;
+}
+
+.bar {
+  @include bar;
+}
+
+
+
+// Arguments with parenthesis
+@mixin baz($color) {
+  color: $color;
+}
+
+$foo: blue;
+
+.baz {
+  @include baz($foo);
+}
+
+
+
+// Parenthesis only where required
+@mixin qux($color: lime) {
+  color: $color;
+}
+
+.qux {
+  @include qux;
+}


### PR DESCRIPTION
This PR adds a rule for Empty Args which enforces whether or not parenthesis should be included if no arguments are defined or used, when declaring or invoking a mixin.

Closes #38 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>