### PR TITLE
Add Trailing Zero rule

### DIFF
--- a/docs/rules/no-trailing-zero.md
+++ b/docs/rules/no-trailing-zero.md
@@ -1,0 +1,21 @@
+# No Trailing Zero
+
+Rule `no-trailing-zero` will enforce that trailing zeros are not allowed.
+
+## Examples
+
+When enabled, the following are disallowed:
+
+```scss
+.foo {
+  margin: 1.500rem;
+}
+
+.foo {
+  margin: .500rem;
+}
+
+.foo {
+  margin: 0.2500rem;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -28,6 +28,7 @@ rules:
   no-invalid-hex: 1
   no-css-comments: 1
   no-color-literals: 1
+  no-trailing-zero: 1
   no-url-protocols: 1
   no-vendor-prefixes: 1
 

--- a/lib/rules/no-trailing-zero.js
+++ b/lib/rules/no-trailing-zero.js
@@ -27,4 +27,4 @@ module.exports = {
 
     return result;
   }
-}
+};

--- a/lib/rules/no-trailing-zero.js
+++ b/lib/rules/no-trailing-zero.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var trailingZeroRegex = /^(\d+\.|\.)+(\d*?[1-9])0+$/;
+
+module.exports = {
+  'name': 'no-trailing-zero',
+  'defaults': {
+    'include': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('number', function (num) {
+
+      if (num.content.match(trailingZeroRegex)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': num.start.line,
+          'column': num.start.column,
+          'message': 'Don\'t include trailing zeros on numbers',
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+}

--- a/tests/rules/no-trailing-zero.js
+++ b/tests/rules/no-trailing-zero.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('no-trailing-zero.scss');
+
+describe('no trailing zero', function () {
+  it('enforce', function (done) {
+    lint.test(file, {
+      'trailing-zero': 1
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/no-trailing-zero.scss
+++ b/tests/sass/no-trailing-zero.scss
@@ -1,0 +1,27 @@
+.foo {
+  margin: 1.5rem;
+}
+
+.foo {
+  margin: 1.500rem;
+}
+
+.foo {
+  margin: .5rem;
+}
+
+.foo {
+  margin: .500rem;
+}
+
+.foo {
+  margin: 0.25rem;
+}
+
+.foo {
+  margin: 0.2500rem;
+}
+
+.foo {
+  margin: 0;
+}


### PR DESCRIPTION
Rule `no-trailing-zero` will enforce that trailing zeros are not allowed.

Closes #162 

### Warning messages

> Don't include trailing zeros on numbers

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com