### PR TITLE
Hotfix Master: cli output fix

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -10,17 +10,13 @@ var configPath,
     configOptions = {};
 
 var detectPattern = function (pattern) {
-  var detects,
-      formatted;
+  var detects;
 
   detects = lint.lintFiles(pattern, configOptions, configPath);
-  formatted = lint.format(detects, configOptions, configPath);
-
 
   if (program.verbose) {
-    lint.outputResults(formatted, configOptions, configPath);
+    lint.outputResults(detects, configOptions, configPath);
   }
-
 
   if (program.exit) {
     lint.failOnError(detects);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var slConfig = require('./lib/config'),
     slRules = require('./lib/rules'),
     glob = require('glob'),
     path = require('path'),
+    jsonFormatter = require('eslint/lib/formatters/json'),
     fs = require('fs-extra');
 
 
@@ -20,7 +21,8 @@ sassLint.getConfig = function (config, configPath) {
 
 sassLint.resultCount = function (results) {
   var flagCount = 0,
-      jsonResults = JSON.parse(results);
+      jsonResults = JSON.parse(jsonFormatter(results));
+
 
   for (var i = 0; i < jsonResults.length; i++) {
     flagCount += (jsonResults[i].warningCount + jsonResults[i].errorCount);
@@ -108,9 +110,12 @@ sassLint.outputResults = function (results, options, configPath) {
   var config = this.getConfig(options, configPath);
 
   if (this.resultCount(results)) {
+
+    var formatted = this.format(results, options, configPath);
+
     if (config.options['output-file']) {
       try {
-        fs.outputFileSync(path.resolve(process.cwd(), config.options['output-file']), results);
+        fs.outputFileSync(path.resolve(process.cwd(), config.options['output-file']), formatted);
         console.log('Output successfully written to ' + path.resolve(process.cwd(), config.options['output-file']));
       }
       catch (e) {
@@ -118,7 +123,7 @@ sassLint.outputResults = function (results, options, configPath) {
       }
     }
     else {
-      console.log(results);
+      console.log(formatted);
     }
   }
   return results;

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -108,4 +108,21 @@ describe('cli', function () {
       }
     });
   });
+
+  it('should return a warning - stylish', function (done) {
+    var command = 'sass-lint -c tests/yml/.stylish-errors.yml tests/sass/cli.scss --verbose',
+        expectedOutputLength = 155;
+
+    childProcess.exec(command, function (err, stdout) {
+
+      if (err) {
+        return done(err);
+      }
+
+      else {
+        assert.equal(expectedOutputLength, stdout.length);
+        done();
+      }
+    });
+  });
 });

--- a/tests/output.js
+++ b/tests/output.js
@@ -64,8 +64,7 @@ describe('output', function () {
     };
 
     var outPath = path.resolve(process.cwd(), options.options['output-file']),
-        formatted = lint.format(results, options),
-        output = lint.outputResults(formatted, options);
+        output = lint.outputResults(results, options);
 
     output = fs.readFileSync(outPath, 'utf-8');
     fs.removeSync(outPath);

--- a/tests/yml/.stylish-errors.yml
+++ b/tests/yml/.stylish-errors.yml
@@ -1,0 +1,58 @@
+options:
+  formatter: stylish
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 0
+  extends-before-declarations: 0
+  placeholder-in-extend: 0
+
+  # Mixins
+  mixins-before-declarations: 0
+
+  # Line Spacing
+  one-declaration-per-line: 0
+  empty-line-between-blocks: 0
+  single-line-per-selector: 0
+
+  # Disallows
+  no-debug: 0
+  no-duplicate-properties: 0
+  no-empty-rulesets: 0
+  no-extends: 0
+  no-ids: 0
+  no-important: 0
+  no-warn: 0
+  no-color-keywords: 1
+  no-invalid-hex: 0
+  no-css-comments: 0
+  no-color-literals: 0
+  no-vendor-prefix: 0
+
+  # Style Guide
+  border-zero: 0
+  clean-import-paths: 0
+  empty-args: 0
+  hex-length: 0
+  hex-notation: 0
+  indentation: 0
+  leading-zero: 0
+  nesting-depth: 0
+  property-sort-order: 0
+  quotes: 0
+  variable-for-property: 0
+  zero-unit: 0
+
+  # Inner Spacing
+  space-after-comma: 0
+  space-before-colon: 0
+  space-after-colon: 0
+  space-before-brace: 0
+  space-before-bang: 0
+  space-after-bang: 0
+  space-between-parens: 0
+
+  # Final Items
+  trailing-semicolon: 0
+  final-newline: 0


### PR DESCRIPTION
This is quite an urgent hotfix. The cli output is currently broken for all styles other than json due to the way the formatting was happening pre result count (my bad!).

This is a hotfix for that, and should close #212 and close #197

Added a basic test to make sure `stylish` errors are still being reported

This output will need to be revisited for `1.3.0` but for now this hotfix should avoid the issues being encountered

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com