### PR TITLE
Hotfix master - Fix Sass syntax issue with placeholder-in-extend rule

### DIFF
--- a/lib/rules/placeholder-in-extend.js
+++ b/lib/rules/placeholder-in-extend.js
@@ -8,22 +8,28 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('extend', function (extend) {
-      extend.forEach('simpleSelector', function (selector) {
-        var placeholder = false;
-        selector.content.forEach(function (selectorPiece) {
-          if (selectorPiece.type === 'placeholder') {
-            placeholder = true;
-          }
-        });
+    ast.traverseByType('atkeyword', function (keyword, i, parent) {
+      keyword.forEach(function (item) {
+        if (item.content === 'extend') {
 
-        if (!placeholder) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': selector.start.line,
-            'column': selector.start.column,
-            'message': '@extend must be used with a %placeholder',
-            'severity': parser.severity
+          parent.forEach('simpleSelector', function (selector) {
+            var placeholder = false;
+
+            selector.content.forEach(function (selectorPiece) {
+              if (selectorPiece.type === 'placeholder') {
+                placeholder = true;
+              }
+            });
+
+            if (!placeholder) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': selector.start.line,
+                'column': selector.start.column,
+                'message': '@extend must be used with a %placeholder',
+                'severity': parser.severity
+              });
+            }
           });
         }
       });


### PR DESCRIPTION
placeholder-in-extend rule doesn't work with Sass syntax. This fixes that issue.

Fixes #199

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com