### PR TITLE
Add Url Format rule

### DIFF
--- a/docs/rules/url-format.md
+++ b/docs/rules/url-format.md
@@ -1,0 +1,37 @@
+# URL Format
+
+Rule `url-format` will enforce that protocols and domains are not used within urls.
+
+## Examples
+
+When enabled, the following are allowed:
+
+```scss
+.foo {
+  background-image: url('/img/bar.png');
+}
+
+.foo {
+  background-image: url('img/bar.png');
+}
+
+.foo {
+  background-image: url('bar.png');
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.foo {
+  background-image: url('https://foo.com/img/bar.png');
+}
+
+.foo {
+  background-image: url('http://foo.com/img/bar.png');
+}
+
+.foo {
+  background-image: url('//foo.com/img/bar.png');
+}
+```

--- a/lib/rules/url-format.js
+++ b/lib/rules/url-format.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var isUrlRegex = /^(http(s?)):\/\/|\/\//;
+
+var stripQuotes = function (str) {
+  return str.substring(1, str.length - 1);
+};
+
+module.exports = {
+  'name': 'url-format',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('uri', function (uri) {
+      uri.traverse(function (item) {
+        if (item.is('string')) {
+          var stripped = stripQuotes(item.content);
+
+          if (stripped.match(isUrlRegex)) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'severity': parser.severity,
+              'line': item.end.line,
+              'column': item.end.column,
+              'message': 'Protocols and domains in URLs are disallowed'
+            });
+          }
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/url-format.js
+++ b/tests/rules/url-format.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('url-format.scss');
+
+describe('url format', function () {
+  it('enforce', function (done) {
+    lint.test(file, {
+      'url-format': 1
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/url-format.scss
+++ b/tests/sass/url-format.scss
@@ -14,7 +14,7 @@
   background-image: url('/img/bar.png');
 }
 
-.fop {
+.foo {
   background-image: url('img/bar.png');
 }
 

--- a/tests/sass/url-format.scss
+++ b/tests/sass/url-format.scss
@@ -1,0 +1,23 @@
+.foo {
+  background-image: url('https://foo.com/img/bar.png');
+}
+
+.foo {
+  background-image: url('http://foo.com/img/bar.png');
+}
+
+.foo {
+  background-image: url('//foo.com/img/bar.png');
+}
+
+.foo {
+  background-image: url('/img/bar.png');
+}
+
+.fop {
+  background-image: url('img/bar.png');
+}
+
+.foo {
+  background-image: url('bar.png');
+}


### PR DESCRIPTION
Adds the `url-format` rule that disallows protocols and/or domains in urls.

When enabled, if a protocol or domain is found, the following warning message gets displayed:
> Protocols and domains in URLs are disallowed

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com

Closes #94 