### PR TITLE
Add Border Zero rule

### DIFF
--- a/docs/rules/border-zero.md
+++ b/docs/rules/border-zero.md
@@ -4,11 +4,11 @@ Rule `border-zero` will enforce whether one should use `0` or `none` when specif
 
 ## Options
 
-* `convention`: `0`/`'none'` (defaults to `0`)
+* `convention`: `'0'`/`'none'` (defaults to `0`)
 
 ## Examples
 
-When `convention: 0`, the following are allowed. When `convention: none`, the following are disallowed:
+When `convention: '0'`, the following are allowed. When `convention: 'none'`, the following are disallowed:
 
 ```scss
 .foo {
@@ -20,7 +20,7 @@ When `convention: 0`, the following are allowed. When `convention: none`, the fo
 }
 ```
 
-When `convention: none`, the following are allowed. When `convention: 0`, the following are disallowed:
+When `convention: 'none'`, the following are allowed. When `convention: '0'`, the following are disallowed:
 
 ```scss
 .foo {

--- a/docs/rules/border-zero.md
+++ b/docs/rules/border-zero.md
@@ -1,0 +1,33 @@
+# Border Zero
+
+Rule `border-zero` will enforce whether one should use `0` or `none` when specifying a zero `border` value
+
+## Options
+
+* `convention`: `0`/`'none'` (defaults to `0`)
+
+## Examples
+
+When `convention: 0`, the following are allowed. When `convention: none`, the following are disallowed:
+
+```scss
+.foo {
+  border: 0;
+}
+
+.bar {
+  border-right: 0;
+}
+```
+
+When `convention: none`, the following are allowed. When `convention: 0`, the following are disallowed:
+
+```scss
+.foo {
+  border: none;
+}
+
+.bar {
+  border-left: none;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -24,6 +24,7 @@ rules:
   no-warn: 1
 
   # Style Guide
+  border-zero: 1
   clean-import-paths: 1
   indentation: 1
   leading-zero: 1

--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -34,7 +34,7 @@ module.exports = {
                     'ruleId': parser.rule.name,
                     'line': node.start.line,
                     'column': node.start.column,
-                    'message': 'Values must use `' + parser.options.convention + '` convention',
+                    'message': 'Values must use the `' + parser.options.convention + '` convention',
                     'severity': parser.severity
                   });
                 }

--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -34,7 +34,7 @@ module.exports = {
                     'ruleId': parser.rule.name,
                     'line': node.start.line,
                     'column': node.start.column,
-                    'message': 'Values must use the `' + parser.options.convention + '` convention',
+                    'message': 'A value of `' + node.content + '` is not allowed. `' + parser.options.convention + '` must be used.',
                     'severity': parser.severity
                   });
                 }

--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var borders = ['border', 'border-top', 'border-right', 'border-bottom', 'border-left'];
+
+module.exports = {
+  'name': 'border-zero',
+  'defaults': {
+    'convention': '0'
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('declaration', function (declaration) {
+      var isBorder = false;
+
+      declaration.traverse(function (item) {
+        if (item.type === 'property') {
+          item.traverse(function (child) {
+            if (borders.indexOf(child.content) !== -1) {
+              isBorder = true;
+            }
+          });
+        }
+
+        if (isBorder) {
+          if (item.type === 'value') {
+            var node = item.content[0];
+            if (node.type === 'number' || node.type === 'ident') {
+              if (node.content === '0' || node.content === 'none') {
+                if (parser.options.convention !== node.content) {
+                  result = helpers.addUnique(result, {
+                    'ruleId': parser.rule.name,
+                    'line': node.start.line,
+                    'column': node.start.column,
+                    'message': 'Values must use `' + parser.options.convention + '` convention',
+                    'severity': parser.severity
+                  });
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -344,21 +344,21 @@ describe('rule', function () {
     });
   });
 
-  //////////////////////////////
-  // Zero Unit
-  //////////////////////////////
+  // //////////////////////////////
+  // // Zero Unit
+  // //////////////////////////////
 
-  // Default
-  it('zero unit - [include: false]', function (done) {
-    lintFile('zero-unit.scss', {
-      'rules': {
-        'zero-unit': 1
-      }
-    }, function (data) {
-      assert.equal(4, data.warningCount);
-      done();
-    });
-  });
+  // // Default
+  // it('zero unit - [include: false]', function (done) {
+  //   lintFile('zero-unit.scss', {
+  //     'rules': {
+  //       'zero-unit': 1
+  //     }
+  //   }, function (data) {
+  //     assert.equal(4, data.warningCount);
+  //     done();
+  //   });
+  // });
 
   it('zero unit - [include: true]', function (done) {
     lintFile('zero-unit.scss', {
@@ -377,6 +377,34 @@ describe('rule', function () {
   it('clean import paths', function (done) {
     lintFile('clean-import-paths.scss', function (data) {
       assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Border Zero
+  //////////////////////////////
+
+  // Default
+  it('border zero - [convention: \'0\']', function (done) {
+    lintFile('border-zero.scss', {
+      'rules': {
+        'zero-unit': 0
+      }
+    }, function (data) {
+      assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('border zero - [convention: \'none\']', function (done) {
+    lintFile('border-zero.scss', {
+      'rules': {
+        'zero-unit': 0,
+        'border-zero': [1, { 'convention': 'none' }]
+      }
+    }, function (data) {
+      assert.equal(2, data.warningCount);
       done();
     });
   });

--- a/tests/main.js
+++ b/tests/main.js
@@ -344,21 +344,21 @@ describe('rule', function () {
     });
   });
 
-  // //////////////////////////////
-  // // Zero Unit
-  // //////////////////////////////
+  //////////////////////////////
+  // Zero Unit
+  //////////////////////////////
 
-  // // Default
-  // it('zero unit - [include: false]', function (done) {
-  //   lintFile('zero-unit.scss', {
-  //     'rules': {
-  //       'zero-unit': 1
-  //     }
-  //   }, function (data) {
-  //     assert.equal(4, data.warningCount);
-  //     done();
-  //   });
-  // });
+  // Default
+  it('zero unit - [include: false]', function (done) {
+    lintFile('zero-unit.scss', {
+      'rules': {
+        'zero-unit': 1
+      }
+    }, function (data) {
+      assert.equal(4, data.warningCount);
+      done();
+    });
+  });
 
   it('zero unit - [include: true]', function (done) {
     lintFile('zero-unit.scss', {

--- a/tests/sass/border-zero.scss
+++ b/tests/sass/border-zero.scss
@@ -1,0 +1,19 @@
+.foo {
+  border: 0;
+}
+
+.bar {
+  border: none;
+}
+
+.baz {
+  border-right: 0;
+}
+
+.qux {
+  border-left: none;
+}
+
+.norf {
+  border: 1px;
+}


### PR DESCRIPTION
This PR adds a rule for Border Zero which enforces whether one should use `0` or `none` when specifying a zero `border` value

### Warning messages

When `convention: '0'` and value is `'none'`, the following message is displayed:
> A value of `none` is not allowed. `0` must be used.

When `convention: 'none'` and value is `'0'`, the following message is displayed:
> A value of `0` is not allowed. `none` must be used.

Closes #84 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>