### PR TITLE
Fix bug in Space After Comma rule

### DIFF
--- a/lib/rules/space-after-comma.js
+++ b/lib/rules/space-after-comma.js
@@ -18,27 +18,28 @@ module.exports = {
         next = parent.content[i + 1];
 
         if (next) {
-          if (next.is('space')) {
-            if ((next.content.indexOf(os.EOL) === -1) && !parser.options.include) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': next.start.line,
-                'column': next.start.column,
-                'message': 'Commas should not be followed by a space',
-                'severity': parser.severity
-              });
+          if (operator.is('delimiter')) {
+            if (next.is('simpleSelector')) {
+              next = next.content[0];
             }
           }
-          else {
-            if (parser.options.include) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': operator.start.line,
-                'column': operator.start.column,
-                'message': 'Commas should be followed by a space',
-                'severity': parser.severity
-              });
-            }
+          if ((next.is('space') && next.content.indexOf(os.EOL) === -1) && !parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': next.start.line,
+              'column': next.start.column,
+              'message': 'Commas should not be followed by a space',
+              'severity': parser.severity
+            });
+          }
+          if (!next.is('space') && parser.options.include) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': operator.start.line,
+              'column': operator.start.column,
+              'message': 'Commas should be followed by a space',
+              'severity': parser.severity
+            });
           }
         }
       }

--- a/tests/rules/space-after-comma.js
+++ b/tests/rules/space-after-comma.js
@@ -9,7 +9,7 @@ describe('space after comma', function () {
     lint.test(file, {
       'space-after-comma': 1
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('space after comma', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-after-comma.scss
+++ b/tests/sass/space-after-comma.scss
@@ -1,23 +1,50 @@
+h1,h2 {
+  content: 'foo';
+}
+
+h1, h2 {
+  content: 'foo';
+}
+
+h1,
+h2 {
+  content: 'foo';
+}
+
 .foo {
-  @include mixin('foo', 'bar');
+  box-shadow: 1px 1px black,1px 1px black;
+}
+
+.foo {
   box-shadow: 1px 1px black, 1px 1px black;
 }
 
 .bar {
   @include mixin('foo','bar');
-  box-shadow: 1px 1px black,1px 1px black;
 }
 
-@mixin baz(
+.bar {
+  @include mixin('foo', 'bar');
+}
+
+@function foo($bar,$baz) {
+  @return $bar * $baz;
+}
+
+@function foo($bar, $baz) {
+  @return $bar * $baz;
+}
+
+@mixin foo(
   $foo: true,
   $bar: false
 ) {
   content: 'foo';
 }
 
-@mixin norf(
-  $foo: true, // This is a comment
-  $bar: false /* This is a comment */
+@mixin foo(
+  $foo: true, // Foo
+  $bar: false /* Bar */
 ) {
   content: 'foo';
 }


### PR DESCRIPTION
Fixes an issue in the Space After Comma rule concerning selectors and end of lines incorrectly being reported as spaces.

Fixes #125 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com