### PR TITLE
Add shorthand values rule

### DIFF
--- a/docs/rules/shorthand-values.md
+++ b/docs/rules/shorthand-values.md
@@ -1,4 +1,4 @@
-# Border Zero
+# Shorthand Values
 
 Rule `shorthand-values` will enforce that values in their shorthand form are as concise as specified.
 

--- a/docs/rules/shorthand-values.md
+++ b/docs/rules/shorthand-values.md
@@ -1,0 +1,67 @@
+# Border Zero
+
+Rule `shorthand-values` will enforce that values in their shorthand form are as concise as specified.
+
+## Options
+
+* `allowed-shorthands`: `[array of allowed shorthand lengths]` (defaults to `[1, 2, 3]`)
+
+## Examples
+
+When `allowed-shorthands` is left at default, the following is enforced:
+
+```scss
+margin: 1px 1px 1px 1px;
+
+// Will be enforced to 1 value
+margin: 1px;
+```
+```scss
+margin: 1px 2px 1px 2px;
+
+// Will be enforced to 2 values
+margin: 1px 2px;
+```
+```scss
+margin: 1px 2px 3px 2px;
+
+// Will be enforced to 3 values
+margin: 1px 2px 3px;
+```
+
+When `allowed-shorthands` is `[1]`, the following is enforced:
+
+```scss
+margin: 1px 1px 1px 1px;
+
+// Will be enforced to 1 value
+margin: 1px;
+```
+
+Any value that can't be shortened to 1 value will be unenforced
+```scss
+// Could be shortened to 2 values but will not generate a warning
+margin: 1px 2px 1px 2px;
+```
+
+When `allowed-shorthands` is `[1, 2]`, the following is enforced:
+
+```scss
+margin: 1px 1px 1px 1px;
+
+// Will be enforced to 1 value
+margin: 1px;
+```
+
+```scss
+margin: 1px 2px 1px 2px;
+
+// Will be enforced to 2 values
+margin: 1px 2px;
+```
+
+Any value that can't be shortened to 2 values will be unenforced
+```scss
+// Could be shortened to 3 values but will not generate a warning
+margin: 1px 2px 3px 2px;
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -31,7 +31,7 @@ rules:
   no-url-protocols: 1
   no-vendor-prefixes: 1
   no-warn: 1
-  
+
   # Style Guide
   border-zero: 1
   brace-style: 1
@@ -44,6 +44,7 @@ rules:
   nesting-depth: 1
   property-sort-order: 1
   quotes: 1
+  shorthand-values: 1
   url-quotes: 1
   variable-for-property: 1
   zero-unit: 1

--- a/lib/rules/shorthand-values.js
+++ b/lib/rules/shorthand-values.js
@@ -55,7 +55,7 @@ module.exports = {
 
       declaration.traverse(function (item) {
 
-        if (item.type === 'property') {
+        if (item.is('property')) {
           item.traverse(function (child) {
             // check if the property is a possible shorthand property
             if (shortVals.indexOf(child.content) !== -1) {
@@ -70,7 +70,7 @@ module.exports = {
         if (isShorthandProperty) {
           var value = [];
 
-          if (item.type === 'value') {
+          if (item.is('value')) {
             var node = item.content,
                 fullVal = '';
 

--- a/lib/rules/shorthand-values.js
+++ b/lib/rules/shorthand-values.js
@@ -1,0 +1,136 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var shortVals = [
+  'border-color',
+  'border-radius',
+  'border-style',
+  'border-width',
+  'margin',
+  'padding'
+];
+
+var condenseToOne = function (value, allowed) {
+  if (allowed.indexOf(1) !== -1 && value.length > 1) {
+    for (var i = 1; i < value.length; i++) {
+      if (value[i] !== value[0]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+var condenseToTwo = function (value, allowed) {
+  if (allowed.indexOf(2) !== -1 && value.length > 2) {
+    if ((value[0] === value[2] && value[1] === value[3]) || (value[0] === value[2] && !value[3] && value[0] !== value[1])) {
+      return true;
+    }
+  }
+  return false;
+};
+
+var condenseToThree = function (value, allowed) {
+  if (allowed.indexOf(3) !== -1 && value.length > 3) {
+    if (value[1] === value[3] ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+module.exports = {
+  'name': 'shorthand-values',
+  'defaults': {
+    'allowed-shorthands': [1, 2, 3]
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('declaration', function (declaration) {
+      var isShorthandProperty = false;
+      var property;
+
+      declaration.traverse(function (item) {
+
+        if (item.type === 'property') {
+          item.traverse(function (child) {
+            // check if the property is a possible shorthand property
+            if (shortVals.indexOf(child.content) !== -1) {
+              isShorthandProperty = true;
+
+              // store a reference to the property for our error
+              property = shortVals[shortVals.indexOf(child.content)];
+            }
+          });
+        }
+
+        if (isShorthandProperty) {
+          var value = [];
+
+          if (item.type === 'value') {
+            var node = item.content,
+                fullVal = '';
+
+            // Build each value into an array of strings with value and type
+            node.forEach(function (val) {
+              // add to our value string depending on node type
+              if (val.is('dimension')) {
+                val.forEach(function (el) {
+                  fullVal += el.content;
+                });
+              }
+              else if (val.is('operator') || val.is('ident')) {
+                fullVal += val.content;
+              }
+              else if (val.is('variable')) {
+                val.forEach(function (el) {
+                  fullVal += '$' + el.content;
+                });
+              }
+              else {
+                // This is a non value character such as a space
+                // We want to start another value here
+                value.push(fullVal);
+
+                // reset the value string for the next iteration
+                fullVal = '';
+              }
+            });
+
+            // The last dimension in a value will not be followed by a character so we push here
+            value.push(fullVal);
+
+            if (value.length <= 4 && value.length >= 1) {
+              var output = [];
+
+              // check which values can condense
+              if (condenseToOne(value, parser.options['allowed-shorthands'])) {
+                output = [value[0]];
+              }
+              else if (condenseToTwo(value, parser.options['allowed-shorthands'])) {
+                output = [value[0], value[1]];
+              }
+              else if (condenseToThree(value, parser.options['allowed-shorthands'])) {
+                output = [value[0], value[1], value[2]];
+              }
+
+              if (output.length) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': item.start.line,
+                  'column': item.start.column,
+                  'message': 'Property `' + property + '` should be written more concisely as `' + output.join(' ') + '` instead of `' + value.join(' ') + '`',
+                  'severity': parser.severity
+                });
+              }
+            }
+          }
+        }
+      });
+    });
+    return result;
+  }
+};

--- a/tests/rules/shorthand-values.js
+++ b/tests/rules/shorthand-values.js
@@ -4,7 +4,7 @@ var lint = require('./_lint');
 
 var file = lint.file('shorthand-values.scss');
 
-describe('shorthand values', function () {
+describe('shorthand values - scss', function () {
   it('[default]', function (done) {
     lint.test(file, {
       'shorthand-values': 1
@@ -130,6 +130,151 @@ describe('shorthand values', function () {
 
   it('[allowed: 1, 2, 3] - as default', function (done) {
     lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1,
+            2,
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(44, data.warningCount);
+      done();
+    });
+  });
+});
+
+// Sass
+
+describe('shorthand values - sass', function () {
+  it('[default]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': 1
+    }, function (data) {
+      lint.assert.equal(44, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(19, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 2]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            2
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 3]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(26, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: none]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1, 2]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1,
+            2
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(32, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1, 3]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1,
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(38, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 2, 3]', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            2,
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(32, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1, 2, 3] - as default', function (done) {
+    lint.test(lint.file('shorthand-values.sass'), {
       'shorthand-values': [
         1,
         {

--- a/tests/rules/shorthand-values.js
+++ b/tests/rules/shorthand-values.js
@@ -1,0 +1,148 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('shorthand-values.scss');
+
+describe('shorthand values', function () {
+  it('[default]', function (done) {
+    lint.test(file, {
+      'shorthand-values': 1
+    }, function (data) {
+      lint.assert.equal(44, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(19, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 2]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            2
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 3]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(26, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: none]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1, 2]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1,
+            2
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(32, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1, 3]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1,
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(38, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 2, 3]', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            2,
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(32, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allowed: 1, 2, 3] - as default', function (done) {
+    lint.test(file, {
+      'shorthand-values': [
+        1,
+        {
+          'allowed-shorthands': [
+            1,
+            2,
+            3
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(44, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/rules/shorthand-values.js
+++ b/tests/rules/shorthand-values.js
@@ -2,9 +2,9 @@
 
 var lint = require('./_lint');
 
-var file = lint.file('shorthand-values.scss');
-
 describe('shorthand values - scss', function () {
+  var file = lint.file('shorthand-values.scss');
+
   it('[default]', function (done) {
     lint.test(file, {
       'shorthand-values': 1
@@ -147,11 +147,15 @@ describe('shorthand values - scss', function () {
   });
 });
 
+/////////////////////////////
 // Sass
+/////////////////////////////
 
 describe('shorthand values - sass', function () {
+  var file = lint.file('shorthand-values.sass');
+
   it('[default]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': 1
     }, function (data) {
       lint.assert.equal(44, data.warningCount);
@@ -160,7 +164,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 1]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -176,7 +180,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 2]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -192,7 +196,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 3]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -208,7 +212,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: none]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -223,7 +227,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 1, 2]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -240,7 +244,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 1, 3]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -257,7 +261,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 2, 3]', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {
@@ -274,7 +278,7 @@ describe('shorthand values - sass', function () {
   });
 
   it('[allowed: 1, 2, 3] - as default', function (done) {
-    lint.test(lint.file('shorthand-values.sass'), {
+    lint.test(file, {
       'shorthand-values': [
         1,
         {

--- a/tests/sass/shorthand-values.sass
+++ b/tests/sass/shorthand-values.sass
@@ -54,6 +54,14 @@
   margin: 1rem 1rem 2rem
   padding: 1px 1px 2px
 
+.value-three-diff-four
+  border-color: red blue orange
+  border-radius: 1px/1rem 2px/2rem 3px/3rem
+  border-style: dashed dotted double
+  border-width: inherit 10px 20px
+  margin: 1rem 2rem 3rem
+  padding: 1px 2px 3px
+
 .value-four-ident
   border-color: red red red red
   border-radius: 1px/1rem 1px/1rem 1px/1rem 1px/1rem
@@ -101,6 +109,14 @@
   border-width: inherit 10px inherit 10px
   margin: 1rem 2rem 1rem 2rem
   padding: 1px 2px 1px 2px
+
+.value-four-diff-six
+  border-color: red blue orange green
+  border-radius: 1px/1rem 2px/2rem 3px/3rem 4px/4rem
+  border-style: dashed dotted double none
+  border-width: inherit 10px 20px 30px
+  margin: 1rem 2rem 3rem 4rem
+  padding: 1px 2px 3px 4px
 
 .value-four-ident
   border-color: $red $red $red $red

--- a/tests/sass/shorthand-values.sass
+++ b/tests/sass/shorthand-values.sass
@@ -1,0 +1,111 @@
+.value-one
+  border-color: red
+  border-radius: 1px/1rem
+  border-style: dashed
+  border-width: inherit
+  margin: 1rem
+  padding: 1px
+
+.value-two-ident
+  border-color: red red
+  border-radius: 1px/1rem 1px/1rem
+  border-style: dashed dashed
+  border-width: inherit inherit
+  margin: 1rem 1rem
+  padding: 1px 1px
+
+.value-two-diff
+  border-color: red blue
+  border-radius: 1px/1rem 2px/2rem
+  border-style: dashed dotted
+  border-width: inherit 2em
+  margin: 1rem 2rem
+  padding: 1px 2px
+
+.value-three-ident
+  border-color: red red red
+  border-radius: 1px/1rem 1px/1rem 1px/1rem
+  border-style: dashed dashed dashed
+  border-width: inherit inherit inherit
+  margin: 1rem 1rem 1rem
+  padding: 1px 1px 1px
+
+.value-three-diff-one
+  border-color: blue red red
+  border-radius: 2px/2rem 1px/1rem 1px/1rem
+  border-style: dotted dashed dashed
+  border-width: 10px inherit inherit
+  margin: 2rem 1rem 1rem
+  padding: 2px 1px 1px
+
+.value-three-diff-two
+  border-color: red blue red
+  border-radius: 1px/1rem 2px/2rem 1px/1rem
+  border-style: dashed dotted dashed
+  border-width: inherit 10px inherit
+  margin: 1rem 2rem 1rem
+  padding: 1px 2px 1px
+
+.value-three-diff-three
+  border-color: red red blue
+  border-radius: 1px/1rem 1px/1rem 2px/2rem
+  border-style: dashed dashed dotted
+  border-width: inherit inherit 10px
+  margin: 1rem 1rem 2rem
+  padding: 1px 1px 2px
+
+.value-four-ident
+  border-color: red red red red
+  border-radius: 1px/1rem 1px/1rem 1px/1rem 1px/1rem
+  border-style: dashed dashed dashed dashed
+  border-width: inherit inherit inherit inherit
+  margin: 1rem 1rem 1rem 1rem
+  padding: 1px 1px 1px 1px
+
+.value-four-diff-one
+  border-color: blue red red red
+  border-radius: 2px/2rem 1px/1rem 1px/1rem 1px/1rem
+  border-style: dotted dashed dashed dashed
+  border-width: 10px inherit inherit inherit
+  margin: 2rem 1rem 1rem 1rem
+  padding: 2px 1px 1px 1px
+
+.value-four-diff-two
+  border-color: red blue red red
+  border-radius: 1px/1rem 2px/2rem 1px/1rem 1px/1rem
+  border-style: dashed dotted dashed dashed
+  border-width: inherit 10px inherit inherit
+  margin: 1rem 2rem 1rem 1rem
+  padding: 1px 2px 1px 1px
+
+.value-four-diff-three
+  border-color: red red blue red
+  border-radius: 1px/1rem 1px/1rem 2px/2rem 1px/1rem
+  border-style: dashed dashed dotted dashed
+  border-width: inherit inherit 10px inherit
+  margin: 1rem 1rem 2rem 1rem
+  padding: 1px 1px 2px 1px
+
+.value-four-diff-four
+  border-color: red red red blue
+  border-radius: 1px/1rem 1px/1rem 1px/1rem 2px/2rem
+  border-style: dashed dashed dashed dotted
+  border-width: inherit inherit inherit 10px
+  margin: 1rem 1rem 1rem 2rem
+  padding: 1px 1px 1px 2px
+
+.value-four-diff-five
+  border-color: red blue red blue
+  border-radius: 1px/1rem 2px/2rem 1px/1rem 2px/2rem
+  border-style: dashed dotted dashed dotted
+  border-width: inherit 10px inherit 10px
+  margin: 1rem 2rem 1rem 2rem
+  padding: 1px 2px 1px 2px
+
+.value-four-ident
+  border-color: $red $red $red $red
+  border-radius: $one $two $one $two
+  border-style: $one $two $three $one
+  border-width: $one $two $three $four
+  margin: $one $two $one $three
+  padding: $one $one $one $two

--- a/tests/sass/shorthand-values.scss
+++ b/tests/sass/shorthand-values.scss
@@ -1,0 +1,125 @@
+.value-one {
+  border-color: red;
+  border-radius: 1px/1rem;
+  border-style: dashed;
+  border-width: inherit;
+  margin: 1rem;
+  padding: 1px;
+}
+
+.value-two-ident {
+  border-color: red red;
+  border-radius: 1px/1rem 1px/1rem;
+  border-style: dashed dashed;
+  border-width: inherit inherit;
+  margin: 1rem 1rem;
+  padding: 1px 1px;
+}
+
+.value-two-diff {
+  border-color: red blue;
+  border-radius: 1px/1rem 2px/2rem;
+  border-style: dashed dotted;
+  border-width: inherit 2em;
+  margin: 1rem 2rem;
+  padding: 1px 2px;
+}
+
+.value-three-ident {
+  border-color: red red red;
+  border-radius: 1px/1rem 1px/1rem 1px/1rem;
+  border-style: dashed dashed dashed;
+  border-width: inherit inherit inherit;
+  margin: 1rem 1rem 1rem;
+  padding: 1px 1px 1px;
+}
+
+.value-three-diff-one {
+  border-color: blue red red;
+  border-radius: 2px/2rem 1px/1rem 1px/1rem;
+  border-style: dotted dashed dashed;
+  border-width: 10px inherit inherit;
+  margin: 2rem 1rem 1rem;
+  padding: 2px 1px 1px;
+}
+
+.value-three-diff-two {
+  border-color: red blue red;
+  border-radius: 1px/1rem 2px/2rem 1px/1rem;
+  border-style: dashed dotted dashed;
+  border-width: inherit 10px inherit;
+  margin: 1rem 2rem 1rem;
+  padding: 1px 2px 1px;
+}
+
+.value-three-diff-three {
+  border-color: red red blue;
+  border-radius: 1px/1rem 1px/1rem 2px/2rem;
+  border-style: dashed dashed dotted;
+  border-width: inherit inherit 10px;
+  margin: 1rem 1rem 2rem;
+  padding: 1px 1px 2px;
+}
+
+.value-four-ident {
+  border-color: red red red red;
+  border-radius: 1px/1rem 1px/1rem 1px/1rem 1px/1rem;
+  border-style: dashed dashed dashed dashed;
+  border-width: inherit inherit inherit inherit;
+  margin: 1rem 1rem 1rem 1rem;
+  padding: 1px 1px 1px 1px;
+}
+
+.value-four-diff-one {
+  border-color: blue red red red;
+  border-radius: 2px/2rem 1px/1rem 1px/1rem 1px/1rem;
+  border-style: dotted dashed dashed dashed;
+  border-width: 10px inherit inherit inherit;
+  margin: 2rem 1rem 1rem 1rem;
+  padding: 2px 1px 1px 1px;
+}
+
+.value-four-diff-two {
+  border-color: red blue red red;
+  border-radius: 1px/1rem 2px/2rem 1px/1rem 1px/1rem;
+  border-style: dashed dotted dashed dashed;
+  border-width: inherit 10px inherit inherit;
+  margin: 1rem 2rem 1rem 1rem;
+  padding: 1px 2px 1px 1px;
+}
+
+.value-four-diff-three {
+  border-color: red red blue red;
+  border-radius: 1px/1rem 1px/1rem 2px/2rem 1px/1rem;
+  border-style: dashed dashed dotted dashed;
+  border-width: inherit inherit 10px inherit;
+  margin: 1rem 1rem 2rem 1rem;
+  padding: 1px 1px 2px 1px;
+}
+
+.value-four-diff-four {
+  border-color: red red red blue;
+  border-radius: 1px/1rem 1px/1rem 1px/1rem 2px/2rem;
+  border-style: dashed dashed dashed dotted;
+  border-width: inherit inherit inherit 10px;
+  margin: 1rem 1rem 1rem 2rem;
+  padding: 1px 1px 1px 2px;
+}
+
+.value-four-diff-five {
+  border-color: red blue red blue;
+  border-radius: 1px/1rem 2px/2rem 1px/1rem 2px/2rem;
+  border-style: dashed dotted dashed dotted;
+  border-width: inherit 10px inherit 10px;
+  margin: 1rem 2rem 1rem 2rem;
+  padding: 1px 2px 1px 2px;
+}
+
+.value-four-ident {
+  border-color: $red $red $red $red;
+  border-radius: $one $two $one $two;
+  border-style: $one $two $three $one;
+  border-width: $one $two $three $four;
+  margin: $one $two $one $three;
+  padding: $one $one $one $two;
+}

--- a/tests/sass/shorthand-values.scss
+++ b/tests/sass/shorthand-values.scss
@@ -61,6 +61,15 @@
   padding: 1px 1px 2px;
 }
 
+.value-three-diff-four {
+  border-color: red blue orange;
+  border-radius: 1px/1rem 2px/2rem 3px/3rem;
+  border-style: dashed dotted double;
+  border-width: inherit 10px 20px;
+  margin: 1rem 2rem 3rem;
+  padding: 1px 2px 3px;
+}
+
 .value-four-ident {
   border-color: red red red red;
   border-radius: 1px/1rem 1px/1rem 1px/1rem 1px/1rem;
@@ -113,6 +122,15 @@
   border-width: inherit 10px inherit 10px;
   margin: 1rem 2rem 1rem 2rem;
   padding: 1px 2px 1px 2px;
+}
+
+.value-four-diff-six {
+  border-color: red blue orange green;
+  border-radius: 1px/1rem 2px/2rem 3px/3rem 4px/4rem;
+  border-style: dashed dotted double none;
+  border-width: inherit 10px 20px 30px;
+  margin: 1rem 2rem 3rem 4rem;
+  padding: 1px 2px 3px 4px;
 }
 
 .value-four-ident {


### PR DESCRIPTION
Rule `shorthand-values` will enforce that values in their shorthand form are as concise as specified.

Related to #15 

Warning message
> Property `margin` should be written more concisely as `1px` instead of `1px 1px 1px 1px`

Don't include trailing zeros on numbers
DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com