### PR TITLE
Hotfix/mixins before selectors - Master

### DIFF
--- a/lib/rules/mixins-before-declarations.js
+++ b/lib/rules/mixins-before-declarations.js
@@ -18,13 +18,22 @@ module.exports = {
       var depth = 0,
           declarationCount = [depth];
 
-      parent.traverse( function (item) {
+      parent.forEach( function (item) {
         if (item.type === 'ruleset') {
           depth++;
           declarationCount[depth] = 0;
         }
         else if (item.type === 'declaration') {
-          declarationCount[depth]++;
+          if (item.first().is('property')) {
+
+            var prop = item.first();
+
+            if(prop.first().is('ident')) {
+
+              declarationCount[depth]++;
+
+            }
+          }
         }
         else if (item.type === 'include') {
           item.forEach('simpleSelector', function (name) {

--- a/lib/rules/mixins-before-declarations.js
+++ b/lib/rules/mixins-before-declarations.js
@@ -28,7 +28,7 @@ module.exports = {
 
             var prop = item.first();
 
-            if(prop.first().is('ident')) {
+            if (prop.first().is('ident')) {
 
               declarationCount[depth]++;
 

--- a/tests/rules/mixins-before-declarations.js
+++ b/tests/rules/mixins-before-declarations.js
@@ -20,7 +20,7 @@ describe('mixins before declarations', function () {
   //////////////////////////////
   // Mixins Before Declarations - overwrite
   //////////////////////////////
-  it('[excludes]', function (done) {
+  it('[excludes: all]', function (done) {
     lint.test(file, {
       'mixins-before-declarations': [
         1,
@@ -35,6 +35,28 @@ describe('mixins before declarations', function () {
       ]
     }, function (data) {
       lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Mixins Before Declarations - exclude certain
+  // mixin test-again is not excluded
+  //////////////////////////////
+  it('[excludes: limited]', function (done) {
+    lint.test(file, {
+      'mixins-before-declarations': [
+        1,
+        {
+          'exclude': [
+            'waldo',
+            'mq',
+            'breakpoint'
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
       done();
     });
   });

--- a/tests/sass/mixins-before-declarations.scss
+++ b/tests/sass/mixins-before-declarations.scss
@@ -1,3 +1,6 @@
+
+@include waldo;
+
 .foo {
   @include waldo;
   content: 'baz';
@@ -46,4 +49,29 @@
       @include test-again;
     }
   }
+}
+
+// added from issue #230 https://github.com/sasstools/sass-lint/issues/230
+
+.area-current {
+  $active: #00acac;
+  $background: #2d353c;
+
+  @include area-menu($active, $background);
+}
+
+// added from issue #227 https://github.com/sasstools/sass-lint/issues/227
+
+@include hello;
+
+@media (min-width: 50em) {
+  @include hello;
+}
+
+@supports (display: flex) {
+  @include hello;
+}
+
+@at-root {
+  @include hello;
 }


### PR DESCRIPTION
Fixes a few issues raised with the mixins before declaration rule.

* Added a check for the node content type for each declaration to correctly identify those that should raise an issue rather than a catch all. Fixes #230
* Added an extra test to only exclude 3 of the 4 failing mixins in order to catch any issues with exclusion
* Removed the parent traversal in favour of the forEach loop. Reduces the time to traverse the nodes while also adding extra control over block scoping. Fixes #227 

This should be merged prior to #239

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com