### PR TITLE
Add hex validation rule

### DIFF
--- a/docs/rules/hex-validation.md
+++ b/docs/rules/hex-validation.md
@@ -1,0 +1,34 @@
+# Hex Validation
+
+Rule `hex-validation` will enforce the validity of hexadecimal values.
+
+## Examples
+
+When enabled any invalid hexadecimal characters will generate a warning/error:
+
+```scss
+
+// must be 3 or 6 characters
+$invalid-long: #1234567;
+$invalid-med: #1234;
+$invalid-short: #12;
+$invalid-letters-long: #abcdefg;
+$invalid-letters-med: #abcd;
+$invalid-letters-short: #ab;
+$invalid-mixed-long: #1bcdefg;
+$invalid-mixed-med: #1bcd;
+$invalid-mixed-short: #1b;
+$invalid-mixed-letters-long: #abcdef7;
+$invalid-mixed-letters-med: #abc4;
+$invalid-mixed-letters-short: #a1;
+
+// mustn't contain invalid characters
+$invalid-character-map: (
+  invalid-characters-upper-letters: #GHIJKL,
+  invalid-characters-upper-letters-short: #GHI,
+  even-more-invalid-map: (
+    invalid-characters-lower-letters-short: #ghijkl,
+    invalid-characters-lower-letters-short: #ghi
+  )
+);
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -26,6 +26,7 @@ rules:
   # Style Guide
   clean-import-paths: 1
   indentation: 1
+  hex-validation: 1
   leading-zero: 1
   nesting-depth: 1
   property-sort-order: 1

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -26,8 +26,8 @@ rules:
   # Style Guide
   clean-import-paths: 1
   hex-length: 1
-  indentation: 1
   hex-validation: 1
+  indentation: 1
   leading-zero: 1
   nesting-depth: 1
   property-sort-order: 1

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -74,4 +74,11 @@ helpers.sortDetects = function (a, b) {
   return 0;
 };
 
+helpers.isValidHex = function (str) {
+  if (str.match(/^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
+    return true;
+  }
+  return false;
+};
+
 module.exports = helpers;

--- a/lib/rules/hex-validation.js
+++ b/lib/rules/hex-validation.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'hex-validation',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('color', function (value) {
+      if (!helpers.isValidHex(value.content)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': value.start.line,
+          'column': value.start.column,
+          'message': 'Hexadecimal values must be a valid format',
+          'severity': parser.severity
+        });
+      }
+    });
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -107,7 +107,11 @@ describe('rule', function () {
   // Hex Validation
   //////////////////////////////
   it('hex validation', function (done) {
-    lintFile('hex-validation.scss', function (data) {
+    lintFile('hex-validation.scss', {
+      'rules': {
+        'hex-length': 0
+      }
+    }, function (data) {
       assert.equal(16, data.warningCount);
       done();
     });
@@ -117,7 +121,11 @@ describe('rule', function () {
   // Hex Length Short - Default
   //////////////////////////////
   it('hex length - short', function (done) {
-    lintFile('hex-length.scss', function (data) {
+    lintFile('hex-length.scss', {
+      'rules': {
+        'hex-length': 1
+      }
+    }, function (data) {
       assert.equal(4, data.warningCount);
       done();
     });

--- a/tests/main.js
+++ b/tests/main.js
@@ -104,6 +104,16 @@ describe('rule', function () {
   });
 
   //////////////////////////////
+  // Hex Validation
+  //////////////////////////////
+  it('hex validation', function (done) {
+    lintFile('hex-validation.scss', function (data) {
+      assert.equal(16, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
   // Mixins Before DEclarations
   //////////////////////////////
   it('mixins before declarations', function (done) {

--- a/tests/sass/hex-validation.scss
+++ b/tests/sass/hex-validation.scss
@@ -1,0 +1,52 @@
+//valid
+
+$numbers-long: #123456;
+$numbers-short: #123
+$letters-long: #abcdef;
+$letters-short: #abc;
+$mixed-long: #a12a12;
+$mixed-short: #a12;
+$mixed-num-long: #12a12a;
+$mixed-num-short: #12a;
+
+$upper-letters-long: #ABCDEF;
+$upper-letters-short: #ABC;
+$upper-mixed-long: #A12A12;
+$upper-mixed-short: #A12;
+$upper-mixed-num-long: #12A12A;
+$upper-mixed-num-short: #12A;
+
+
+//invalid
+
+$invalid-long: #1234567;
+$invalid-med: #1234;
+$invalid-short: #12;
+
+$invalid-letters-long: #abcdefg;
+$invalid-letters-med: #abcd;
+$invalid-letters-short: #ab;
+
+$invalid-mixed-long: #1bcdefg;
+$invalid-mixed-med: #1bcd;
+$invalid-mixed-short: #1b;
+
+$invalid-mixed-letters-long: #abcdef7;
+$invalid-mixed-letters-med: #abc4;
+$invalid-mixed-letters-short: #a1;
+
+$invalid-character-map: (
+  invalid-characters-upper-letters: #GHIJKL,
+  invalid-characters-upper-letters-short: #GHI,
+  even-more-invalid-map: (
+    invalid-characters-lower-letters-short: #ghijkl,
+    invalid-characters-lower-letters-short: #ghi
+  )
+);
+// check that only hex colours are being parsed
+
+$literal-color: red;
+$rgb-color: rgb(255, 255, 255);
+$rgba-color: rgba(0, 0, 0, .1);
+$hsl-color: hsl(40, 50%, 50%);
+$hsla-color: hsla(40, 50%, 50%, .3);


### PR DESCRIPTION
Rule hex-validation will enforce all hexadecimal values are of a valid format.

* 3 or 6 characters long
* 0-9 a-f A-F

Adds a new `isValidHex` helper function

closes #82 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com