### PR TITLE
Hotfix master - Fix issue with Single Line Per Selector and Sass syntax 

### DIFF
--- a/lib/rules/single-line-per-selector.js
+++ b/lib/rules/single-line-per-selector.js
@@ -13,18 +13,20 @@ module.exports = {
       selector.forEach('delimiter', function (delimiter, i) {
         var next = selector.content[i + 1];
 
-        if (next.is('simpleSelector')) {
-          next = next.content[0];
-        }
+        if (next) {
+          if (next.is('simpleSelector')) {
+            next = next.content[0];
+          }
 
-        if (!(next.is('space') && next.content.indexOf(os.EOL) !== -1)) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': next.start.line,
-            'column': next.start.column,
-            'message': 'Selectors must be placed on new lines',
-            'severity': parser.severity
-          });
+          if (!(next.is('space') && next.content.indexOf(os.EOL) !== -1)) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': next.start.line,
+              'column': next.start.column,
+              'message': 'Selectors must be placed on new lines',
+              'severity': parser.severity
+            });
+          }
         }
       });
     });

--- a/lib/rules/single-line-per-selector.js
+++ b/lib/rules/single-line-per-selector.js
@@ -10,19 +10,21 @@ module.exports = {
     var result = [];
 
     ast.traverseByType('selector', function (selector) {
-      selector.forEach('delimiter', function (del, i) {
-        var next = selector.content[i + 1].content[0];
+      selector.forEach('delimiter', function (delimiter, i) {
+        var next = selector.content[i + 1];
 
-        if (next) {
-          if (next.type !== 'space' || next.content.indexOf(os.EOL) === -1) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': next.start.line,
-              'column': next.start.column,
-              'message': 'Selectors must be placed on new lines',
-              'severity': parser.severity
-            });
-          }
+        if (next.is('simpleSelector')) {
+          next = next.content[0];
+        }
+
+        if (!(next.is('space') && next.content.indexOf(os.EOL) !== -1)) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': next.start.line,
+            'column': next.start.column,
+            'message': 'Selectors must be placed on new lines',
+            'severity': parser.severity
+          });
         }
       });
     });


### PR DESCRIPTION
This PR fixes #165 where Single Line Per Selector rule would fail due to the parser interpreting the stylesheet differently to scss. 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com