### PR TITLE
Doc enhancement: Add property order lists in property-sort-order rule doc

### DIFF
--- a/docs/rules/property-sort-order.md
+++ b/docs/rules/property-sort-order.md
@@ -6,6 +6,8 @@ Rule `property-sort-order` will enforce the order in which declarations are writ
 
 * `order`: `'alphabetical'`, [`'concentric'`](http://rhodesmill.org/brandon/2011/concentric-css/), [`'recess'`](http://twitter.github.io/recess/), [`'smacss'`](http://smacss.com/book/formatting), or `[array of properties]` (defaults to `alphabetical`. Unknown properties are sorted alphabetically)
 
+Property orders: https://github.com/sasstools/sass-lint/tree/develop/lib/config/property-sort-orders
+
 ## Examples
 
 When enabled (assuming `order: alphabetical`), the following are allowed:


### PR DESCRIPTION
close  https://github.com/sasstools/sass-lint/issues/234
These lists are useful for people being refactoring their base code. So a link to exhaustive lists of ordered properties in the documentation could be useful.

DCO 1.1 Signed-off-by: Nicolas Fortin <nicolas.fortin37@gmail.com>