### PR TITLE
Update rule names to match config

### DIFF
--- a/lib/rules/clean-import-paths.js
+++ b/lib/rules/clean-import-paths.js
@@ -32,7 +32,7 @@ var getImportPath = function (parent) {
 };
 
 module.exports = {
-  'name': 'import-path',
+  'name': 'clean-import-paths',
   'defaults': {
     'leading-underscore': false,
     'filename-extension': false

--- a/lib/rules/no-duplicate-property.js
+++ b/lib/rules/no-duplicate-property.js
@@ -3,7 +3,7 @@
 var helpers = require('../helpers');
 
 module.exports = {
-  'name': 'duplicate-property',
+  'name': 'no-duplicate-property',
   'defaults': {},
   'detect': function (ast, parser) {
     var result = [];


### PR DESCRIPTION
Updated the rule names for `clean-import-paths` and `no-duplicate-property`. They were inconsistently named in the rule file compared to everywhere else.

fixes #118

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com