### PR TITLE
Add format and output options to CLI

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -34,6 +34,8 @@ program
   .option('-i, --ignore [pattern]', 'pattern to ignore. For multiple ignores, separate each pattern by `, `')
   .option('-q, --no-exit', 'do not exit on errors')
   .option('-v, --verbose', 'verbose output')
+  .option('-f, --format [format]', 'pass one of the available eslint formats')
+  .option('-o, --output [output]', 'the path and filename where you would like output to be written')
   .parse(process.argv);
 
 
@@ -43,11 +45,36 @@ if (program.config && program.config !== true) {
 
 if (program.ignore && program.ignore !== true) {
   ignores = program.ignore.split(', ');
-  configOptions = {
-    'files': {
+  if (configOptions.hasOwnProperty('files')) {
+    configOptions.files.ignore = ignores;
+  }
+  else {
+    configOptions.files = {
       'ignore': ignores
-    }
-  };
+    };
+  }
+}
+
+if (program.format && program.format !== true) {
+  if (configOptions.hasOwnProperty('options')) {
+    configOptions.options.formatter = program.format;
+  }
+  else {
+    configOptions.options = {
+      'formatter': program.format
+    };
+  }
+}
+
+if (program.output && program.output !== true) {
+  if (configOptions.hasOwnProperty('options')) {
+    configOptions.options['output-file'] = program.output;
+  }
+  else {
+    configOptions.options = {
+      'output-file': program.output
+    };
+  }
 }
 
 if (program.args.length === 0) {

--- a/docs/cli/readme.md
+++ b/docs/cli/readme.md
@@ -14,4 +14,5 @@ The following options are available for the CLI:
 * `-i, --ignore [pattern]`: A pattern that should be ignored from linting. Multiple patterns can be used by separating each pattern by `, `. Patterns should be wrapped in quotes (will be merged with other ignore options)
 * `-q, --no-exit`: Prevents the CLI from throwing an error if there is one (useful for development work)
 * `-v, --verbose`: Verbose output (fully formatted output)
- 
+* `-f, --format [format]`: Pass one of the available [Eslint formats](https://github.com/eslint/eslint/tree/master/lib/formatters) to format the output of sass-lint results.
+* `-o, --output [output]`: The path plus file name relative to where Sass Lint is being run from where the output should be written to.

--- a/index.js
+++ b/index.js
@@ -86,9 +86,10 @@ sassLint.lintFiles = function (files, options, configPath) {
 
 
 sassLint.format = function (results, options, configPath) {
-  var config = this.getConfig(options, configPath);
+  var config = this.getConfig(options, configPath),
+      format = config.options.formatter.toLowerCase();
 
-  var formatted = require('eslint/lib/formatters/' + config.options.formatter);
+  var formatted = require('eslint/lib/formatters/' + format);
 
   return formatted(results);
 };

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,5 +1,7 @@
 var assert = require('assert'),
     should = require('should'),
+    fs = require('fs-extra'),
+    path = require('path'),
     childProcess = require('child_process');
 
 
@@ -32,5 +34,81 @@ describe('cli', function () {
       done(null);
     });
 
+  });
+
+  it('CLI format option should output JSON', function (done) {
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON';
+
+    childProcess.exec(command, function (err, stdout) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        try {
+          JSON.parse(stdout);
+          return done();
+        }
+        catch (e) {
+          return done(new Error('Not JSON'));
+        }
+      }
+    });
+  });
+
+  it('CLI output option should write to test file', function (done) {
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON --output tests/cli-output.json',
+        outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
+
+    childProcess.exec(command, function (err) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        var contents = fs.readFileSync(outputFile, 'utf8');
+
+        if (contents.length > 0) {
+          fs.removeSync(outputFile);
+          return done();
+        }
+        else {
+          return done(new Error(outputFile + 'is empty'));
+        }
+      }
+    });
+  });
+
+  it('CLI output option should write JSON to test file', function (done) {
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON --output tests/cli-output.json',
+        outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
+
+    childProcess.exec(command, function (err) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        var contents = fs.readFileSync(outputFile, 'utf8');
+
+        if (contents.length > 0) {
+
+          try {
+            JSON.parse(contents);
+            fs.removeSync(outputFile);
+            return done();
+          }
+          catch (e) {
+            fs.removeSync(outputFile);
+            return done(new Error('Written file is not in JSON format'));
+          }
+
+        }
+        else {
+          fs.removeSync(outputFile);
+          return done(new Error(outputFile + 'is empty'));
+        }
+      }
+    });
   });
 });

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -35,7 +35,7 @@ describe('cli', function () {
   });
 
   it('CLI format option should output JSON', function (done) {
-    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON';
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format json';
 
     childProcess.exec(command, function (err, stdout) {
 
@@ -55,7 +55,7 @@ describe('cli', function () {
   });
 
   it('CLI output option should write to test file', function (done) {
-    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON --output tests/cli-output.json',
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format json --output tests/cli-output.json',
         outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
 
     childProcess.exec(command, function (err) {
@@ -78,7 +78,7 @@ describe('cli', function () {
   });
 
   it('CLI output option should write JSON to test file', function (done) {
-    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON --output tests/cli-output.json',
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format json --output tests/cli-output.json',
         outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
 
     childProcess.exec(command, function (err) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -110,6 +110,39 @@ describe('cli', function () {
     });
   });
 
+  it('CLI output option should write JSON to test file when upper case format is used', function (done) {
+    var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON --output tests/cli-output.json',
+        outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
+
+    childProcess.exec(command, function (err) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        var contents = fs.readFileSync(outputFile, 'utf8');
+
+        if (contents.length > 0) {
+
+          try {
+            JSON.parse(contents);
+            fs.removeSync(outputFile);
+            return done();
+          }
+          catch (e) {
+            fs.removeSync(outputFile);
+            return done(new Error('Written file is not in JSON format'));
+          }
+
+        }
+        else {
+          fs.removeSync(outputFile);
+          return done(new Error(outputFile + 'is empty'));
+        }
+      }
+    });
+  });
+
   // Test custom config path
 
   it('should return JSON from a custom config', function (done) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -18,7 +18,6 @@ describe('cli', function () {
 
       done(null);
     });
-
   });
 
   it('should return a version', function (done) {
@@ -33,7 +32,6 @@ describe('cli', function () {
 
       done(null);
     });
-
   });
 
   it('CLI format option should output JSON', function (done) {

--- a/tests/sass/cli.scss
+++ b/tests/sass/cli.scss
@@ -1,0 +1,3 @@
+.cli {
+  color: red;
+}

--- a/tests/yml/.stylish-output.yml
+++ b/tests/yml/.stylish-output.yml
@@ -1,0 +1,57 @@
+options:
+  formatter: stylish
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 0
+  extends-before-declarations: 0
+  placeholder-in-extend: 0
+
+  # Mixins
+  mixins-before-declarations: 0
+
+  # Line Spacing
+  one-declaration-per-line: 0
+  empty-line-between-blocks: 0
+  single-line-per-selector: 0
+
+  # Disallows
+  no-debug: 0
+  no-duplicate-properties: 0
+  no-empty-rulesets: 0
+  no-extends: 0
+  no-ids: 0
+  no-important: 0
+  no-warn: 0
+  no-color-keywords: 0
+  no-invalid-hex: 0
+  no-css-comments: 0
+  no-color-literals: 0
+
+  # Style Guide
+  border-zero: 0
+  clean-import-paths: 0
+  empty-args: 0
+  hex-length: 0
+  hex-notation: 0
+  indentation: 0
+  leading-zero: 0
+  nesting-depth: 0
+  property-sort-order: 0
+  quotes: 0
+  variable-for-property: 0
+  zero-unit: 0
+
+  # Inner Spacing
+  space-after-comma: 0
+  space-before-colon: 0
+  space-after-colon: 0
+  space-before-brace: 0
+  space-before-bang: 0
+  space-after-bang: 0
+  space-between-parens: 0
+
+  # Final Items
+  trailing-semicolon: 0
+  final-newline: 0


### PR DESCRIPTION
Added 2 new flags to the CLI 
* `-f --format [format]`
* `-o --output [output]`

This makes the CLI feature complete compared to the current `sass-lint` build. Format allows you to specify an output format from any of the eslint formatters. Output allows you to specify and output directory & file to write linting results to.

Also added tests for each option.

There's a slight overlap in some of the files added here as in #151 which should probably be merged first due to it fixing bugs.

closes #127 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com