### PR TITLE
Add more selector tests for Brace Style

### DIFF
--- a/tests/rules/brace-style.js
+++ b/tests/rules/brace-style.js
@@ -9,7 +9,7 @@ describe('brace style', function () {
     lint.test(file, {
       'brace-style': 1
     }, function (data) {
-      lint.assert.equal(20, data.warningCount);
+      lint.assert.equal(30, data.warningCount);
       done();
     });
   });
@@ -24,7 +24,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(49, data.warningCount);
       done();
     });
   });
@@ -39,7 +39,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(18, data.warningCount);
+      lint.assert.equal(28, data.warningCount);
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(37, data.warningCount);
+      lint.assert.equal(47, data.warningCount);
       done();
     });
   });
@@ -69,7 +69,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(23, data.warningCount);
+      lint.assert.equal(32, data.warningCount);
       done();
     });
   });
@@ -84,7 +84,7 @@ describe('brace style', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(42, data.warningCount);
+      lint.assert.equal(51, data.warningCount);
       done();
     });
   });

--- a/tests/sass/brace-style.scss
+++ b/tests/sass/brace-style.scss
@@ -14,6 +14,12 @@
 }
 
 
+.foo, .bar
+{
+  content: 'bar';
+}
+
+
 .foo,
 .bar {
   content: 'bar';
@@ -25,6 +31,118 @@
 {
   content: 'bar';
 }
+
+
+
+
+h1 {
+  content: 'foo';
+}
+
+
+h1
+{
+  content: 'foo';
+}
+
+
+h1, h2 {
+  content: 'foo';
+}
+
+
+h1, h2
+{
+  content: 'foo';
+}
+
+
+h1,
+h2 {
+  content: 'foo';
+}
+
+
+h1,
+h2
+{
+  content: 'foo';
+}
+
+
+
+
+#foo {
+  content: 'foo';
+}
+
+
+#foo
+{
+  content: 'foo';
+}
+
+
+#foo, #bar {
+  content: 'foo';
+}
+
+
+#foo, #bar
+{
+  content: 'foo';
+}
+
+
+#foo,
+#bar {
+  content: 'foo';
+}
+
+
+#foo,
+#bar
+{
+  content: 'foo';
+}
+
+
+
+
+.foo[type="text"] {
+  content: 'foo';
+}
+
+
+.foo[type="text"]
+{
+  content: 'foo';
+}
+
+
+.foo[type="text"], .bar[type="email"] {
+  content: 'foo';
+}
+
+
+.foo[type="text"], .bar[type="email"]
+{
+  content: 'foo';
+}
+
+
+.foo[type="text"],
+.bar[type="email"] {
+  content: 'foo';
+}
+
+
+.foo[type="text"],
+.bar[type="email"]
+{
+  content: 'foo';
+}
+
 
 
 


### PR DESCRIPTION
This adds more tests specifically for selectors to the Brace Style rule added in #143 .

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>