### PR TITLE
Add Brace Style rule

### DIFF
--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -1,0 +1,81 @@
+# Brace Style
+
+Rule `brace-style` will enforce the use of the chosen brace style.
+
+## Options
+
+* `style`: [`'1tbs'`](https://en.wikipedia.org/wiki/Indent_style#Variant:_1TBS), [`'stroustrup'`](https://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup), [`'allman'`](https://en.wikipedia.org/wiki/Indent_style#Allman_style)
+
+## Examples
+
+When `style: '1tbs'` or `style: 'stroustrup'`, the following are allowed. When `style: 'allman'` the following are disallowed:
+
+```scss
+.foo {
+  content: 'foo';
+}
+
+.foo,
+.bar {
+  content: 'bar';
+}
+
+@function foo() {
+  @return 'foo';
+}
+
+@mixin bar() {
+  content: 'bar';
+}
+```
+
+When `style: 'allman'`, the following are allowed. When `style: '1tbs'` or `style: 'stroustrup'`, the following are disallowed:
+
+
+```scss
+.foo
+{
+  content: 'foo';
+}
+
+.foo,
+.bar
+{
+  content: 'bar';
+}
+
+@function foo()
+{
+  @return 'foo';
+}
+
+@mixin bar()
+{
+  content: 'bar';
+}
+
+```
+
+---
+### Differences between `1tbs` and `stroustrup`
+
+When `style: '1tbs'`, the following are allowed. When `style: 'stroustrup'` or `style: 'allman'`, the following are disallowed:
+
+```scss
+@if ($foo) {
+  $bar: 'bar';
+} @else {
+  $bar: false;
+}
+```
+
+When `style: 'stroustrup'`, the following are allowed. When `style: '1tbs'` or `style: 'stroustrup'`, the following are disallowed:
+
+```scss
+@if ($foo) {
+  $bar: 'bar';
+}
+@else {
+  $bar: false;
+}
+```

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -4,9 +4,12 @@ Rule `brace-style` will enforce the use of the chosen brace style.
 
 ## Options
 
-* `style`: [`'1tbs'`](https://en.wikipedia.org/wiki/Indent_style#Variant:_1TBS), [`'stroustrup'`](https://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup), [`'allman'`](https://en.wikipedia.org/wiki/Indent_style#Allman_style)
+* `style`: [`'1tbs'`](https://en.wikipedia.org/wiki/Indent_style#Variant:_1TBS), [`'stroustrup'`](https://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup), [`'allman'`](https://en.wikipedia.org/wiki/Indent_style#Allman_style) (defaults to `1tbs`)
+* `allow-single-line`: `true`/`false` (defaults to `true`)
 
 ## Examples
+
+### `style`
 
 When `style: '1tbs'` or `style: 'stroustrup'`, the following are allowed. When `style: 'allman'` the following are disallowed:
 
@@ -56,8 +59,8 @@ When `style: 'allman'`, the following are allowed. When `style: '1tbs'` or `styl
 
 ```
 
----
-### Differences between `1tbs` and `stroustrup`
+
+#### Differences between `1tbs` and `stroustrup`
 
 When `style: '1tbs'`, the following are allowed. When `style: 'stroustrup'` or `style: 'allman'`, the following are disallowed:
 
@@ -78,4 +81,24 @@ When `style: 'stroustrup'`, the following are allowed. When `style: '1tbs'` or `
 @else {
   $bar: false;
 }
+```
+
+---
+
+### `allow-single-line`
+
+When `allow-single-line: true`, the following are allowed. When `allow-single-line: false`, the following are disallowed:
+
+```scss
+.foo { content: 'foo'; }
+.foo, .bar { content: 'bar'; }
+
+@if ($foo) { $bar: 'foo'; }
+
+// Allowed with style: '1tbs', disallowed with style: 'stroustrup' or style: 'allman'
+@if ($foo) { $bar: 'foo'; } @else { $bar: false; }
+
+// Allowed with style: 'stroustrup' or style: 'allman', disallowed with style: '1tbs'
+@if ($foo) { $bar: 'foo'; }
+@else { $bar: false; }
 ```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -31,6 +31,7 @@ rules:
 
   # Style Guide
   border-zero: 1
+  brace-style: 1
   clean-import-paths: 1
   empty-args: 1
   hex-length: 1

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -6,7 +6,8 @@ var helpers = require('../helpers'),
 module.exports = {
   'name': 'brace-style',
   'defaults': {
-    'style': '1tbs'
+    'style': '1tbs',
+    'allow-single-line': true
   },
   'detect': function (ast, parser) {
     var result = [];
@@ -15,16 +16,26 @@ module.exports = {
       var next = false,
           previous = false;
 
+      // Store leading space node for @elseif statements
+      if (block.is('atruleb')) {
+        var atKeyword = block.first('atkeyword');
+
+        if (atKeyword.first('ident').content === 'else') {
+          previous = parent.get(i - 1);
+        }
+      }
+
+      // Store leading space node for @else statements
       if (block.is('conditionalStatement')) {
         previous = parent.get(i - 1);
       }
 
+      // Store trailing space node for conditional statements, mixins and loops
       if (block.is('atruleb') || block.is('conditionalStatement') || block.is('mixin') || block.is('loop')) {
-        block.forEach('block', function (item, j, itemParent) {
-          next = itemParent.get(j - 1);
-        });
+        next = block.last('space');
       }
 
+      // Store trailing space node for selectors
       if (block.is('selector')) {
         next = block.last('simpleSelector').last('space');
       }
@@ -65,7 +76,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': previous.start.line,
                 'column': previous.start.column,
-                'message': 'Conditional statement should be on a new line',
+                'message': 'Statement should begin on a new line',
                 'severity': parser.severity
               });
             }
@@ -77,7 +88,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': previous.start.line,
                 'column': previous.start.column,
-                'message': 'Following conditional statement should be on current line',
+                'message': 'Statement on next line should begin on the current line',
                 'severity': parser.severity
               });
             }

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -3,6 +3,10 @@
 var helpers = require('../helpers'),
     os = require('os');
 
+var isSingleLineStatement = function (node) {
+  return node.start.line === node.end.line;
+};
+
 module.exports = {
   'name': 'brace-style',
   'defaults': {
@@ -14,7 +18,8 @@ module.exports = {
 
     ast.traverseByTypes(['conditionalStatement', 'atruleb', 'selector', 'mixin', 'loop'], function (block, i, parent) {
       var next = false,
-          previous = false;
+          previous = false,
+          isSingleLine = false;
 
       // Store leading space node for @elseif statements
       if (block.is('atruleb')) {
@@ -33,64 +38,86 @@ module.exports = {
       // Store trailing space node for conditional statements, mixins and loops
       if (block.is('atruleb') || block.is('conditionalStatement') || block.is('mixin') || block.is('loop')) {
         next = block.last('space');
+
+        // Determine if single line statement
+        isSingleLine = isSingleLineStatement(block);
       }
 
       // Store trailing space node for selectors
       if (block.is('selector')) {
         next = block.last('simpleSelector').last('space');
-      }
 
-      if (next) {
-        if (next.is('space')) {
-          if (next.content.indexOf(os.EOL) === -1) {
-            if (parser.options.style === 'allman') {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': next.start.line,
-                'column': next.start.column,
-                'message': 'Brace must be on a new line',
-                'severity': parser.severity
-              });
-            }
-          }
-
-          if (next.content.indexOf(os.EOL) !== -1) {
-            if (parser.options.style === '1tbs' || parser.options.style === 'stroustrup') {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': next.start.line,
-                'column': next.start.column,
-                'message': 'Brace must be on same line as condition',
-                'severity': parser.severity
-              });
-            }
-          }
+        // Determine if single line statement
+        if (parent.is('ruleset')) {
+          isSingleLine = isSingleLineStatement(parent);
         }
       }
 
-      if (previous) {
-        if (previous.is('space')) {
-          if (previous.content.indexOf(os.EOL) === -1) {
-            if (parser.options.style === 'allman' || parser.options.style === 'stroustrup') {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': previous.start.line,
-                'column': previous.start.column,
-                'message': 'Statement should begin on a new line',
-                'severity': parser.severity
-              });
+      if ((parser.options['allow-single-line'] === false) && isSingleLine) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': block.start.line,
+          'column': block.start.column,
+          'message': 'Single line statements are not allowed',
+          'severity': parser.severity
+        });
+      }
+      else {
+        if (next) {
+          if (next.is('space')) {
+            if (next.content.indexOf(os.EOL) === -1) {
+              if (parser.options.style === 'allman') {
+                // Report if it's not single line statement
+                if (!((parser.options['allow-single-line'] === true) && isSingleLine)) {
+                  result = helpers.addUnique(result, {
+                    'ruleId': parser.rule.name,
+                    'line': next.start.line,
+                    'column': next.start.column,
+                    'message': 'Brace must be on a new line',
+                    'severity': parser.severity
+                  });
+                }
+              }
+            }
+
+            if (next.content.indexOf(os.EOL) !== -1) {
+              if (parser.options.style === '1tbs' || parser.options.style === 'stroustrup') {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': next.start.line,
+                  'column': next.start.column,
+                  'message': 'Brace must be on same line as condition',
+                  'severity': parser.severity
+                });
+              }
             }
           }
+        }
 
-          if (previous.content.indexOf(os.EOL) !== -1) {
-            if (parser.options.style === '1tbs') {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': previous.start.line,
-                'column': previous.start.column,
-                'message': 'Statement on next line should begin on the current line',
-                'severity': parser.severity
-              });
+        if (previous) {
+          if (previous.is('space')) {
+            if (previous.content.indexOf(os.EOL) === -1) {
+              if (parser.options.style === 'allman' || parser.options.style === 'stroustrup') {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': previous.start.line,
+                  'column': previous.start.column,
+                  'message': 'Statement should begin on a new line',
+                  'severity': parser.severity
+                });
+              }
+            }
+
+            if (previous.content.indexOf(os.EOL) !== -1) {
+              if (parser.options.style === '1tbs') {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': previous.start.line,
+                  'column': previous.start.column,
+                  'message': 'Statement on next line should begin on the current line',
+                  'severity': parser.severity
+                });
+              }
             }
           }
         }

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -16,6 +16,8 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
+  //   console.log(ast.toJson());
+
     ast.traverseByTypes(['conditionalStatement', 'atruleb', 'selector', 'mixin', 'loop'], function (block, i, parent) {
       var next = false,
           previous = false,
@@ -32,7 +34,9 @@ module.exports = {
 
       // Store leading space node for @else statements
       if (block.is('conditionalStatement')) {
-        previous = parent.get(i - 1);
+        if (block.first('condition').first('atkeyword').first('ident').content === 'else') {
+          previous = parent.get(i - 1);
+        }
       }
 
       // Store trailing space node for conditional statements, mixins and loops
@@ -52,6 +56,10 @@ module.exports = {
           isSingleLine = isSingleLineStatement(parent);
         }
       }
+
+
+      // console.log(block);
+
 
       if ((parser.options['allow-single-line'] === false) && isSingleLine) {
         result = helpers.addUnique(result, {

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -16,8 +16,6 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-  //   console.log(ast.toJson());
-
     ast.traverseByTypes(['conditionalStatement', 'atruleb', 'selector', 'mixin', 'loop'], function (block, i, parent) {
       var next = false,
           previous = false,
@@ -56,10 +54,6 @@ module.exports = {
           isSingleLine = isSingleLineStatement(parent);
         }
       }
-
-
-      // console.log(block);
-
 
       if ((parser.options['allow-single-line'] === false) && isSingleLine) {
         result = helpers.addUnique(result, {

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var helpers = require('../helpers'),
+    os = require('os');
+
+module.exports = {
+  'name': 'brace-style',
+  'defaults': {
+    'style': '1tbs'
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByTypes(['conditionalStatement', 'atruleb', 'selector', 'mixin', 'loop'], function (block, i, parent) {
+      var next = false,
+          previous = false;
+
+      if (block.is('conditionalStatement')) {
+        previous = parent.get(i - 1);
+      }
+
+      if (block.is('atruleb') || block.is('conditionalStatement') || block.is('mixin') || block.is('loop')) {
+        block.forEach('block', function (item, j, itemParent) {
+          next = itemParent.get(j - 1);
+        });
+      }
+
+      if (block.is('selector')) {
+        next = block.last('simpleSelector').last('space');
+      }
+
+      if (next) {
+        if (next.is('space')) {
+          if (next.content.indexOf(os.EOL) === -1) {
+            if (parser.options.style === 'allman') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': next.start.line,
+                'column': next.start.column,
+                'message': 'Brace must be on a new line',
+                'severity': parser.severity
+              });
+            }
+          }
+
+          if (next.content.indexOf(os.EOL) !== -1) {
+            if (parser.options.style === '1tbs' || parser.options.style === 'stroustrup') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': next.start.line,
+                'column': next.start.column,
+                'message': 'Brace must be on same line as condition',
+                'severity': parser.severity
+              });
+            }
+          }
+        }
+      }
+
+      if (previous) {
+        if (previous.is('space')) {
+          if (previous.content.indexOf(os.EOL) === -1) {
+            if (parser.options.style === 'allman' || parser.options.style === 'stroustrup') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': previous.start.line,
+                'column': previous.start.column,
+                'message': 'Conditional statement should be on a new line',
+                'severity': parser.severity
+              });
+            }
+          }
+
+          if (previous.content.indexOf(os.EOL) !== -1) {
+            if (parser.options.style === '1tbs') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': previous.start.line,
+                'column': previous.start.column,
+                'message': 'Following conditional statement should be on current line',
+                'severity': parser.severity
+              });
+            }
+          }
+        }
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/brace-style.js
+++ b/tests/rules/brace-style.js
@@ -24,7 +24,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(38, data.warningCount);
+      lint.assert.equal(39, data.warningCount);
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(36, data.warningCount);
+      lint.assert.equal(37, data.warningCount);
       done();
     });
   });
@@ -69,7 +69,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(22, data.warningCount);
+      lint.assert.equal(23, data.warningCount);
       done();
     });
   });
@@ -84,7 +84,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(40, data.warningCount);
+      lint.assert.equal(42, data.warningCount);
       done();
     });
   });

--- a/tests/rules/brace-style.js
+++ b/tests/rules/brace-style.js
@@ -9,7 +9,7 @@ describe('brace style', function () {
     lint.test(file, {
       'brace-style': 1
     }, function (data) {
-      lint.assert.equal(14, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -37,7 +37,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(19, data.warningCount);
       done();
     });
   });

--- a/tests/rules/brace-style.js
+++ b/tests/rules/brace-style.js
@@ -5,39 +5,86 @@ var lint = require('./_lint');
 var file = lint.file('brace-style.scss');
 
 describe('brace style', function () {
-  it('[style: 1tbs]', function (done) {
+  it('[style: 1tbs, allow-single-line: true]', function (done) {
     lint.test(file, {
       'brace-style': 1
     }, function (data) {
-      lint.assert.equal(17, data.warningCount);
+      lint.assert.equal(20, data.warningCount);
       done();
     });
   });
 
-  it('[style: stroustrup]', function (done) {
+  it('[style: 1tbs, allow-single-line: false]', function (done) {
     lint.test(file, {
       'brace-style': [
         1,
         {
-          'style': 'stroustrup'
+          'style': '1tbs',
+          'allow-single-line': false
         }
       ]
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      lint.assert.equal(30, data.warningCount);
       done();
     });
   });
 
-  it('[style: allman]', function (done) {
+  it('[style: stroustrup, allow-single-line: true]', function (done) {
     lint.test(file, {
       'brace-style': [
         1,
         {
-          'style': 'allman'
+          'style': 'stroustrup',
+          'allow-single-line': true
         }
       ]
     }, function (data) {
-      lint.assert.equal(19, data.warningCount);
+      lint.assert.equal(18, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: stroustrup, allow-single-line: false]', function (done) {
+    lint.test(file, {
+      'brace-style': [
+        1,
+        {
+          'style': 'stroustrup',
+          'allow-single-line': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(28, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: allman, allow-single-line: true]', function (done) {
+    lint.test(file, {
+      'brace-style': [
+        1,
+        {
+          'style': 'allman',
+          'allow-single-line': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(22, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: allman, allow-single-line: false]', function (done) {
+    lint.test(file, {
+      'brace-style': [
+        1,
+        {
+          'style': 'allman',
+          'allow-single-line': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(32, data.warningCount);
       done();
     });
   });

--- a/tests/rules/brace-style.js
+++ b/tests/rules/brace-style.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('brace-style.scss');
+
+describe('brace style', function () {
+  it('[style: 1tbs]', function (done) {
+    lint.test(file, {
+      'brace-style': 1
+    }, function (data) {
+      lint.assert.equal(14, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: stroustrup]', function (done) {
+    lint.test(file, {
+      'brace-style': [
+        1,
+        {
+          'style': 'stroustrup'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: allman]', function (done) {
+    lint.test(file, {
+      'brace-style': [
+        1,
+        {
+          'style': 'allman'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(16, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/rules/brace-style.js
+++ b/tests/rules/brace-style.js
@@ -24,7 +24,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(30, data.warningCount);
+      lint.assert.equal(38, data.warningCount);
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(28, data.warningCount);
+      lint.assert.equal(36, data.warningCount);
       done();
     });
   });
@@ -84,7 +84,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(32, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });

--- a/tests/sass/brace-style.scss
+++ b/tests/sass/brace-style.scss
@@ -174,3 +174,18 @@ $total: 4;
 @if ($foo) { $bar: 'foo'; }
 @else if { $bar: 'bar'; }
 @else { $bar: false; }
+
+
+@function foo() { @return 'foo'; }
+
+
+@mixin bar() { content: 'bar'; }
+
+
+@for $i from 1 through 5 { .for-#{$i} { content: 'foo'; } }
+
+
+@each $item in $list { .each-#{$item} { content: #{$item}; } }
+
+
+@while $total > 0 { .while-#{$total} { content: #{$total}; } $total: $total - 1; }

--- a/tests/sass/brace-style.scss
+++ b/tests/sass/brace-style.scss
@@ -189,3 +189,14 @@ $total: 4;
 
 
 @while $total > 0 { .while-#{$total} { content: #{$total}; } $total: $total - 1; }
+
+
+
+
+// No parens
+
+@if $foo { $bar: 'foo'; }
+
+@if $foo {
+  $bar: 'foo';
+}

--- a/tests/sass/brace-style.scss
+++ b/tests/sass/brace-style.scss
@@ -111,6 +111,8 @@
 
 $list: (foo bar baz qux);
 
+
+
 @each $item in $list {
   .each-#{$item} {
     content: #{$item};
@@ -149,3 +151,26 @@ $total: 4;
 
   $total: $total - 1;
 }
+
+
+
+
+// Single-line statements
+
+.foo { content: 'foo'; }
+.foo, .bar { content: 'bar'; }
+
+
+@if ($foo) { $bar: 'foo'; }
+
+@if ($foo) { $bar: 'foo'; } @else { $bar: false; }
+@if ($foo) { $bar: 'foo'; } @else if { $bar: 'bar'; } @else { $bar: false; }
+
+
+@if ($foo) { $bar: 'foo'; }
+@else { $bar: false; }
+
+
+@if ($foo) { $bar: 'foo'; }
+@else if { $bar: 'bar'; }
+@else { $bar: false; }

--- a/tests/sass/brace-style.scss
+++ b/tests/sass/brace-style.scss
@@ -1,0 +1,142 @@
+.foo {
+  content: 'foo';
+}
+
+
+.foo
+{
+  content: 'foo';
+}
+
+
+.foo, .bar {
+  content: 'bar';
+}
+
+
+.foo,
+.bar {
+  content: 'bar';
+}
+
+
+.foo,
+.bar
+{
+  content: 'bar';
+}
+
+
+
+
+@function foo() {
+  @return 'foo';
+}
+
+
+@function foo()
+{
+  @return 'foo';
+}
+
+
+
+
+@mixin bar() {
+  content: 'bar';
+}
+
+
+@mixin bar()
+{
+  content: 'bar';
+}
+
+
+
+
+@if ($foo) {
+  $bar: 'bar';
+} @else {
+  $bar: false;
+}
+
+
+@if ($foo) {
+  $bar: 'bar';
+}
+@else {
+  $bar: false;
+}
+
+
+@if ($foo)
+{
+  $bar: 'bar';
+}
+@else
+{
+  $bar: false;
+}
+
+
+
+
+@for $i from 1 through 5 {
+  .for-#{$i} {
+    content: 'foo';
+  }
+}
+
+
+@for $i from 1 through 5
+{
+  .for-#{$i}
+  {
+    content: 'foo';
+  }
+}
+
+
+
+
+$list: (foo bar baz qux);
+
+@each $item in $list {
+  .each-#{$item} {
+    content: #{$item};
+  }
+}
+
+
+@each $item in $list
+{
+  .each-#{$item}
+  {
+    content: #{$item};
+  }
+}
+
+
+
+
+$total: 4;
+
+@while $total > 0 {
+  .while-#{$total} {
+    content: #{$total};
+  }
+
+  $total: $total - 1;
+}
+
+
+@while $total > 0
+{
+  .while-#{$total}
+  {
+    content: #{$total};
+  }
+
+  $total: $total - 1;
+}

--- a/tests/sass/brace-style.scss
+++ b/tests/sass/brace-style.scss
@@ -56,6 +56,8 @@
 
 
 @if ($foo) {
+  $bar: 'foo';
+} @else if ($bar) {
   $bar: 'bar';
 } @else {
   $bar: false;
@@ -63,6 +65,9 @@
 
 
 @if ($foo) {
+  $bar: 'foo';
+}
+@else if ($bar) {
   $bar: 'bar';
 }
 @else {
@@ -71,6 +76,10 @@
 
 
 @if ($foo)
+{
+  $bar: 'foo';
+}
+@else if ($bar)
 {
   $bar: 'bar';
 }


### PR DESCRIPTION
Adds a rule that will enforce the use of the chosen brace style. Can be `1tbs`, `stroustrup` or `allman`.

## Warning messages

When `style: allman` and brace on same line:
> Brace must be on a new line

When `style: 1tbs` or `style: stroustrup` and brace on new line:
> Brace must be on same line as condition

**For `@else` and `@elseif` statements**
When `style: allman` or `style: stroustrup` and statement on same line as previous brace:
> Statement should begin on a new line

When `style: 1tbs` and statement on new line:
> Statement on next line should begin on the current line

## Todo

- Add option and support to allow for single-line statements


Closes #36 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>