### PR TITLE
Fix CLI custom config assertion error #150

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -14,11 +14,11 @@ var detectPattern = function (pattern) {
       formatted;
 
   detects = lint.lintFiles(pattern, configOptions, configPath);
-  formatted = lint.format(detects);
+  formatted = lint.format(detects, configOptions, configPath);
 
 
   if (program.verbose) {
-    lint.outputResults(formatted);
+    lint.outputResults(formatted, configOptions, configPath);
   }
 
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -113,7 +113,7 @@ describe('cli', function () {
           return done();
         }
         else {
-          return done(new Error('warnings/errors were returned'));
+          return done(new Error('warnings/errors were expected to be returned but weren\'t'));
         }
       }
     });

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -33,4 +33,89 @@ describe('cli', function () {
     });
 
   });
+
+  // Test custom config path
+
+  it('should return JSON from a custom config', function (done) {
+    var command = 'sass-lint -c tests/yml/.json-lint.yml tests/sass/cli.scss --verbose';
+
+    childProcess.exec(command, function (err, stdout) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        try {
+          JSON.parse(stdout);
+          return done();
+        }
+        catch (e) {
+          return done(new Error('Not JSON'));
+        }
+      }
+    });
+  });
+
+  // Test 0 errors/warnings when rules set to 0 in config
+
+  it('should return no errors/warnings', function (done) {
+    var command = 'sass-lint -c tests/yml/.json-lint.yml tests/sass/cli.scss --verbose';
+
+    childProcess.exec(command, function (err, stdout) {
+
+      var result = '';
+
+      if (err) {
+        return done(err);
+      }
+
+      else {
+        try {
+          result = JSON.parse(stdout);
+        }
+        catch (e) {
+          return done(new Error('Not JSON'));
+        }
+
+        if (result[0].warningCount === 0 && result[0].errorCount === 0) {
+          return done();
+        }
+        else {
+          return done(new Error('warnings/errors were returned'));
+        }
+
+      }
+    });
+  });
+
+  // Test 1 warning when rules set to 0 in config
+
+  it('should return a warning', function (done) {
+    var command = 'sass-lint -c tests/yml/.color-keyword-errors.yml tests/sass/cli.scss --verbose';
+
+    childProcess.exec(command, function (err, stdout) {
+
+      var result = '';
+
+      if (err) {
+        return done(err);
+      }
+
+      else {
+        try {
+          result = JSON.parse(stdout);
+        }
+        catch (e) {
+          return done(new Error('Not JSON'));
+        }
+
+        if (result[0].warningCount === 1 && result[0].errorCount === 0) {
+          return done();
+        }
+        else {
+          return done(new Error('warnings/errors were returned'));
+        }
+      }
+    });
+  });
 });

--- a/tests/sass/cli.scss
+++ b/tests/sass/cli.scss
@@ -1,0 +1,3 @@
+.cli {
+  color: red;
+}

--- a/tests/yml/.color-keyword-errors.yml
+++ b/tests/yml/.color-keyword-errors.yml
@@ -1,0 +1,58 @@
+options:
+  formatter: json
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 0
+  extends-before-declarations: 0
+  placeholder-in-extend: 0
+
+  # Mixins
+  mixins-before-declarations: 0
+
+  # Line Spacing
+  one-declaration-per-line: 0
+  empty-line-between-blocks: 0
+  single-line-per-selector: 0
+
+  # Disallows
+  no-debug: 0
+  no-duplicate-properties: 0
+  no-empty-rulesets: 0
+  no-extends: 0
+  no-ids: 0
+  no-important: 0
+  no-warn: 0
+  no-color-keywords: 1
+  no-invalid-hex: 0
+  no-css-comments: 0
+  no-color-literals: 0
+  no-vendor-prefix: 0
+
+  # Style Guide
+  border-zero: 0
+  clean-import-paths: 0
+  empty-args: 0
+  hex-length: 0
+  hex-notation: 0
+  indentation: 0
+  leading-zero: 0
+  nesting-depth: 0
+  property-sort-order: 0
+  quotes: 0
+  variable-for-property: 0
+  zero-unit: 0
+
+  # Inner Spacing
+  space-after-comma: 0
+  space-before-colon: 0
+  space-after-colon: 0
+  space-before-brace: 0
+  space-before-bang: 0
+  space-after-bang: 0
+  space-between-parens: 0
+
+  # Final Items
+  trailing-semicolon: 0
+  final-newline: 0

--- a/tests/yml/.json-lint.yml
+++ b/tests/yml/.json-lint.yml
@@ -1,0 +1,58 @@
+options:
+  formatter: json
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 0
+  extends-before-declarations: 0
+  placeholder-in-extend: 0
+
+  # Mixins
+  mixins-before-declarations: 0
+
+  # Line Spacing
+  one-declaration-per-line: 0
+  empty-line-between-blocks: 0
+  single-line-per-selector: 0
+
+  # Disallows
+  no-debug: 0
+  no-duplicate-properties: 0
+  no-empty-rulesets: 0
+  no-extends: 0
+  no-ids: 0
+  no-important: 0
+  no-warn: 0
+  no-color-keywords: 0
+  no-invalid-hex: 0
+  no-css-comments: 0
+  no-color-literals: 0
+  no-vendor-prefix: 0
+
+  # Style Guide
+  border-zero: 0
+  clean-import-paths: 0
+  empty-args: 0
+  hex-length: 0
+  hex-notation: 0
+  indentation: 0
+  leading-zero: 0
+  nesting-depth: 0
+  property-sort-order: 0
+  quotes: 0
+  variable-for-property: 0
+  zero-unit: 0
+
+  # Inner Spacing
+  space-after-comma: 0
+  space-before-colon: 0
+  space-after-colon: 0
+  space-before-brace: 0
+  space-before-bang: 0
+  space-after-bang: 0
+  space-between-parens: 0
+
+  # Final Items
+  trailing-semicolon: 0
+  final-newline: 0


### PR DESCRIPTION
This fixes an assertion error you would encounter if using the CLI from a directory that didn't contain a `.sass-lint.yml` or `package.json` with a config file specified.

The reason being the format and output functions of the linter weren't being passed the config options from the CLI and therefore were defaulting to whatever config was in the current directory. If these don't exist then we encounter assertion errors.

Also added 3 tests for the CLI custom config path

closes #150 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com