### PR TITLE
Add rule: mixin-name-format

### DIFF
--- a/docs/rules/mixin-name-format.md
+++ b/docs/rules/mixin-name-format.md
@@ -5,7 +5,7 @@ Rule `mixin-name-format` will enforce the use of hexadecimal color values rather
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `/^[_A-Z]+$/`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a mixin doesn't adhere to the convention
 
 ## Example 1
@@ -119,7 +119,7 @@ When enabled, the following are disallowed:
 
 Settings:
 - `allow-leading-underscore: true`
-- `convention: /^[_A-Z]+$/`
+- `convention: ^[_A-Z]+$`
 - `convention-explanation: 'Mixins must contain only uppercase letters and underscores'`
 
 When enabled, the following are allowed:

--- a/docs/rules/mixin-name-format.md
+++ b/docs/rules/mixin-name-format.md
@@ -1,0 +1,153 @@
+# Mixin Name Format
+
+Rule `mixin-name-format` will enforce the use of hexadecimal color values rather than literals.
+
+## Options
+
+* `allow-leading-underscore`: `true`/`false` (defaults to `true`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `/^[_A-Z]+$/`)
+* `convention-explanation`: Custom explanation to display to the user if a mixin doesn't adhere to the convention
+
+## Example 1
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+@mixin hyphenated-lowercase() {
+  content: '';
+}
+
+@mixin _leading-underscore() {
+  content: '';
+}
+
+.foo {
+  @include hyphenated-lowercase();
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@mixin HYPHENATED-UPPERCASE() {
+  content: '';
+}
+
+@mixin _camelCaseWithLeadingUnderscore() {
+  content: '';
+}
+
+.foo {
+  @include snake_case();
+}
+```
+
+## Example 2
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: camelcase`
+
+When enabled, the following are allowed:
+
+```scss
+@mixin camelCase() {
+  content: '';
+}
+
+.foo {
+  @include anotherCamelCase();
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@mixin HYPHENATED-UPPERCASE() {
+  content: '';
+}
+
+@mixin _camelCaseWithLeadingUnderscore() {
+  content: '';
+}
+
+.foo {
+  @include snake_case();
+}
+```
+
+## Example 3
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: snakecase`
+
+When enabled, the following are allowed:
+
+```scss
+@mixin snake_case() {
+  content: '';
+}
+
+.foo {
+  @include another_snake_case();
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@mixin HYPHENATED-UPPERCASE() {
+  content: '';
+}
+
+@mixin _snake_case_with_leading_underscore() {
+  content: '';
+}
+
+.foo {
+  @include camelCase();
+}
+```
+
+## Example 4
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: /^[_A-Z]+$/`
+- `convention-explanation: 'Mixins must contain only uppercase letters and underscores'`
+
+When enabled, the following are allowed:
+
+```scss
+@mixin SCREAMING_SNAKE_CASE() {
+  content: '';
+}
+
+.foo {
+  @include _LEADING_UNDERSCORE();
+}
+```
+
+When enabled, the following are disallowed:
+
+(Each line with a variable will report `Mixins must contain only uppercase letters and underscores` when linted.)
+
+```scss
+@mixin HYPHENATED-UPPERCASE() {
+  content: '';
+}
+
+@mixin _snake_case_with_leading_underscore() {
+  content: '';
+}
+
+.foo {
+  @include camelCase();
+}
+```

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -1,0 +1,78 @@
+// Note that this file is nearly identical to function-name-format.js, variable-name-format.js, and placeholder-name-format.js
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'mixin-name-format',
+  'defaults': {
+    'allow-leading-underscore': true,
+    'convention': 'hyphenatedlowercase'
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByTypes(['mixin', 'include'], function (node) {
+      var name;
+
+      if (node.type === 'mixin') {
+        name = node.first('ident').content;
+      }
+      else {
+        name = node.first('simpleSelector').first('ident').content;
+      }
+
+      var originalName = name;
+
+      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+        name = name.slice(1);
+      }
+
+      if (parser.options.convention === 'hyphenatedlowercase' && !helpers.isHyphenatedLowercase(name)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Mixin \'' + originalName + '\' should be written in lowercase with hyphens',
+          'severity': parser.severity
+        });
+      }
+      else if (parser.options.convention === 'camelcase' && !helpers.isCamelCase(name)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Mixin \'' + originalName + '\' should be written in camelCase',
+          'severity': parser.severity
+        });
+      }
+      else if (parser.options.convention === 'snakecase' && !helpers.isSnakeCase(name)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Mixin \'' + originalName + '\' should be written in snake_case',
+          'severity': parser.severity
+        });
+      }
+      else if (parser.options.convention instanceof RegExp && !parser.options.convention.test(name)) {
+        var message = parser.options['convention-explanation'];
+
+        if (!message) {
+          message = 'should match regular expression /' + parser.options.convention.source + '/' +
+                    (parser.options.convention.ignoreCase ? 'i' : '');
+        }
+
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Mixin \'' + originalName + '\' ' + message,
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -7,14 +7,16 @@ module.exports = {
   'name': 'mixin-name-format',
   'defaults': {
     'allow-leading-underscore': true,
-    'convention': 'hyphenatedlowercase'
+    'convention': 'hyphenatedlowercase',
+    'convention-explanation': false
   },
   'detect': function (ast, parser) {
     var result = [];
 
     ast.traverseByTypes(['mixin', 'include'], function (node) {
       var name,
-          strippedName;
+          strippedName,
+          violationMessage = false;
 
       if (node.type === 'mixin') {
         name = node.first('ident').content;
@@ -29,46 +31,39 @@ module.exports = {
         strippedName = name.slice(1);
       }
 
-      if (parser.options.convention === 'hyphenatedlowercase' && !helpers.isHyphenatedLowercase(strippedName)) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': node.start.line,
-          'column': node.start.column,
-          'message': 'Mixin \'' + name + '\' should be written in lowercase with hyphens',
-          'severity': parser.severity
-        });
-      }
-      else if (parser.options.convention === 'camelcase' && !helpers.isCamelCase(strippedName)) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': node.start.line,
-          'column': node.start.column,
-          'message': 'Mixin \'' + name + '\' should be written in camelCase',
-          'severity': parser.severity
-        });
-      }
-      else if (parser.options.convention === 'snakecase' && !helpers.isSnakeCase(strippedName)) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': node.start.line,
-          'column': node.start.column,
-          'message': 'Mixin \'' + name + '\' should be written in snake_case',
-          'severity': parser.severity
-        });
-      }
-      else if (parser.options.convention instanceof RegExp && !parser.options.convention.test(strippedName)) {
-        var message = parser.options['convention-explanation'];
-
-        if (!message) {
-          message = 'should match regular expression /' + parser.options.convention.source + '/' +
-                    (parser.options.convention.ignoreCase ? 'i' : '');
+      switch (parser.options.convention) {
+      case 'hyphenatedlowercase':
+        if (!helpers.isHyphenatedLowercase(strippedName)) {
+          violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
         }
+        break;
+      case 'camelcase':
+        if (!helpers.isCamelCase(strippedName)) {
+          violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
+        }
+        break;
+      case 'snakecase':
+        if (!helpers.isSnakeCase(strippedName)) {
+          violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
+        }
+        break;
+      default:
+        if (!(new RegExp(parser.options.convention).test(strippedName))) {
+          violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
 
+          // convention-message overrides violationMessage
+          if (parser.options['convention-explanation']) {
+            violationMessage = parser.options['convention-explanation'];
+          }
+        }
+      }
+
+      if (violationMessage) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Mixin \'' + name + '\' ' + message,
+          'message': violationMessage,
           'severity': parser.severity
         });
       }

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -13,7 +13,8 @@ module.exports = {
     var result = [];
 
     ast.traverseByTypes(['mixin', 'include'], function (node) {
-      var name;
+      var name,
+          strippedName;
 
       if (node.type === 'mixin') {
         name = node.first('ident').content;
@@ -22,40 +23,40 @@ module.exports = {
         name = node.first('simpleSelector').first('ident').content;
       }
 
-      var originalName = name;
+      strippedName = name;
 
       if (parser.options['allow-leading-underscore'] && name[0] === '_') {
-        name = name.slice(1);
+        strippedName = name.slice(1);
       }
 
-      if (parser.options.convention === 'hyphenatedlowercase' && !helpers.isHyphenatedLowercase(name)) {
+      if (parser.options.convention === 'hyphenatedlowercase' && !helpers.isHyphenatedLowercase(strippedName)) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Mixin \'' + originalName + '\' should be written in lowercase with hyphens',
+          'message': 'Mixin \'' + name + '\' should be written in lowercase with hyphens',
           'severity': parser.severity
         });
       }
-      else if (parser.options.convention === 'camelcase' && !helpers.isCamelCase(name)) {
+      else if (parser.options.convention === 'camelcase' && !helpers.isCamelCase(strippedName)) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Mixin \'' + originalName + '\' should be written in camelCase',
+          'message': 'Mixin \'' + name + '\' should be written in camelCase',
           'severity': parser.severity
         });
       }
-      else if (parser.options.convention === 'snakecase' && !helpers.isSnakeCase(name)) {
+      else if (parser.options.convention === 'snakecase' && !helpers.isSnakeCase(strippedName)) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Mixin \'' + originalName + '\' should be written in snake_case',
+          'message': 'Mixin \'' + name + '\' should be written in snake_case',
           'severity': parser.severity
         });
       }
-      else if (parser.options.convention instanceof RegExp && !parser.options.convention.test(name)) {
+      else if (parser.options.convention instanceof RegExp && !parser.options.convention.test(strippedName)) {
         var message = parser.options['convention-explanation'];
 
         if (!message) {
@@ -67,7 +68,7 @@ module.exports = {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Mixin \'' + originalName + '\' ' + message,
+          'message': 'Mixin \'' + name + '\' ' + message,
           'severity': parser.severity
         });
       }

--- a/tests/rules/mixin-name-format.js
+++ b/tests/rules/mixin-name-format.js
@@ -1,0 +1,143 @@
+'use strict';
+
+var lint = require('./_lint');
+
+describe('mixin name format - scss', function () {
+  var file = lint.file('mixin-name-format.scss');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': /^[_A-Z]+$/,
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});
+
+describe('mixin name format - sass', function () {
+  var file = lint.file('mixin-name-format.sass');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': /^[_A-Z]+$/,
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/rules/mixin-name-format.js
+++ b/tests/rules/mixin-name-format.js
@@ -42,12 +42,12 @@ describe('mixin name format - scss', function () {
     });
   });
 
-  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
     lint.test(file, {
       'mixin-name-format': [
         1,
         {
-          'convention': /^[_A-Z]+$/,
+          'convention': '^[_A-Z]+$',
           'convention-explanation': 'Its bad and you should feel bad.'
         }
       ]

--- a/tests/sass/mixin-name-format.sass
+++ b/tests/sass/mixin-name-format.sass
@@ -1,0 +1,26 @@
+=hyphenated-lowercase()
+  content: ''
+
+=snake_case()
+  content: ''
+
+=camelCase()
+  content: ''
+
+=PascalCase()
+  content: ''
+
+=Camel_Snake_Case()
+  content: ''
+
+=SCREAMING_SNAKE_CASE()
+  content: ''
+
+=_with-leading-underscore()
+  content: ''
+
+=_does_NOT-fitSTANDARD()
+  content: ''
+
+.class
+  +snake_case()

--- a/tests/sass/mixin-name-format.scss
+++ b/tests/sass/mixin-name-format.scss
@@ -1,0 +1,35 @@
+@mixin hyphenated-lowercase() {
+  content: '';
+}
+
+@mixin snake_case() {
+  content: '';
+}
+
+@mixin camelCase() {
+  content: '';
+}
+
+@mixin PascalCase() {
+  content: '';
+}
+
+@mixin Camel_Snake_Case() {
+  content: '';
+}
+
+@mixin SCREAMING_SNAKE_CASE() {
+  content: '';
+}
+
+@mixin _with-leading-underscore() {
+  content: '';
+}
+
+@mixin _does_NOT-fitSTANDARD() {
+  content: '';
+}
+
+.class {
+  @include snake_case();
+}


### PR DESCRIPTION
Add rule: variable-name-format which validates that all variables adhere to a convention

Options:
`allow-leading-underscore`: Allow variables to begin with an underscore (default true)
`convention`: one of `hyphenatedlowercase` (default), `camelcase`, `snakecase`, or a RegExp
`convention-explanation`: defaults to `should match regular expression /[regex]/[flags]`, explanation if the RegExp from `convention` fails

Closes #276

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>