### PR TITLE
Hotfix master - Fix No Extends to work on Sass Syntax files

### DIFF
--- a/lib/rules/no-extends.js
+++ b/lib/rules/no-extends.js
@@ -8,13 +8,17 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('extend', function (item) {
-      result = helpers.addUnique(result, {
-        'ruleId': parser.rule.name,
-        'line': item.start.line,
-        'column': item.start.column,
-        'message': '@extend not allowed',
-        'severity': parser.severity
+    ast.traverseByType('atkeyword', function (keyword) {
+      keyword.traverse(function (item) {
+        if (item.content === 'extend') {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': item.start.line,
+            'column': item.start.column,
+            'message': '@extend not allowed',
+            'severity': parser.severity
+          });
+        }
       });
     });
 


### PR DESCRIPTION
This PR fixes an issue where Extends were not being caught when looking for nodes of type extend. Turns out when using Sass syntax, the parser doesn't assign an extend type so I've implemented another way. This method is in line with the way we detect warns and debugs.

Closes #173 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com