### PR TITLE
Remove duplicate test

### DIFF
--- a/tests/main.js
+++ b/tests/main.js
@@ -749,23 +749,6 @@ describe('rule', function () {
   });
 
   //////////////////////////////
-  // Clean Import Paths
-  //////////////////////////////
-  it('clean import paths', function (done) {
-    lintFile('clean-import-paths.scss', {
-      'options': {
-        'merge-default-rules': false
-      },
-      'rules': {
-        'clean-import-paths': 1
-      }
-    }, function (data) {
-      assert.equal(8, data.warningCount);
-      done();
-    });
-  });
-
-  //////////////////////////////
   // Empty Args
   //////////////////////////////
 


### PR DESCRIPTION
Currently there's a duplicate test for the Clean Import Path defaults.

This fixes #110 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>