### PR TITLE
Hotfix master - Silence output on no errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,17 @@ sassLint.getConfig = function (config, configPath) {
   return slConfig(config, configPath);
 };
 
+sassLint.resultCount = function (results) {
+  var flagCount = 0,
+      jsonResults = JSON.parse(results);
+
+  for (var i = 0; i < jsonResults.length; i++) {
+    flagCount += (jsonResults[i].warningCount + jsonResults[i].errorCount);
+  }
+
+  return flagCount;
+};
+
 sassLint.lintText = function (file, options, configPath) {
   var rules = slRules(this.getConfig(options, configPath)),
       ast = groot(file.text, file.format, file.filename),
@@ -96,11 +107,20 @@ sassLint.format = function (results, options, configPath) {
 sassLint.outputResults = function (results, options, configPath) {
   var config = this.getConfig(options, configPath);
 
-  if (config.options['output-file']) {
-    fs.outputFileSync(path.resolve(process.cwd(), config.options['output-file']), results);
-  }
-  else {
-    console.log(results);
+  if (this.resultCount(results)) {
+    if (config.options['output-file']) {
+      try {
+        fs.outputFileSync(path.resolve(process.cwd(), config.options['output-file']), results);
+        console.log('Output successfully written to ' + path.resolve(process.cwd(), config.options['output-file']));
+      }
+      catch (e) {
+        console.log('Error: Output was unable to be written to ' + path.resolve(process.cwd(), config.options['output-file']));
+      }
+
+    }
+    else {
+      console.log(results);
+    }
   }
   return results;
 };
@@ -119,4 +139,3 @@ sassLint.failOnError = function (results) {
 };
 
 module.exports = sassLint;
-

--- a/index.js
+++ b/index.js
@@ -116,7 +116,6 @@ sassLint.outputResults = function (results, options, configPath) {
       catch (e) {
         console.log('Error: Output was unable to be written to ' + path.resolve(process.cwd(), config.options['output-file']));
       }
-
     }
     else {
       console.log(results);

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -68,7 +68,6 @@ describe('cli', function () {
       if (err) {
         return done(err);
       }
-      console.log(stdout.length);
       result = stdout.length;
 
       if (result !== 0) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -37,7 +37,7 @@ describe('cli', function () {
   // Test custom config path
 
   it('should return JSON from a custom config', function (done) {
-    var command = 'sass-lint -c tests/yml/.json-lint.yml tests/sass/cli.scss --verbose';
+    var command = 'sass-lint -c tests/yml/.color-keyword-errors.yml tests/sass/cli.scss --verbose';
 
     childProcess.exec(command, function (err, stdout) {
 
@@ -58,33 +58,24 @@ describe('cli', function () {
 
   // Test 0 errors/warnings when rules set to 0 in config
 
-  it('should return no errors/warnings', function (done) {
+  it('output should return no errors/warnings', function (done) {
     var command = 'sass-lint -c tests/yml/.json-lint.yml tests/sass/cli.scss --verbose';
 
     childProcess.exec(command, function (err, stdout) {
 
-      var result = '';
+      var result = 0;
 
       if (err) {
         return done(err);
       }
+      console.log(stdout.length);
+      result = stdout.length;
 
-      else {
-        try {
-          result = JSON.parse(stdout);
-        }
-        catch (e) {
-          return done(new Error('Not JSON'));
-        }
-
-        if (result[0].warningCount === 0 && result[0].errorCount === 0) {
-          return done();
-        }
-        else {
-          return done(new Error('warnings/errors were returned'));
-        }
-
+      if (result !== 0) {
+        return done(new Error('warnings/errors were returned'));
       }
+
+      return done();
     });
   });
 


### PR DESCRIPTION
Silences error output when no warnings or errors are present in linted files. Also improves the handling of writing output to the file system with completion/error messages but no error thrown.

@Snugug - Im hoping this is what you were aiming for, I'll gladly update or revert this if it's not quite what was envisaged.

closes #141 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com