### PR TITLE
Hotfix master - Fix Sass extends-before-mixins bug

### DIFF
--- a/lib/rules/extends-before-mixins.js
+++ b/lib/rules/extends-before-mixins.js
@@ -10,22 +10,35 @@ module.exports = {
 
     ast.traverseByType('block', function (block) {
       var lastMixin = null;
-      block.traverse(function (item, j) {
-        if (item.type === 'extend') {
-          if (j > lastMixin && lastMixin !== null) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': item.start.line,
-              'column': item.start.column,
-              'message': 'Extends should come before mixins',
-              'severity': parser.severity
-            });
+
+      block.forEach(function (item, j) {
+        if (item.type === 'include' || item.type === 'extend') {
+          if (item.first('atkeyword')) {
+            var atkeyword = item.first('atkeyword');
+
+            if (atkeyword.first('ident')) {
+              var ident = atkeyword.first('ident');
+
+              if (ident.content === 'extend') {
+                if (j > lastMixin && lastMixin !== null) {
+                  result = helpers.addUnique(result, {
+                    'ruleId': parser.rule.name,
+                    'line': item.start.line,
+                    'column': item.start.column,
+                    'message': 'Extends should come before mixins',
+                    'severity': parser.severity
+                  });
+                }
+              }
+            }
           }
         }
+
         if (item.type === 'include') {
           lastMixin = j;
         }
       });
+
       lastMixin = null;
     });
 


### PR DESCRIPTION
extends-before-mixins rule doesn't work with Sass syntax. This fixes that issue.

Fixes #193

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com