### PR TITLE
New rule: space around operator

### DIFF
--- a/docs/rules/space-around-operator.md
+++ b/docs/rules/space-around-operator.md
@@ -1,0 +1,27 @@
+# Space Around Operator
+
+Rule `space-around-operator` will enforce operators to be formatted with a single space on both sides of an infix operator. These include `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `>`, `>=`, `<`, and `<=`.
+
+Note that this linter only applies to actual, evaluated operators. So values like `nth-child(2n+1)` will not be disallowed.
+
+
+## Examples
+
+When enabled, the following are allowed:
+
+```scss
+.bar {
+  font: 16px / 24px Arial sans-serif;
+  margin: 5px + 5px;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.bar {
+  margin: 5px   +   5px;
+  font: 16px/24px Arial sans-serif;
+}
+```
+

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -51,6 +51,7 @@ rules:
   space-before-bang: 1
   space-after-bang: 1
   space-between-parens: 1
+  space-around-operator: 1
 
   # Final Items
   trailing-semicolon: 1

--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var validateExpression = function (parser, result, expressionNode) {
+  if (!expressionNode) {
+    return;
+  }
+
+  for (var j = 0; j < expressionNode.content.length; j += 2) {
+    // every second node should be a single space
+    var node = expressionNode.content[j + 1];
+    if (node && !node.is('space')) {
+      helpers.addUnique(result, {
+        'ruleId': parser.rule.name,
+        'line': node.start.line,
+        'column': node.start.column,
+        'message': 'Value should be followed by a space',
+        'severity': parser.severity
+      });
+      break;
+    }
+    else if (node && node.is('space') && node.content !== ' ') {
+      helpers.addUnique(result, {
+        'ruleId': parser.rule.name,
+        'line': node.start.line,
+        'column': node.start.column,
+        'message': 'Value should be followed by a single space',
+        'severity': parser.severity
+      });
+      break;
+    }
+  }
+};
+
+module.exports = {
+  'name': 'space-around-operator',
+  'defaults': {
+    'include': true
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('atruleb', function (exp) {
+      exp.content.forEach(function (node) {
+        if (node.is('parentheses')) {
+          validateExpression(parser, result, node);
+        }
+      });
+    });
+
+    ast.traverseByType('value', function (value) {
+      value.content.forEach(function (node) {
+        if (node.is('operator') || node.is('unaryOperator')) {
+          validateExpression(parser, result, value);
+          return false;
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/tests/main.js
+++ b/tests/main.js
@@ -620,6 +620,25 @@ describe('rule', function () {
   });
 
   //////////////////////////////
+  // Space Around Operator
+  //////////////////////////////
+
+  // Default
+  it('space around operator - [include: true]', function (done) {
+    lintFile('space-around-operator.scss', {
+      'options': {
+        'merge-default-rules': false
+      },
+      'rules': {
+        'space-around-operator': 1
+      }
+    }, function (data) {
+      assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
   // Space Before Colon
   //////////////////////////////
 

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -1,0 +1,53 @@
+@mixin font-fl($font) {
+  &:after {
+    @if (type-of($font)         == string) {
+      content: 'My font is: #{$font}.';
+    } @else {
+      content: 'Sorry, the argument #{$font} is a #{type-of($font)}.';
+    }
+  }
+}
+
+.v-fail {
+  font: 16px / 24px Arial sans-serif;
+  size: 20px+  30px;
+}
+
+$v-ok: 90px + 10px;
+$v-ok2: (90px / 10px) + 10px;
+
+$v-fail1: 90px-10px;
+$v-fail2: 90px   +  10px;
+$v-fail3: 90px                 + 10px;
+$v-fail4: 90px  +   10px;
+
+$font-stack:    Helvetica , sans-serif;
+$primary-color: #333;
+
+body {
+  color: $primary-color;
+  font: 100%  $font-stack;
+}
+
+article[role="main"] {
+  float: left;
+  font: 16px  /  24px Arial sans-serif;
+  width: 600px / 960px * 100%;
+}
+
+aside[role="complimentary"] {
+  float: right;
+  width: 300px  / 960px *  100%;
+}
+
+nth-child(2n+1) {
+  float: right;
+}
+
+// FIXME: should also be an error: https://github.com/tonyganch/gonzales-pe/issues/85
+body {
+  background: url('a'  +  'b.png');
+}
+
+// FIXME: current mod operator is not working in gonzales:
+// $foo: 90px   %10px;


### PR DESCRIPTION
This resolves #31. 

Due to bugs in `gonzales-pe` the following will currently fail:
```sass
body {
  background: url('a'  +  'b.png');  // will not throw an error
}

$foo: 90px   %10px;  // will crash
```

DCO 1.1 Signed-off-by: Kenneth Skovhus kenneth.skovhus@gmail.com
