### PR TITLE
Fix warning message for no-qualifying-elements rule

### DIFF
--- a/lib/rules/no-qualifying-elements.js
+++ b/lib/rules/no-qualifying-elements.js
@@ -24,7 +24,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': item.start.line,
                 'column': item.start.column,
-                'message': 'Qualifying elements are not allowed for ' + item.type + 'selectors',
+                'message': 'Qualifying elements are not allowed for ' + item.type + ' selectors',
                 'severity': parser.severity
               });
             }


### PR DESCRIPTION
Adds a needed space to the warning message.

Fixes #261 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com