### PR TITLE
Fix bug in Space After Colon

### DIFF
--- a/lib/rules/space-after-colon.js
+++ b/lib/rules/space-after-colon.js
@@ -10,29 +10,31 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('propertyDelimiter', function (delimiter, i, parent) {
-      var next = parent.content[i + 1];
+    ast.traverseByTypes(['propertyDelimiter', 'operator'], function (delimiter, i, parent) {
+      if (delimiter.content === ':') {
+        var next = parent.content[i + 1];
 
-      if (next.is('space')) {
-        if (!parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': next.start.line,
-            'column': next.start.column,
-            'message': 'No space allowed after `:`',
-            'severity': parser.severity
-          });
+        if (next.is('space')) {
+          if (!parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': next.start.line,
+              'column': next.start.column,
+              'message': 'No space allowed after `:`',
+              'severity': parser.severity
+            });
+          }
         }
-      }
-      else {
-        if (parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': delimiter.start.line,
-            'column': delimiter.start.column,
-            'message': 'Space expected after `:`',
-            'severity': parser.severity
-          });
+        else {
+          if (parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': delimiter.start.line,
+              'column': delimiter.start.column,
+              'message': 'Space expected after `:`',
+              'severity': parser.severity
+            });
+          }
         }
       }
     });

--- a/tests/main.js
+++ b/tests/main.js
@@ -342,9 +342,26 @@ describe('rule', function () {
   //////////////////////////////
   // Space After Colon
   //////////////////////////////
-  it('space after colon', function (done) {
-    lintFile('space-after-colon.scss', function (data) {
-      assert.equal(1, data.warningCount);
+
+  it('space after colon - [include: false]', function (done) {
+    lintFile('space-after-colon.scss', {
+      'rules': {
+        'space-after-colon': [1, { 'include': false }]
+      }
+    }, function (data) {
+      assert.equal(4, data.warningCount);
+      done();
+    });
+  });
+
+  // Default
+  it('space after colon - [include: true]', function (done) {
+    lintFile('space-after-colon.scss', {
+      'rules': {
+        'space-after-colon': [1, { 'include': true }]
+      }
+    }, function (data) {
+      assert.equal(3, data.warningCount);
       done();
     });
   });

--- a/tests/main.js
+++ b/tests/main.js
@@ -496,10 +496,10 @@ describe('rule', function () {
 
   it('space after colon - [include: false]', function (done) {
     lintFile('space-after-colon.scss', {
+      'options': {
+        'merge-default-rules': false
+      },
       'rules': {
-        'options': {
-          'merge-default-rules': false
-        },
         'space-after-colon': [
           1,
           {

--- a/tests/main.js
+++ b/tests/main.js
@@ -497,6 +497,9 @@ describe('rule', function () {
   it('space after colon - [include: false]', function (done) {
     lintFile('space-after-colon.scss', {
       'rules': {
+        'options': {
+          'merge-default-rules': false
+        },
         'space-after-colon': [
           1,
           {

--- a/tests/sass/space-after-colon.scss
+++ b/tests/sass/space-after-colon.scss
@@ -1,4 +1,16 @@
 .foo {
-  content: 'bar';
+  content: 'foo';
+}
+
+.bar {
   content:'bar';
 }
+
+.baz {
+  @media (max-width: 50em) and (orientation:landscape) {
+    content: 'baz';
+  }
+}
+
+$qux: 'qux';
+$norf:'norf';


### PR DESCRIPTION
Now works for all colons, whether the parser considers them of type `propertyDelimiter` or `operator`.

Fixes #98 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>