### PR TITLE
Add comment rule

### DIFF
--- a/docs/rules/comment.md
+++ b/docs/rules/comment.md
@@ -1,0 +1,55 @@
+# Comment
+
+Rule `comment` will enforce the comment style used, preventing the use of multiline comments which would appear in your compiled CSS.
+
+## Options
+
+* `allowed`: regEx - regular expression
+
+e.g.
+
+`allowed: '^[\/* ]*Bad'`
+
+## Examples
+
+When enabled the following are allowed:
+
+```scss
+
+// This is a good comment
+
+// =========
+// This is a good comment
+// =========
+
+//////////////////
+// This is a good comment
+//////////////////
+```
+
+When enabled the following are disallowed:
+
+```scss
+
+/* This comment will appear in your compiled css */
+
+/*
+ * Mulitline comments are bad
+ */
+```
+
+When enabled and a regular expression is passed to the allowed option you can bypass the linter
+
+```yaml
+comment:
+  - 1
+  -
+    allowed
+     - '/\* Allowed Comment'
+```
+
+```scss
+/*
+ * Allowed Comment
+ */
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -25,6 +25,7 @@ rules:
 
   # Style Guide
   clean-import-paths: 1
+  comment: 1
   indentation: 1
   leading-zero: 1
   nesting-depth: 1

--- a/lib/rules/comment.js
+++ b/lib/rules/comment.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'comment',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+    var valid = false;
+
+    ast.traverseByType('multilineComment', function (node) {
+      if (parser.options.allowed) {
+        parser.options.allowed.forEach(function (rule) {
+          var rex = new RegExp(rule);
+          if (node.content.match(rex)) {
+            valid = true;
+          }
+        });
+      }
+      if (!valid) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Multiline style comments should not be used',
+          'severity': parser.severity
+        });
+      }
+      valid = false;
+    });
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -427,7 +427,7 @@ describe('rule', function () {
   //////////////////////////////
   // Comment - 2 allowed
   //////////////////////////////
-  it('comment', function (done) {
+  it('comment - allowed regEx', function (done) {
     lintFile('comment.scss', {
       'rules': {
         'comment': [

--- a/tests/main.js
+++ b/tests/main.js
@@ -37,7 +37,11 @@ describe('rule', function () {
   // Empty Line With Comment
   //////////////////////////////
   it('empty line between blocks with comments', function (done) {
-    lintFile('empty-line-with-comments.scss', function (data) {
+    lintFile('empty-line-with-comments.scss', {
+      'rules': {
+        'comment': 0
+      }
+    }, function (data) {
       assert.equal(2, data.warningCount);
       done();
     });

--- a/tests/main.js
+++ b/tests/main.js
@@ -418,7 +418,11 @@ describe('rule', function () {
   // Comment - no allowed
   //////////////////////////////
   it('comment', function (done) {
-    lintFile('comment.scss', function (data) {
+    lintFile('comment.scss', {
+      'rules': {
+        'comment': 1
+      }
+    }, function (data) {
       assert.equal(4, data.warningCount);
       done();
     });

--- a/tests/main.js
+++ b/tests/main.js
@@ -367,4 +367,36 @@ describe('rule', function () {
       done();
     });
   });
+
+  //////////////////////////////
+  // Comment - no allowed
+  //////////////////////////////
+  it('comment', function (done) {
+    lintFile('comment.scss', function (data) {
+      assert.equal(4, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Comment - 2 allowed
+  //////////////////////////////
+  it('comment', function (done) {
+    lintFile('comment.scss', {
+      'rules': {
+        'comment': [
+          1,
+          {
+            'allowed': [
+              '^[\/* ]*Bad',
+              '/\* Test Comment'
+            ]
+          }
+        ]
+      }
+    }, function (data) {
+      assert.equal(2, data.warningCount);
+      done();
+    });
+  });
 });

--- a/tests/sass/comment.scss
+++ b/tests/sass/comment.scss
@@ -1,0 +1,47 @@
+/* Bad */
+.foo {
+  content: ' ';
+}
+
+/*
+ * Test Comment
+ */
+.bar {
+  content: ' ';
+}
+
+// good comment
+.baz {
+  content: ' ';
+}
+
+/* comment */
+.qux {
+  content: ' ';
+}
+
+/*
+ * Multiline Comments are bad
+ */
+.test {
+  content: ' ';
+}
+
+// this is a good comment
+.class {
+  content: ' ';
+}
+
+// =========
+// This is a good comment
+// =========
+.blip {
+  content: ' ';
+}
+
+//////////////////
+// This is a good comment
+//////////////////
+.blop {
+  content: ' ';
+}


### PR DESCRIPTION
Rule comment will enforce the use of single line comments and disallow multiline comments.

A regular expression can be passed as an option to bypass the linter on certain comments.

Had to modify the empty line comment test as the test case uses a now disallowed multiline comment.

closes #85 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com