### PR TITLE
Enhance no-duplicate-properties rule to allow exceptions

### DIFF
--- a/docs/rules/no-duplicate-properties.md
+++ b/docs/rules/no-duplicate-properties.md
@@ -2,6 +2,11 @@
 
 Rule `no-duplicate-properties` will enforce that duplicate properties are not allowed within the same block.
 
+## Options
+
+* `exclude`: `[array of property names to be excluded from this rule]` (defaults to empty array `[]`)
+
+
 ## Examples
 
 When enabled, the following are disallowed:

--- a/lib/rules/no-duplicate-properties.js
+++ b/lib/rules/no-duplicate-properties.js
@@ -4,7 +4,9 @@ var helpers = require('../helpers');
 
 module.exports = {
   'name': 'no-duplicate-properties',
-  'defaults': {},
+  'defaults': {
+    'exclude': []
+  },
   'detect': function (ast, parser) {
     var result = [];
 
@@ -26,13 +28,15 @@ module.exports = {
             properties.push(property);
           }
           else {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': item.start.line,
-              'column': item.start.column,
-              'message': 'Duplicate properties are not allowed within a block',
-              'severity': parser.severity
-            });
+            if (parser.options.exclude.indexOf(property) === -1) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'Duplicate properties are not allowed within a block',
+                'severity': parser.severity
+              });
+            }
           }
         });
       });

--- a/tests/rules/no-duplicate-properties.js
+++ b/tests/rules/no-duplicate-properties.js
@@ -5,12 +5,25 @@ var lint = require('./_lint');
 var file = lint.file('no-duplicate-properties.scss');
 
 describe('no duplicate properties', function () {
- //////////////////////////////
-  // Duplicate Property
-  //////////////////////////////
   it('enforce', function (done) {
     lint.test(file, {
       'no-duplicate-properties': 1
+    }, function (data) {
+      lint.assert.equal(4, data.warningCount);
+      done();
+    });
+  });
+
+  it('enforce - [exclude: background]', function (done) {
+    lint.test(file, {
+      'no-duplicate-properties': [
+        1,
+        {
+          'exclude': [
+            'background'
+          ]
+        }
+      ]
     }, function (data) {
       lint.assert.equal(3, data.warningCount);
       done();

--- a/tests/sass/no-duplicate-properties.scss
+++ b/tests/sass/no-duplicate-properties.scss
@@ -15,3 +15,8 @@
     display: none;
   }
 }
+
+.qux {
+  background: rgb(200, 54, 54);
+  background: rgba(200, 54, 54, 0.5);
+}


### PR DESCRIPTION
Adds a feature to exclude properties from the no-duplicate-properties rule. Closes #142 

DCO 1.1 Signed-off-by: Ben Griffith <gt11687@gmail.com>