### PR TITLE
Add unit test for ignored files

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -31,7 +31,7 @@ program
   .version(meta.version)
   .usage('[options] <pattern>')
   .option('-c, --config [path]', 'path to custom config file')
-  .option('-i, --ignore [pattern]', 'pattern to ignore. For multiple ignores, separate each pattern by `, `')
+  .option('-i, --ignore [pattern]', 'pattern to ignore. For multiple ignores, separate each pattern by `,`')
   .option('-q, --no-exit', 'do not exit on errors')
   .option('-v, --verbose', 'verbose output')
   .parse(process.argv);
@@ -42,7 +42,7 @@ if (program.config && program.config !== true) {
 }
 
 if (program.ignore && program.ignore !== true) {
-  ignores = program.ignore.split(', ');
+  ignores = program.ignore.split(',');
   configOptions = {
     'files': {
       'ignore': ignores

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,7 +1,8 @@
 var assert = require('assert'),
     should = require('should'),
     childProcess = require('child_process'),
-    fs = require('fs');
+    fs = require('fs'),
+    path = require('path');
 
 
 describe('cli', function () {
@@ -36,11 +37,12 @@ describe('cli', function () {
   });
 
   it('should not include ignored paths', function (done) {
-    var sassTestsPath = 'tests/sass/',
+
+    var sassTestsPath = path.join(__dirname, '/sass/'),
         files = [];
 
-    files.push(sassTestsPath + fs.readdirSync('tests/sass')[0]);
-    files.push(sassTestsPath + fs.readdirSync('tests/sass')[1]);
+    files.push(sassTestsPath + fs.readdirSync(sassTestsPath)[0]);
+    files.push(sassTestsPath + fs.readdirSync(sassTestsPath)[1]);
 
     var command = 'sass-lint -v -i ' + files;
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     should = require('should'),
-    childProcess = require('child_process');
+    childProcess = require('child_process'),
+    fs = require('fs');
 
 
 describe('cli', function () {
@@ -28,6 +29,29 @@ describe('cli', function () {
       }
 
       should(stdout).match(/^[0-9]+.[0-9]+(.[0-9]+)?/);
+
+      done(null);
+    });
+
+  });
+
+  it('should not include ignored paths', function (done) {
+    var sassTestsPath = 'tests/sass/',
+        files = [];
+
+    files.push(sassTestsPath + fs.readdirSync('tests/sass')[0]);
+    files.push(sassTestsPath + fs.readdirSync('tests/sass')[1]);
+
+    var command = 'sass-lint -v -i ' + files;
+
+    childProcess.exec(command, function (err, stdout) {
+      if (err) {
+        return done(err);
+      }
+
+      files.forEach(function (file) {
+        assert(stdout.indexOf(file) === -1);
+      });
 
       done(null);
     });


### PR DESCRIPTION
It seems there must be no space between each ignored pattern for glob to recognize them all. I fixed that, as well as added a unit test to test against ignored files. I ran `npm test` and it passed successfully.

```bash
cli
    ✓ should return help instructions (120ms)
    ✓ should return a version (119ms)
    ✓ should not include ignored paths (461ms)
```
...
```bash
 zero unit
    ✓ [include: false]
    ✓ [include: true]

  60 passing (219ms)
```