### PR TITLE
Change travis config to fix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - '0.10'
   - node
   - iojs
-before_install: npm install -g sass-lint
+before_script: npm link
 notifications:
   slack:
     secure: RrEbq2xE1hWdog4AckkaKDnIYYwo5VdjPcFNhRJbn/7KI0fKeZVCKZy1Ww7aaJGth7R7UX415sEV1U6RrjFyhnBb6Sh+rh8fKTvcvuTbENZW45SbtUD+xmgOvb2kfk4PzgD5Q457DpchAZD7W+E+9qr3xI3Uvh4II1uhDmSKiLI=


### PR DESCRIPTION
This should fix the build errors we were experiencing in Travis CI. Using `npm link` instead of installing from NPM. 

Referencing: #172 

DCO 1.1 Signed-off-by: Michael Vendivel vendivel@gmail.com