### PR TITLE
Add URL Quotes rule

### DIFF
--- a/docs/rules/url-quotes.md
+++ b/docs/rules/url-quotes.md
@@ -1,6 +1,6 @@
 # URL Quotes
 
-Rule `url-quotes` will enforce that URL strings are wrapped in quotes.
+Rule `url-quotes` will enforce that URLs are wrapped in quotes.
 
 ## Examples
 

--- a/docs/rules/url-quotes.md
+++ b/docs/rules/url-quotes.md
@@ -1,0 +1,31 @@
+# URL Quotes
+
+Rule `url-quotes` will enforce that URL strings are wrapped in quotes.
+
+## Examples
+
+When enabled, the following are allowed:
+
+```scss
+.foo {
+  background-image: url('foo.png');
+}
+
+.qux {
+  background-image: url('bar/' + $foo);
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.bar {
+  background-image: url(foo.png);
+}
+
+.norf {
+  background-image: url(bar/ + $foo);
+}
+
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -40,6 +40,7 @@ rules:
   nesting-depth: 1
   property-sort-order: 1
   quotes: 1
+  url-quotes: 1
   variable-for-property: 1
   zero-unit: 1
 

--- a/lib/rules/url-quotes.js
+++ b/lib/rules/url-quotes.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var isVarRegex = /^[\$]/;
+
+module.exports = {
+  'name': 'url-quotes',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('uri', function (node) {
+
+      node.traverse(function (item) {
+        if (item.is('raw')) {
+          if (!item.content.match(isVarRegex)) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'severity': parser.severity,
+              'line': item.end.line,
+              'column': item.end.column,
+              'message': 'Quotes around URLs are required'
+            });
+          }
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/url-quotes.js
+++ b/lib/rules/url-quotes.js
@@ -11,7 +11,6 @@ module.exports = {
     var result = [];
 
     ast.traverseByType('uri', function (node) {
-
       node.traverse(function (item) {
         if (item.is('raw')) {
           if (!item.content.match(isVarRegex)) {

--- a/tests/rules/url-quotes.js
+++ b/tests/rules/url-quotes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('url-quotes.scss');
+
+describe('url quotes', function () {
+  it('enforce', function (done) {
+    lint.test(file, {
+      'url-quotes': 1
+    }, function (data) {
+      lint.assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/url-quotes.scss
+++ b/tests/sass/url-quotes.scss
@@ -1,0 +1,21 @@
+$foo: 'foo.png';
+
+.foo {
+  background-image: url('foo.png');
+}
+
+.bar {
+  background-image: url(foo.png);
+}
+
+.baz {
+  background-image: url($foo);
+}
+
+.qux {
+  background-image: url('bar/' + $foo);
+}
+
+.norf {
+  background-image: url(bar/ + $foo);
+}


### PR DESCRIPTION
Adds the `url-quotes` rule that enforces that all URLs are wrapped in quotes.

When enabled, if a non quoted url is found, the warning message that gets displayed is:

> Quotes around URLs are required

Closes #93 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>