### PR TITLE
Fix a bug in shorthand-values

### DIFF
--- a/lib/rules/shorthand-values.js
+++ b/lib/rules/shorthand-values.js
@@ -82,15 +82,18 @@ module.exports = {
                   fullVal += el.content;
                 });
               }
-              else if (val.is('operator') || val.is('ident')) {
+
+              else if (val.is('operator') || val.is('ident') || val.is('number')) {
                 fullVal += val.content;
               }
+
               else if (val.is('variable')) {
                 val.forEach(function (el) {
                   fullVal += '$' + el.content;
                 });
               }
-              else {
+
+              else if (val.is('space')) {
                 // This is a non value character such as a space
                 // We want to start another value here
                 value.push(fullVal);
@@ -99,32 +102,33 @@ module.exports = {
                 fullVal = '';
               }
             });
+            if (fullVal !== '') {
+              // The last dimension in a value will not be followed by a character so we push here
+              value.push(fullVal);
 
-            // The last dimension in a value will not be followed by a character so we push here
-            value.push(fullVal);
+              if (value.length <= 4 && value.length >= 1) {
+                var output = [];
 
-            if (value.length <= 4 && value.length >= 1) {
-              var output = [];
+                // check which values can condense
+                if (condenseToOne(value, parser.options['allowed-shorthands'])) {
+                  output = [value[0]];
+                }
+                else if (condenseToTwo(value, parser.options['allowed-shorthands'])) {
+                  output = [value[0], value[1]];
+                }
+                else if (condenseToThree(value, parser.options['allowed-shorthands'])) {
+                  output = [value[0], value[1], value[2]];
+                }
 
-              // check which values can condense
-              if (condenseToOne(value, parser.options['allowed-shorthands'])) {
-                output = [value[0]];
-              }
-              else if (condenseToTwo(value, parser.options['allowed-shorthands'])) {
-                output = [value[0], value[1]];
-              }
-              else if (condenseToThree(value, parser.options['allowed-shorthands'])) {
-                output = [value[0], value[1], value[2]];
-              }
-
-              if (output.length) {
-                result = helpers.addUnique(result, {
-                  'ruleId': parser.rule.name,
-                  'line': item.start.line,
-                  'column': item.start.column,
-                  'message': 'Property `' + property + '` should be written more concisely as `' + output.join(' ') + '` instead of `' + value.join(' ') + '`',
-                  'severity': parser.severity
-                });
+                if (output.length) {
+                  result = helpers.addUnique(result, {
+                    'ruleId': parser.rule.name,
+                    'line': item.start.line,
+                    'column': item.start.column,
+                    'message': 'Property `' + property + '` should be written more concisely as `' + output.join(' ') + '` instead of `' + value.join(' ') + '`',
+                    'severity': parser.severity
+                  });
+                }
               }
             }
           }

--- a/tests/sass/shorthand-values.sass
+++ b/tests/sass/shorthand-values.sass
@@ -125,3 +125,16 @@
   border-width: $one $two $three $four
   margin: $one $two $one $three
   padding: $one $one $one $two
+
+.value-of-zero
+  border-radius: 0
+  border-width: none
+  margin: 0 0px
+  padding: 1px 0
+
+
+.value-mixed
+    border-color: $red 1px red 1rem
+    border-radius: 1px 1pc 1rem
+    border-style: $red red
+    border-width: 1px 1pc

--- a/tests/sass/shorthand-values.scss
+++ b/tests/sass/shorthand-values.scss
@@ -141,3 +141,17 @@
   margin: $one $two $one $three;
   padding: $one $one $one $two;
 }
+
+.value-of-zero {
+  border-radius: 0;
+  border-width: none;
+  margin: 0 0px;
+  padding: 1px 0;
+}
+
+.value-mixed {
+    border-color: $red 1px red 1rem;
+    border-radius: 1px 1pc 1rem;
+    border-style: $red red;
+    border-width: 1px 1pc;
+}


### PR DESCRIPTION
Fixes a bug when using plain number values such as `0` in the `shorthand-values` rule.

Only merging to develop due to the impending 1.3.0 release

fixes #263 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com
