### PR TITLE
Add rule: variable-name-format

### DIFF
--- a/docs/rules/variable-name-format.md
+++ b/docs/rules/variable-name-format.md
@@ -5,12 +5,16 @@ Rule `variable-name-format` will enforce the use of hexadecimal color values rat
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `[_A-Z]`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `/^[_A-Z]+$/`)
 * `convention-explanation`: Custom explanation to display to the user if a variable doesn't adhere to the convention
 
-## Examples
+## Example 1
 
-When enabled (assuming `allow-leading-underscore: true` and `convention: hyphenatedlowercase`), the following are allowed:
+Settings:
+- `allow-leading-underscore: true`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
 
 ```scss
 $hyphenated-lowercase: 1px;
@@ -22,7 +26,7 @@ $_leading-underscore: 1px;
 
 ```
 
-When enabled (assuming `allow-leading-underscore: true` and `convention: hyphenatedlowercase`), the following are disallowed:
+When enabled, the following are disallowed:
 
 ```scss
 $HYPHENATED-UPPERCASE: 1px;
@@ -30,5 +34,89 @@ $_camelCaseWithLeadingUnderscore: 1px;
 
 .foo {
   width: $snake_case;
+}
+```
+
+## Example 2
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: camelcase`
+
+When enabled, the following are allowed:
+
+```scss
+$camelCase: 1px;
+
+.foo {
+  width: $anotherCamelCase;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$HYPHENATED-UPPERCASE: 1px;
+$_camelCaseWithLeadingUnderscore: 1px;
+
+.foo {
+  width: $snake_case;
+}
+```
+
+## Example 3
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: snakecase`
+
+When enabled, the following are allowed:
+
+```scss
+$snake_case: 1px;
+
+.foo {
+  width: $another_snake_case;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$HYPHENATED-UPPERCASE: 1px;
+$_snake_case_with_leading_underscore: 1px;
+
+.foo {
+  width: $camelCase;
+}
+```
+
+## Example 4
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: /^[_A-Z]+$/`
+- `convention-explanation: 'Variables must contain only uppercase letters and underscores'`
+
+When enabled, the following are allowed:
+
+```scss
+$SCREAMING_SNAKE_CASE: 1px;
+
+.foo {
+  width: $_LEADING_UNDERSCORE;
+}
+```
+
+When enabled, the following are disallowed:
+
+(Each line with a variable will report `Variables must contain only uppercase letters and underscores` when linted.)
+
+```scss
+$HYPHENATED-UPPERCASE: 1px;
+$_snake_case_with_leading_underscore: 1px;
+
+.foo {
+  width: $camelCase;
 }
 ```

--- a/docs/rules/variable-name-format.md
+++ b/docs/rules/variable-name-format.md
@@ -1,0 +1,34 @@
+# Variable Name Format
+
+Rule `variable-name-format` will enforce the use of hexadecimal color values rather than literals.
+
+## Options
+
+* `allow-leading-underscore`: `true`/`false` (defaults to `true`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `[_A-Z]`)
+* `convention-explanation`: Custom explanation to display to the user if a variable doesn't adhere to the convention
+
+## Examples
+
+When enabled (assuming `allow-leading-underscore: true` and `convention: hyphenatedlowercase`), the following are allowed:
+
+```scss
+$hyphenated-lowercase: 1px;
+$_leading-underscore: 1px;
+
+.foo {
+  width: $hyphenated-lowercase;
+}
+
+```
+
+When enabled (assuming `allow-leading-underscore: true` and `convention: hyphenatedlowercase`), the following are disallowed:
+
+```scss
+$HYPHENATED-UPPERCASE: 1px;
+$_camelCaseWithLeadingUnderscore: 1px;
+
+.foo {
+  width: $snake_case;
+}
+```

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -126,6 +126,18 @@ helpers.isLowerCase = function (str) {
   return false;
 };
 
+helpers.isCamelCase = function (str) {
+  return /^[a-z][a-zA-Z0-9]*$/.test(str);
+};
+
+helpers.isHyphenatedLowercase = function (str) {
+  return !(/[_A-Z]/.test(str));
+};
+
+helpers.isSnakeCase = function (str) {
+  return !(/[^_a-z0-9]/.test(str));
+};
+
 helpers.isValidHex = function (str) {
   if (str.match(/^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
     return true;

--- a/lib/rules/variable-name-format.js
+++ b/lib/rules/variable-name-format.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'variable-name-format',
+  'defaults': {
+    'allow-leading-underscore': true,
+    'convention': 'hyphenatedlowercase'
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('variable', function (variable) {
+      var name = variable.first().content;
+
+      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+        name = name.slice(1);
+      }
+
+      if (parser.options.convention === 'hyphenatedlowercase' && !helpers.isHyphenatedLowercase(name)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': variable.start.line,
+          'column': variable.start.column,
+          'message': 'Variable \'' + variable.first().content + '\' should be written in lowercase with hyphens',
+          'severity': parser.severity
+        });
+      }
+      else if (parser.options.convention === 'camelcase' && !helpers.isCamelCase(name)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': variable.start.line,
+          'column': variable.start.column,
+          'message': 'Variable \'' + variable.first().content + '\' should be written in camelCase',
+          'severity': parser.severity
+        });
+      }
+      else if (parser.options.convention === 'snakecase' && !helpers.isSnakeCase(name)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': variable.start.line,
+          'column': variable.start.column,
+          'message': 'Variable \'' + variable.first().content + '\' should be written in snake_case',
+          'severity': parser.severity
+        });
+      }
+      else if (parser.options.convention instanceof RegExp && !parser.options.convention.test(name)) {
+        var message = parser.options['convention-explanation'];
+
+        if (!message) {
+          message = 'should match regular expression /' + parser.options.convention.source + '/' +
+                    (parser.options.convention.ignoreCase ? 'i' : '');
+        }
+
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': variable.start.line,
+          'column': variable.start.column,
+          'message': 'Variable \'' + variable.first().content + '\' ' + message,
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -414,6 +414,146 @@ describe('helpers', function () {
   });
 
   //////////////////////////////
+  // isCamelCase
+  //////////////////////////////
+
+  it('isCamelCase - [\'TEST\' - false]', function (done) {
+
+    var result = helpers.isCamelCase('TEST');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isCamelCase - [\'test\' - true]', function (done) {
+
+    var result = helpers.isCamelCase('test');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isCamelCase - [abcDEF - true]', function (done) {
+
+    var result = helpers.isCamelCase('abcDEF');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isCamelCase - [\'123\' - false]', function (done) {
+
+    var result = helpers.isCamelCase('123');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isCamelCase - [\'aBcDeF\' - true]', function (done) {
+
+    var result = helpers.isCamelCase('aBcDeF');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  //////////////////////////////
+  // isHyphenatedLowercase
+  //////////////////////////////
+
+  it('isHyphenatedLowercase - [\'TEST\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('TEST');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedLowercase - [\'test\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('test');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isHyphenatedLowercase - [abcDEF - false]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('abcDEF');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedLowercase - [\'123\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('123');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isHyphenatedLowercase - [\'aBcDeF\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('aBcDeF');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  //////////////////////////////
+  // isSnakeCase
+  //////////////////////////////
+
+  it('isSnakeCase - [\'TEST\' - false]', function (done) {
+
+    var result = helpers.isSnakeCase('TEST');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isSnakeCase - [\'test\' - true]', function (done) {
+
+    var result = helpers.isSnakeCase('test');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isSnakeCase - [abcDEF - false]', function (done) {
+
+    var result = helpers.isSnakeCase('abcDEF');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isSnakeCase - [\'123\' - true]', function (done) {
+
+    var result = helpers.isSnakeCase('123');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isSnakeCase - [\'ab_cd_ef\' - true]', function (done) {
+
+    var result = helpers.isSnakeCase('ab_cd_ef');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isSnakeCase - [\'ab_cd-ef\' - false]', function (done) {
+
+    var result = helpers.isSnakeCase('ab_cd-ef');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  //////////////////////////////
   // isValidHex
   //////////////////////////////
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -461,6 +461,14 @@ describe('helpers', function () {
   // isHyphenatedLowercase
   //////////////////////////////
 
+  it('isHyphenatedLowercase - [\'abc-def\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('abc-def');
+
+    assert.equal(true, result);
+    done();
+  });
+
   it('isHyphenatedLowercase - [\'TEST\' - false]', function (done) {
 
     var result = helpers.isHyphenatedLowercase('TEST');

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -52,6 +52,24 @@ describe('variable name format', function () {
   });
 
   //////////////////////////////
+  // Variable Name Format - Regular Expression
+  //////////////////////////////
+  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': /^[_A-Z]+$/,
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
   // Variable Name Format - Allow Leading Underscore (False)
   //////////////////////////////
   it('[convention: allow-leading-underscore false]', function (done) {

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var lint = require('./_lint');
+
+var file = lint.file('variable-name-format.scss');
+
+describe('variable name format', function () {
+  //////////////////////////////
+  // Variable Name Format - Hyphenated Lowercase
+  //////////////////////////////
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'variable-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Variable Name Format - Camel Case
+  //////////////////////////////
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Variable Name Format - Snake Case
+  //////////////////////////////
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  //////////////////////////////
+  // Variable Name Format - Allow Leading Underscore (False)
+  //////////////////////////////
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -2,12 +2,9 @@
 
 var lint = require('./_lint');
 
-var file = lint.file('variable-name-format.scss');
+describe('variable name format - scss', function () {
+  var file = lint.file('variable-name-format.scss');
 
-describe('variable name format', function () {
-  //////////////////////////////
-  // Variable Name Format - Hyphenated Lowercase
-  //////////////////////////////
   it('[convention: hyphenatedlowercase]', function (done) {
     lint.test(file, {
       'variable-name-format': 1
@@ -17,9 +14,6 @@ describe('variable name format', function () {
     });
   });
 
-  //////////////////////////////
-  // Variable Name Format - Camel Case
-  //////////////////////////////
   it('[convention: camelcase]', function (done) {
     lint.test(file, {
       'variable-name-format': [
@@ -34,9 +28,6 @@ describe('variable name format', function () {
     });
   });
 
-  //////////////////////////////
-  // Variable Name Format - Snake Case
-  //////////////////////////////
   it('[convention: snakecase]', function (done) {
     lint.test(file, {
       'variable-name-format': [
@@ -51,9 +42,6 @@ describe('variable name format', function () {
     });
   });
 
-  //////////////////////////////
-  // Variable Name Format - Regular Expression
-  //////////////////////////////
   it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
     lint.test(file, {
       'variable-name-format': [
@@ -69,9 +57,76 @@ describe('variable name format', function () {
     });
   });
 
-  //////////////////////////////
-  // Variable Name Format - Allow Leading Underscore (False)
-  //////////////////////////////
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});
+
+describe('variable name format - sass', function () {
+  var file = lint.file('variable-name-format.sass');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'variable-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': /^[_A-Z]+$/,
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
   it('[convention: allow-leading-underscore false]', function (done) {
     lint.test(file, {
       'variable-name-format': [

--- a/tests/sass/variable-name-format.sass
+++ b/tests/sass/variable-name-format.sass
@@ -1,0 +1,11 @@
+$kabab-case: 1
+$snake_case: 1
+$camelCase: 1
+$PascalCase: 1
+$Camel_Snake_Case: 1
+$SCREAMING_SNAKE_CASE: 1
+$_with-leading-underscore: 1
+$_does_NOT-fitSTANDARD: 1
+
+.class
+  width: $snake_case

--- a/tests/sass/variable-name-format.scss
+++ b/tests/sass/variable-name-format.scss
@@ -1,0 +1,12 @@
+$kabab-case: 1;
+$snake_case: 1;
+$camelCase: 1;
+$PascalCase: 1;
+$Camel_Snake_Case: 1;
+$SCREAMING_SNAKE_CASE: 1;
+$_with-leading-underscore: 1;
+$_does_NOT-fitSTANDARD: 1;
+
+.class {
+  width: $snake_case;
+}


### PR DESCRIPTION
Add rule: variable-name-format which validates that all variables adhere to a convention

Options:
`allow-leading-underscore`: Allow variables to begin with an underscore (default true)
`convention`: one of `hyphenatedlowercase` (default), `camelcase`, `snakecase`, or a RegExp
`convention-explanation`: defaults to `should match regular expression /[regex]/[flags]`, explanation if the RegExp from `convention` fails

I took the patterns for `isCamelCase`, `isHyphenatedLowercase` and `isSnakeCase` from how scss-lint implements them for consistency between projects.

I'll add the related rules to this Pull Request, but since they are very similar I wanted to get feedback early to avoid applying fixes across four rules.

Part 1 of 4 for #17 

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>