### PR TITLE
Fix Space Before Colon and paren issue

### DIFF
--- a/lib/rules/space-before-colon.js
+++ b/lib/rules/space-before-colon.js
@@ -10,29 +10,31 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('propertyDelimiter', function (delimiter, i, parent) {
-      var previous = parent.content[i - 1];
+    ast.traverseByTypes(['propertyDelimiter', 'operator'], function (delimiter, i, parent) {
+      if (delimiter.content === ':') {
+        var previous = parent.content[i - 1];
 
-      if (previous.is('space')) {
-        if (!parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': previous.start.line,
-            'column': previous.start.column,
-            'message': 'No space allowed before `:`',
-            'severity': parser.severity
-          });
+        if (previous.is('space')) {
+          if (!parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': previous.start.line,
+              'column': previous.start.column,
+              'message': 'No space allowed before `:`',
+              'severity': parser.severity
+            });
+          }
         }
-      }
-      else {
-        if (parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': delimiter.start.line,
-            'column': delimiter.start.column - 1,
-            'message': 'Space expected before `:`',
-            'severity': parser.severity
-          });
+        else {
+          if (parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': delimiter.start.line,
+              'column': delimiter.start.column - 1,
+              'message': 'Space expected before `:`',
+              'severity': parser.severity
+            });
+          }
         }
       }
     });

--- a/tests/main.js
+++ b/tests/main.js
@@ -516,7 +516,9 @@ describe('rule', function () {
   //////////////////////////////
   // Space Before Colon
   //////////////////////////////
-  it('space before colon', function (done) {
+
+  // Default
+  it('space before colon - [include: false]', function (done) {
     lintFile('space-before-colon.scss', {
       'options': {
         'merge-default-rules': false
@@ -525,7 +527,26 @@ describe('rule', function () {
         'space-before-colon': 1
       }
     }, function (data) {
-      assert.equal(1, data.warningCount);
+      assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+
+  it('space before colon - [include: true]', function (done) {
+    lintFile('space-before-colon.scss', {
+      'options': {
+        'merge-default-rules': false
+      },
+      'rules': {
+        'space-before-colon': [
+          1,
+          {
+            'include': true
+          }
+        ]
+      }
+    }, function (data) {
+      assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-before-colon.scss
+++ b/tests/sass/space-before-colon.scss
@@ -1,4 +1,16 @@
 .foo {
-  content: 'bar';
-  content : 'bar';
+  content :'foo';
 }
+
+.bar {
+  content:'bar';
+}
+
+.baz {
+  @media (max-width :50em) and (orientation:landscape) {
+    content: 'baz';
+  }
+}
+
+$qux: 'qux';
+$norf :'norf';


### PR DESCRIPTION
Fixes an issue with Space Before Colon that was fixed for the Space After Colon rule. The issue is that colons within parens are not linted.

See issue #98 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>