### PR TITLE
Add No Duplicate Property rule

### DIFF
--- a/docs/rules/no-duplicate-property.md
+++ b/docs/rules/no-duplicate-property.md
@@ -1,6 +1,6 @@
 # No Duplicate Property
 
-Rule `no-duplicate-property` will enforce that duplicate properties are not allowed within a block.
+Rule `no-duplicate-property` will enforce that duplicate properties are not allowed within the same block.
 
 ## Examples
 

--- a/docs/rules/no-duplicate-property.md
+++ b/docs/rules/no-duplicate-property.md
@@ -1,0 +1,14 @@
+# No Duplicate Property
+
+Rule `no-duplicate-property` will enforce that duplicate properties are not allowed within a block.
+
+## Examples
+
+When enabled, the following are disallowed:
+
+```scss
+.foo {
+  margin: 0 0 15px;
+  margin: 0;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -44,3 +44,5 @@ rules:
   # Final Items
   trailing-semicolon: 1
   final-newline: 1
+
+  no-duplicate-property: 1

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -17,6 +17,7 @@ rules:
 
   # Disallows
   no-debug: 1
+  no-duplicate-property: 1
   no-empty-rulesets: 1
   no-extends: 0
   no-ids: 1
@@ -44,5 +45,3 @@ rules:
   # Final Items
   trailing-semicolon: 1
   final-newline: 1
-
-  no-duplicate-property: 1

--- a/lib/rules/no-duplicate-property.js
+++ b/lib/rules/no-duplicate-property.js
@@ -30,7 +30,7 @@ module.exports = {
               'ruleId': parser.rule.name,
               'line': item.start.line,
               'column': item.start.column,
-              'message': 'Duplicate properties are not allowed',
+              'message': 'Duplicate properties are not allowed within a block.',
               'severity': parser.severity
             });
           }

--- a/lib/rules/no-duplicate-property.js
+++ b/lib/rules/no-duplicate-property.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'duplicate-property',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('block', function (block) {
+      var properties = [],
+          items = [];
+
+      block.eachFor('declaration', function (declaration) {
+        items.push(declaration);
+      });
+
+      items.reverse();
+
+      items.forEach(function (declaration) {
+        declaration.eachFor('property', function (item) {
+          var property = item.content[0].content;
+
+          if (properties.indexOf(property) === -1) {
+            properties.push(property);
+          }
+          else {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': item.start.line,
+              'column': item.start.column,
+              'message': 'Duplicate properties are not allowed',
+              'severity': parser.severity
+            });
+          }
+        });
+      });
+    });
+
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -17,7 +17,11 @@ describe('rule', function () {
   // Indentation
   //////////////////////////////
   it('indentation', function (done) {
-    lintFile('indentation.scss', function (data) {
+    lintFile('indentation.scss', {
+      'rules': {
+        'no-duplicate-property': 0
+      }
+    }, function (data) {
       assert.equal(8, data.warningCount);
       done();
     });
@@ -377,6 +381,21 @@ describe('rule', function () {
   it('clean import paths', function (done) {
     lintFile('clean-import-paths.scss', function (data) {
       assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Duplicate Property
+  //////////////////////////////
+  it('no duplicate property', function (done) {
+    lintFile('no-duplicate-property.scss', {
+      'rules': {
+        'no-duplicate-property': 1,
+        'zero-unit': 0
+      }
+    }, function (data) {
+      assert.equal(3, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-duplicate-property.scss
+++ b/tests/sass/no-duplicate-property.scss
@@ -1,0 +1,17 @@
+.foo {
+  margin: 0 0 15px;
+  padding: 10px;
+  margin: 0;
+}
+
+.bar {
+  display: block;
+  width: 100%;
+  display: none;
+
+  .baz {
+    display: block;
+    width: 50%;
+    display: none;
+  }
+}


### PR DESCRIPTION
This PR adds the `No Duplicate Property`g rule which enforces that duplicate properties are not allowed within the same block.

Closes #28 

Warning message is:
> Duplicate properties are not allowed within a block.

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>