### PR TITLE
Hotfix master - with extend rules sass syntax

### DIFF
--- a/lib/rules/extends-before-declarations.js
+++ b/lib/rules/extends-before-declarations.js
@@ -11,21 +11,25 @@ module.exports = {
 
     ast.traverseByType('block', function (block) {
       var lastDeclaration = null;
-      block.traverse(function (item, j) {
-        if (item.type === 'extend') {
-          if (j > lastDeclaration && lastDeclaration !== null) {
-            item.forEach('simpleSelector', function () {
-              error = {
-                'ruleId': parser.rule.name,
-                'line': item.start.line,
-                'column': item.start.column,
-                'message': 'Extends should come before declarations',
-                'severity': parser.severity
-              };
-              result = helpers.addUnique(result, error);
-            });
+      block.forEach(function (item, j) {
+
+        if (item.type === 'include' || item.type === 'extend') {
+          if (item.first('atkeyword').first('ident').content === 'extend') {
+            if (j > lastDeclaration && lastDeclaration !== null) {
+              item.forEach('simpleSelector', function () {
+                error = {
+                  'ruleId': parser.rule.name,
+                  'line': item.start.line,
+                  'column': item.start.column,
+                  'message': 'Extends should come before declarations',
+                  'severity': parser.severity
+                };
+                result = helpers.addUnique(result, error);
+              });
+            }
           }
         }
+
         if (item.type === 'declaration') {
           lastDeclaration = j;
         }

--- a/lib/rules/extends-before-declarations.js
+++ b/lib/rules/extends-before-declarations.js
@@ -11,8 +11,8 @@ module.exports = {
 
     ast.traverseByType('block', function (block) {
       var lastDeclaration = null;
-      block.forEach(function (item, j) {
 
+      block.forEach(function (item, j) {
         if (item.type === 'include' || item.type === 'extend') {
           if (item.first('atkeyword').first('ident').content === 'extend') {
             if (j > lastDeclaration && lastDeclaration !== null) {


### PR DESCRIPTION
This PR fixes an issue where the `extends-before-declarations` rule doesn't work with the Sass syntax due to the way the parser interprets the syntax differently.

Related to issue #173 

Closes #188 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com