### PR TITLE
Update mixin-before-declaration rule fix #80

### DIFF
--- a/lib/rules/mixins-before-declarations.js
+++ b/lib/rules/mixins-before-declarations.js
@@ -11,35 +11,37 @@ module.exports = {
     ]
   },
   'detect': function (ast, parser) {
-    var result = [],
-        error;
+    var result = [];
+    var error;
 
-    ast.traverseByType('block', function (block) {
-      var lastDeclaration = null;
-      block.traverse(function (item, j) {
-        if (item.type === 'include') {
-          if (j > lastDeclaration && lastDeclaration !== null) {
-            item.forEach('simpleSelector', function (name) {
-              if (parser.options.exclude.indexOf(name.content[0].content) === -1) {
-                error = {
-                  'ruleId': parser.rule.name,
-                  'line': item.start.line,
-                  'column': item.start.column,
-                  'message': 'Mixins should come before declarations',
-                  'severity': parser.severity
-                };
-                result = helpers.addUnique(result, error);
-              }
-            });
-          }
+    ast.traverseByType('include', function (node, i, parent) {
+      var depth = 0;
+      var declarationCount = [depth];
+
+      parent.traverse( function (item) {
+        if (item.type === 'ruleset') {
+          depth++;
+          declarationCount[depth] = 0;
         }
         if (item.type === 'declaration') {
-          lastDeclaration = j;
+          declarationCount[depth]++;
+        }
+        else if (item.type === 'include') {
+          item.forEach('simpleSelector', function (name) {
+            if (parser.options.exclude.indexOf(name.content[0].content) === -1 && declarationCount[depth] > 0) {
+              error = {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'Mixins should come before declarations',
+                'severity': parser.severity
+              };
+              result = helpers.addUnique(result, error);
+            }
+          });
         }
       });
-      lastDeclaration = null;
     });
-
     return result;
   }
 };

--- a/lib/rules/mixins-before-declarations.js
+++ b/lib/rules/mixins-before-declarations.js
@@ -23,7 +23,7 @@ module.exports = {
           depth++;
           declarationCount[depth] = 0;
         }
-        if (item.type === 'declaration') {
+        else if (item.type === 'declaration') {
           declarationCount[depth]++;
         }
         else if (item.type === 'include') {

--- a/lib/rules/mixins-before-declarations.js
+++ b/lib/rules/mixins-before-declarations.js
@@ -11,12 +11,12 @@ module.exports = {
     ]
   },
   'detect': function (ast, parser) {
-    var result = [];
-    var error;
+    var result = [],
+        error;
 
     ast.traverseByType('include', function (node, i, parent) {
-      var depth = 0;
-      var declarationCount = [depth];
+      var depth = 0,
+          declarationCount = [depth];
 
       parent.traverse( function (item) {
         if (item.type === 'ruleset') {

--- a/tests/main.js
+++ b/tests/main.js
@@ -133,11 +133,35 @@ describe('rule', function () {
   });
 
   //////////////////////////////
-  // Mixins Before DEclarations
+  // Mixins Before Declarations
   //////////////////////////////
   it('mixins before declarations', function (done) {
     lintFile('mixins-before-declarations.scss', function (data) {
-      assert.equal(4, data.warningCount);
+      assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Mixins Before Declarations - overwrite
+  //////////////////////////////
+  it('mixins before declarations - excludes', function (done) {
+    lintFile('mixins-before-declarations.scss', {
+      'rules': {
+        'mixins-before-declarations': [
+          1,
+          {
+            'exclude': [
+              'test-again',
+              'waldo',
+              'mq',
+              'breakpoint'
+            ]
+          }
+        ]
+      }
+    }, function (data) {
+      assert.equal(0, data.warningCount);
       done();
     });
   });

--- a/tests/sass/mixins-before-declarations.scss
+++ b/tests/sass/mixins-before-declarations.scss
@@ -25,5 +25,25 @@
     content: 'where';
 
     @include waldo;
+
+  }
+
+  &__element {
+    @include element;
+    width: 100%;
+
+    @include mq(500px) {
+      content: 'mq';
+    }
+
+    @include waldo;
+
+    &--modifier {
+      @include foo('yo');
+      @include hello;
+      @include test;
+      height: 100px;
+      @include test-again;
+    }
   }
 }


### PR DESCRIPTION
The current mixin before declaration rule was acting strangely due to the way Gonzales is passing it's node counter value, I rewrote the rule to take into account a 'depth' value when traversing across embedded (can't think of the right word!) rules.

It first looks for include statements and then traverses only the parent element so it's a little easier to keep track of where we are. It then looks for a ruleset block in order to increment depth.

Also added some more test cases as brought up in #80 and added some tests for passing in values to the exclude property.

Hopefully this is ok to rewrite?

fixes #80 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com