### PR TITLE
Allow multi-line arguments with space-between-parens rule

### DIFF
--- a/lib/rules/space-between-parens.js
+++ b/lib/rules/space-between-parens.js
@@ -19,7 +19,7 @@ module.exports = {
       }
 
       if (parser.options.include) {
-        if (first.type !== 'space') {
+        if (!first.is('space')) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': first.start.line,
@@ -28,7 +28,7 @@ module.exports = {
             'severity': parser.severity
           });
         }
-        if (last.type !== 'space') {
+        if (!last.is('space')) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': last.end.line,
@@ -39,7 +39,8 @@ module.exports = {
         }
       }
       else {
-        if (first.type === 'space') {
+        // Ignore if arguments are multi-line
+        if (first.is('space') && !helpers.hasEOL(first.content)) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': first.start.line,
@@ -48,14 +49,22 @@ module.exports = {
             'severity': parser.severity
           });
         }
-        if (last.type === 'space') {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': last.start.line,
-            'column': last.start.column,
-            'message': 'No space allowed at end of parenthesis',
-            'severity': parser.severity
-          });
+        if (last.is('space')) {
+          // Proceed if arguments aren't multi-line.
+          // With Sass we have one extra check for nested nodes where we must
+          // check doublePrevious as the last node will be the indentation
+          if (
+            (ast.syntax === 'scss' && !helpers.hasEOL(last.content))
+            || (ast.syntax === 'sass' && !helpers.hasEOL(last.content) && !helpers.hasEOL(args.content[args.content.length - 2].content))
+          ) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': last.start.line,
+              'column': last.start.column,
+              'message': 'No space allowed at end of parenthesis',
+              'severity': parser.severity
+            });
+          }
         }
       }
     });

--- a/tests/sass/space-between-parens.sass
+++ b/tests/sass/space-between-parens.sass
@@ -15,3 +15,32 @@
   +bar( 'Hello' )
   content: foo('bar')
   width: calc( 100% - 10px)
+
+// Top level mixin
++hello(
+  $foo,
+  $bar,
+  $baz
+)
+
+.foo
+  // Nested Mixin
+  +hello(
+    $foo,
+    $bar,
+    $baz
+  )
+
+  // CSS built-in function
+  background: transparent linear-gradient(
+    to bottom,
+    #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  )
+
+  // User-defined function
+  content: goodbye(
+    $foo,
+    $bar
+  )

--- a/tests/sass/space-between-parens.scss
+++ b/tests/sass/space-between-parens.scss
@@ -15,3 +15,33 @@
   content: foo('bar');
   width: calc( 100% - 10px);
 }
+
+// Top level mixin
+@include hello(
+  $foo,
+  $bar,
+  $baz
+);
+
+.foo {
+  // Nested Mixin
+  @include hello(
+    $foo,
+    $bar,
+    $baz
+  );
+
+  // CSS built-in function
+  background: transparent linear-gradient(
+    to bottom,
+    #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  );
+
+  // User-defined function
+  content: goodbye(
+    $foo,
+    $bar
+  );
+}


### PR DESCRIPTION
This PR fixes the false positive that would arise when it came across multi-line arguments #260.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com