### PR TITLE
Hotfix master - Fix Sass syntax issue with clean-import-paths rule

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -149,4 +149,8 @@ helpers.loadConfigFile = function (configPath) {
   return file;
 };
 
+helpers.stripQuotes = function (str) {
+  return str.substring(1, str.length - 1);
+};
+
 module.exports = helpers;

--- a/lib/rules/clean-import-paths.js
+++ b/lib/rules/clean-import-paths.js
@@ -3,16 +3,50 @@
 var helpers = require('../helpers'),
     path = require('path');
 
-var stripQuotes = function (str) {
-  return str.substring(1, str.length - 1);
-};
-
-var getImportPath = function (parent) {
-  if (parent.first('string')) {
-    return parent.first('string');
-  }
-  else if (parent.first('uri')) {
+var getImportPath = function (parent, syntax) {
+  if (parent.first('uri')) {
     return parent.first('uri');
+  }
+
+  if (parent.first('string')) {
+    return helpers.stripQuotes(parent.first('string').content);
+  }
+
+  if (parent.first('ident')) {
+
+    if (syntax === 'sass') {
+      var output = '',
+          isFinished = false;
+
+      parent.forEach(function (item) {
+        // Force an end if we've appended a 'class'.. aka file extension
+        if (!isFinished) {
+          // Since we don't have quotes, gonzales-pe will parse file path as
+          // multiple different types
+          if (
+            item.type === 'string'
+            || item.type === 'operator'
+            || item.type === 'ident'
+          ) {
+            output += item.content;
+          }
+
+          // Gonzales-pe parses file extensions as classes if they are not
+          // wrapped in quotes...
+          if (item.type === 'class') {
+            if (item.first('ident')) {
+              output += '.' + item.first('ident').content;
+            }
+
+            isFinished = true;
+          }
+        }
+      });
+
+      return output.trim();
+    }
+
+    return parent.first('ident');
   }
 
   return false;
@@ -28,59 +62,60 @@ module.exports = {
     var result = [];
 
     ast.traverseByType('atkeyword', function (keyword, i, parent) {
-      keyword.traverse(function (item) {
+      keyword.forEach(function (item) {
         if (item.content === 'import') {
-          var importPathNode = getImportPath(parent);
+          var importPath = getImportPath(parent, keyword.syntax);
 
-          if (importPathNode && importPathNode.type === 'string') {
-            var importPath = stripQuotes(importPathNode.content),
-                filename = path.basename(importPath),
-                fileExtension = path.extname(filename);
+          if (importPath) {
+            if (typeof importPath === 'string') {
+              var filename = path.basename(importPath),
+                  fileExtension = path.extname(filename);
 
-            if (fileExtension !== '.css') {
-              if (filename.charAt(0) === '_') {
-                if (!parser.options['leading-underscore']) {
-                  result = helpers.addUnique(result, {
-                    'ruleId': parser.rule.name,
-                    'line': item.start.line,
-                    'column': item.start.column,
-                    'message': 'Leading underscores are not allowed',
-                    'severity': parser.severity
-                  });
+              if (fileExtension !== '.css') {
+                if (filename.charAt(0) === '_') {
+                  if (!parser.options['leading-underscore']) {
+                    result = helpers.addUnique(result, {
+                      'ruleId': parser.rule.name,
+                      'line': item.start.line,
+                      'column': item.start.column,
+                      'message': 'Leading underscores are not allowed',
+                      'severity': parser.severity
+                    });
+                  }
                 }
-              }
-              else {
-                if (parser.options['leading-underscore']) {
-                  result = helpers.addUnique(result, {
-                    'ruleId': parser.rule.name,
-                    'line': item.start.line,
-                    'column': item.start.column,
-                    'message': 'Leading underscores are required',
-                    'severity': parser.severity
-                  });
+                else {
+                  if (parser.options['leading-underscore']) {
+                    result = helpers.addUnique(result, {
+                      'ruleId': parser.rule.name,
+                      'line': item.start.line,
+                      'column': item.start.column,
+                      'message': 'Leading underscores are required',
+                      'severity': parser.severity
+                    });
+                  }
                 }
-              }
 
-              if (fileExtension) {
-                if (!parser.options['filename-extension']) {
-                  result = helpers.addUnique(result, {
-                    'ruleId': parser.rule.name,
-                    'line': item.start.line,
-                    'column': item.start.column,
-                    'message': 'File extensions are not allowed',
-                    'severity': parser.severity
-                  });
+                if (fileExtension) {
+                  if (!parser.options['filename-extension']) {
+                    result = helpers.addUnique(result, {
+                      'ruleId': parser.rule.name,
+                      'line': item.start.line,
+                      'column': item.start.column,
+                      'message': 'File extensions are not allowed',
+                      'severity': parser.severity
+                    });
+                  }
                 }
-              }
-              else {
-                if (parser.options['filename-extension']) {
-                  result = helpers.addUnique(result, {
-                    'ruleId': parser.rule.name,
-                    'line': item.start.line,
-                    'column': item.start.column,
-                    'message': 'File extensions are required',
-                    'severity': parser.severity
-                  });
+                else {
+                  if (parser.options['filename-extension']) {
+                    result = helpers.addUnique(result, {
+                      'ruleId': parser.rule.name,
+                      'line': item.start.line,
+                      'column': item.start.column,
+                      'message': 'File extensions are required',
+                      'severity': parser.severity
+                    });
+                  }
                 }
               }
             }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -533,4 +533,24 @@ describe('helpers', function () {
     assert.equal(expect, result);
     done();
   });
+
+  //////////////////////////////
+  // Strip quotes
+  //////////////////////////////
+
+  it('stripQuotes - [double quotes]', function (done) {
+    var result = helpers.stripQuotes('"This is a string"'),
+        expect = 'This is a string';
+
+    assert.equal(expect, result);
+    done();
+  });
+
+  it('stripQuotes - [single quotes]', function (done) {
+    var result = helpers.stripQuotes('\'This is a string\''),
+        expect = 'This is a string';
+
+    assert.equal(expect, result);
+    done();
+  });
 });


### PR DESCRIPTION
clean-import-paths doesn't work with Sass syntax. This fixes that issue.

Fixes #179 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com