### PR TITLE
Add No Qualifying Element

### DIFF
--- a/docs/rules/no-qualifying-elements.md
+++ b/docs/rules/no-qualifying-elements.md
@@ -1,0 +1,69 @@
+# No Qualifying Elements
+
+Rule `no-qualifying-elements` will enforce that selectors are not allowed to have qualifying elements.
+
+## Options
+
+* `allow-element-with-attribute`: `true`/`false` (defaults to `false`)
+* `allow-element-with-class`: `true`/`false` (defaults to `false`)
+* `allow-element-with-id`: `true`/`false` (defaults to `false`)
+
+## Examples
+
+By default, the following are disallowed:
+
+```scss
+div.foo {
+  content: 'foo';
+}
+
+ul#foo {
+  content: 'foo';
+}
+
+input[type='email'] {
+  content: 'foo';
+}
+```
+
+### `allow-element-with-attribute`
+
+When `allow-element-with-attribute: true`, the following are allowed. When `allow-element-with-attribute: false`, the following are disallowed.
+
+```scss
+input[type='email'] {
+  content: 'foo';
+}
+
+a[href] {
+  content: 'foo';
+}
+```
+
+### `allow-element-with-class`
+
+When `allow-element-with-class: true`, the following are allowed. When `allow-element-with-class: false`, the following are disallowed.
+
+```scss
+div.foo {
+  content: 'foo';
+}
+
+h1.bar {
+  content: 'foo';
+}
+```
+
+### `allow-element-with-id`
+
+When `allow-element-with-id: true`, the following are allowed. When `allow-element-with-id: false`, the following are disallowed.
+
+```scss
+ul#foo {
+  content: 'foo';
+}
+
+p#bar {
+  content: 'foo';
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -59,3 +59,5 @@ rules:
   # Final Items
   trailing-semicolon: 1
   final-newline: 1
+
+  no-qualifying-elements: 1

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -17,20 +17,21 @@ rules:
   single-line-per-selector: 1
 
   # Disallows
+  no-color-keywords: 1
+  no-color-literals: 1
+  no-css-comments: 1
   no-debug: 1
   no-duplicate-properties: 1
   no-empty-rulesets: 1
   no-extends: 0
   no-ids: 1
   no-important: 1
-  no-warn: 1
-  no-color-keywords: 1
   no-invalid-hex: 1
-  no-css-comments: 1
-  no-color-literals: 1
+  no-qualifying-elements: 1
   no-url-protocols: 1
   no-vendor-prefixes: 1
-
+  no-warn: 1
+  
   # Style Guide
   border-zero: 1
   brace-style: 1
@@ -59,5 +60,3 @@ rules:
   # Final Items
   trailing-semicolon: 1
   final-newline: 1
-
-  no-qualifying-elements: 1

--- a/lib/rules/no-qualifying-elements.js
+++ b/lib/rules/no-qualifying-elements.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-qualifying-elements',
+  'defaults': {
+    'allow-element-with-attribute': false,
+    'allow-element-with-class': false,
+    'allow-element-with-id': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByTypes(['simpleSelector'], function (selectors) {
+
+      selectors.content.forEach(function (item, i) {
+        if (item.is('class') || item.is('attribute') || item.is('id')) {
+          var previous = selectors.content[i - 1] || false;
+
+          if (previous && previous.is('ident')) {
+            if (!parser.options['allow-element-with-' + item.type]) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'Qualifying element not allowed with ' + item.type,
+                'severity': parser.severity
+              });
+            }
+          }
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/no-qualifying-elements.js
+++ b/lib/rules/no-qualifying-elements.js
@@ -24,7 +24,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': item.start.line,
                 'column': item.start.column,
-                'message': 'Qualifying element not allowed with ' + item.type,
+                'message': 'Qualifying element not allowed for ' + item.type,
                 'severity': parser.severity
               });
             }

--- a/lib/rules/no-qualifying-elements.js
+++ b/lib/rules/no-qualifying-elements.js
@@ -24,7 +24,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': item.start.line,
                 'column': item.start.column,
-                'message': 'Qualifying element not allowed for ' + item.type,
+                'message': 'Qualifying elements are not allowed for ' + item.type + 'selectors',
                 'severity': parser.severity
               });
             }

--- a/lib/rules/no-qualifying-elements.js
+++ b/lib/rules/no-qualifying-elements.js
@@ -12,7 +12,7 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByTypes(['simpleSelector'], function (selectors) {
+    ast.traverseByType('simpleSelector', function (selectors) {
 
       selectors.content.forEach(function (item, i) {
         if (item.is('class') || item.is('attribute') || item.is('id')) {

--- a/tests/rules/no-qualifying-elements.js
+++ b/tests/rules/no-qualifying-elements.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('no-qualifying-elements.scss');
+
+describe('no qualifying elements', function () {
+  it('[attribute: false, class: false, id: false]', function (done) {
+    lint.test(file, {
+      'no-qualifying-elements': 1
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+
+  it('[attribute: true, class: false, id: false]', function (done) {
+    lint.test(file, {
+      'no-qualifying-elements': [
+        1,
+        {
+          'allow-element-with-attribute': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('[attribute: false, class: true, id: false]', function (done) {
+    lint.test(file, {
+      'no-qualifying-elements': [
+        1,
+        {
+          'allow-element-with-class': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('[attribute: false, class: false, id: true]', function (done) {
+    lint.test(file, {
+      'no-qualifying-elements': [
+        1,
+        {
+          'allow-element-with-id': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('[attribute: true, class: true, id: false]', function (done) {
+    lint.test(file, {
+      'no-qualifying-elements': [
+        1,
+        {
+          'allow-element-with-attribute': true,
+          'allow-element-with-class': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  it('[attribute: true, class: true, id: true]', function (done) {
+    lint.test(file, {
+      'no-qualifying-elements': [
+        1,
+        {
+          'allow-element-with-attribute': true,
+          'allow-element-with-class': true,
+          'allow-element-with-id': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+});

--- a/tests/sass/no-qualifying-elements.scss
+++ b/tests/sass/no-qualifying-elements.scss
@@ -1,0 +1,23 @@
+.foo {
+  content: 'foo';
+}
+
+div.foo {
+  content: 'foo';
+}
+
+ul#foo {
+  content: 'foo';
+}
+
+input[type='email'] {
+  content: 'foo';
+}
+
+.foo.bar {
+  content: 'foo';
+}
+
+.foo .bar {
+  content: 'foo';
+}

--- a/tests/sass/no-qualifying-elements.scss
+++ b/tests/sass/no-qualifying-elements.scss
@@ -21,3 +21,23 @@ input[type='email'] {
 .foo .bar {
   content: 'foo';
 }
+
+.foo {
+  .bar {
+    content: 'foo';
+  }
+}
+
+ul {
+  .foo {
+    content: 'foo';
+  }
+}
+
+.foo[type='text'] {
+  content: 'foo';
+}
+
+#foo[type='email'] {
+  content: 'foo';
+}


### PR DESCRIPTION
Rule `no-qualifying-elements` will enforce that selectors are not allowed to have qualifying elements.

There are three options to allow qualifying elements for class, attributes, and/or ids.

### Warning messages are:

> Qualifying element not allowed for attribute

> Qualifying element not allowed for class

> Qualifying element not allowed for id

Closes #30 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com