### PR TITLE
Add CLI unit test for ignored files

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -31,18 +31,17 @@ program
   .version(meta.version)
   .usage('[options] <pattern>')
   .option('-c, --config [path]', 'path to custom config file')
-  .option('-i, --ignore [pattern]', 'pattern to ignore. For multiple ignores, separate each pattern by `, `')
+  .option('-i, --ignore [pattern]', 'pattern to ignore. For multiple ignores, separate each pattern by `,`')
   .option('-q, --no-exit', 'do not exit on errors')
   .option('-v, --verbose', 'verbose output')
   .parse(process.argv);
-
 
 if (program.config && program.config !== true) {
   configPath = program.config;
 }
 
 if (program.ignore && program.ignore !== true) {
-  ignores = program.ignore.split(', ');
+  ignores = program.ignore.split(',');
   configOptions = {
     'files': {
       'ignore': ignores

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     should = require('should'),
-    childProcess = require('child_process');
+    childProcess = require('child_process'),
+    fs = require('fs');
 
 
 describe('cli', function () {
@@ -28,6 +29,29 @@ describe('cli', function () {
       }
 
       should(stdout).match(/^[0-9]+.[0-9]+(.[0-9]+)?/);
+
+      done(null);
+    });
+
+  });
+
+  it('should not include ignored paths', function (done) {
+    var sassTestsPath = 'tests/sass/',
+        files = [];
+
+    files.push(sassTestsPath + fs.readdirSync('tests/sass')[0]);
+    files.push(sassTestsPath + fs.readdirSync('tests/sass')[1]);
+
+    var command = 'sass-lint -v -i ' + files;
+
+    childProcess.exec(command, function (err, stdout) {
+      if (err) {
+        return done(err);
+      }
+
+      files.forEach(function (file) {
+        assert(stdout.indexOf(file) === -1);
+      });
 
       done(null);
     });


### PR DESCRIPTION
It looks like glob.sync ignore doesn't work for multiple files if there's a space after the comma. I had to modify the pattern in the index.js to address that, before I could complete the unit test for it. Randomly selecting the files in the unit test would be an enhancement, but this works for now.