### PR TITLE
Hotfix master - Fix Sass Syntax issue with final-newline rules

### DIFF
--- a/lib/rules/final-newline.js
+++ b/lib/rules/final-newline.js
@@ -54,4 +54,3 @@ module.exports = {
     return result;
   }
 };
-

--- a/lib/rules/final-newline.js
+++ b/lib/rules/final-newline.js
@@ -16,6 +16,18 @@ module.exports = {
           'severity': parser.severity
         };
 
+    if (ast.syntax === 'sass') {
+      if (typeof last.last('block') === 'object') {
+        var lastBlock = last.last('block');
+
+        if (lastBlock.content.length > 0) {
+          if (lastBlock.content[lastBlock.length - 1]) {
+            last = lastBlock.content[lastBlock.length - 1];
+          }
+        }
+      }
+    }
+
     if (last.type !== 'space') {
       if (parser.options.include) {
         error.line = last.end.line;
@@ -42,3 +54,4 @@ module.exports = {
     return result;
   }
 };
+


### PR DESCRIPTION
`final-newline` doesn't work with Sass syntax. This fixes that issue.

Fixes #207

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com