### PR TITLE
Ignore single line rulesets with empty-line-between-blocks rule

### DIFF
--- a/docs/rules/empty-line-between-blocks.md
+++ b/docs/rules/empty-line-between-blocks.md
@@ -5,21 +5,24 @@ Rule `empty-line-between-blocks` will enforce whether or not nested blocks shoul
 ## Options
 
 * `include`: `true`/`false` (defaults to `true`)
+* `ignore-single-line-rulesets`: `true`/`false` (defaults to `true`)
 
 ## Examples
+
+### `include`
 
 When `include: true`, the following are allowed. When `include: false`, the following are disallowed:
 
 ```scss
 .foo {
-  content: 'bar';
+  content: 'foo';
 
-  .baz {
-    content: 'qux';
+  .bar {
+    content: 'bar';
 
     // Waldo
-    &-- {
-      content: 'alpha';
+    &--baz {
+      content: 'baz';
     }
   }
 }
@@ -29,13 +32,34 @@ When `include: false`, the following are allowed. When `include: true`, the foll
 
 ```scss
 .foo {
-  content: 'bar';
-  .baz {
-    content: 'qux';
+  content: 'foo';
+  .bar {
+    content: 'bar';
     // Waldo
-    &-- {
-      content: 'alpha';
+    &--baz {
+      content: 'baz';
     }
   }
 }
+```
+
+### `ignore-single-line-rulesets`
+
+When `ignore-single-line-rulesets: true`, the following are allowed. When `ignore-single-line-rulesets: false`, the following are disallowed:
+
+```scss
+.foo { content: 'foo'; }
+.bar { content: 'bar'; }
+.baz { content: 'baz'; }
+```
+
+When `ignore-single-line-rulesets: false`, the following are allowed. When `ignore-single-line-rulesets: true`, the following are disallowed:
+
+```scss
+.foo { content: 'foo'; }
+
+.bar { content: 'bar'; }
+
+.baz { content: 'baz'; }
+
 ```

--- a/docs/rules/empty-line-between-blocks.md
+++ b/docs/rules/empty-line-between-blocks.md
@@ -5,7 +5,7 @@ Rule `empty-line-between-blocks` will enforce whether or not nested blocks shoul
 ## Options
 
 * `include`: `true`/`false` (defaults to `true`)
-* `ignore-single-line-rulesets`: `true`/`false` (defaults to `true`)
+* `allow-single-line-rulesets`: `true`/`false` (defaults to `true`)
 
 ## Examples
 
@@ -43,23 +43,12 @@ When `include: false`, the following are allowed. When `include: true`, the foll
 }
 ```
 
-### `ignore-single-line-rulesets`
+### `allow-single-line-rulesets`
 
-When `ignore-single-line-rulesets: true`, the following are allowed. When `ignore-single-line-rulesets: false`, the following are disallowed:
+When `allow-single-line-rulesets: true`, the following are allowed. When `allow-single-line-rulesets: false`, the following are disallowed:
 
 ```scss
 .foo { content: 'foo'; }
 .bar { content: 'bar'; }
 .baz { content: 'baz'; }
-```
-
-When `ignore-single-line-rulesets: false`, the following are allowed. When `ignore-single-line-rulesets: true`, the following are disallowed:
-
-```scss
-.foo { content: 'foo'; }
-
-.bar { content: 'bar'; }
-
-.baz { content: 'baz'; }
-
 ```

--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -105,7 +105,8 @@ var findNearestReturnSass = function (parent, i) {
 module.exports = {
   'name': 'empty-line-between-blocks',
   'defaults': {
-    'include': true
+    'include': true,
+    'allow-single-line-rulesets': true
   },
   'detect': function (ast, parser) {
     var result = [];
@@ -113,6 +114,10 @@ module.exports = {
 
     ast.traverseByType('ruleset', function (node, j, p) {
       var space;
+
+      if ((node.start.line === node.end.line) && parser.options['allow-single-line-rulesets']) {
+        return false;
+      }
 
       if (syntax === 'scss') {
         space = findNearestReturnSCSS(p, j);

--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -106,7 +106,7 @@ module.exports = {
   'name': 'empty-line-between-blocks',
   'defaults': {
     'include': true,
-    'ignore-single-line-rulesets': true
+    'allow-single-line-rulesets': true
   },
   'detect': function (ast, parser) {
     var result = [];
@@ -115,7 +115,7 @@ module.exports = {
     ast.traverseByType('ruleset', function (node, j, p) {
       var space;
 
-      if ((node.start.line === node.end.line) && parser.options['ignore-single-line-rulesets']) {
+      if ((node.start.line === node.end.line) && parser.options['allow-single-line-rulesets']) {
         return false;
       }
 

--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -106,7 +106,7 @@ module.exports = {
   'name': 'empty-line-between-blocks',
   'defaults': {
     'include': true,
-    'allow-single-line-rulesets': true
+    'ignore-single-line-rulesets': true
   },
   'detect': function (ast, parser) {
     var result = [];
@@ -115,7 +115,7 @@ module.exports = {
     ast.traverseByType('ruleset', function (node, j, p) {
       var space;
 
-      if ((node.start.line === node.end.line) && parser.options['allow-single-line-rulesets']) {
+      if ((node.start.line === node.end.line) && parser.options['ignore-single-line-rulesets']) {
         return false;
       }
 

--- a/tests/rules/empty-line-between-blocks.js
+++ b/tests/rules/empty-line-between-blocks.js
@@ -6,7 +6,7 @@ var lint = require('./_lint');
 // SCSS syntax tests
 //////////////////////////////
 describe('empty line between blocks - scss', function () {
-  it('without comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -17,7 +17,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('without comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -25,16 +25,16 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': true,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
 
-  it('without comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: false, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -42,7 +42,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': true
+          'allow-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -51,7 +51,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('without comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: false, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -59,16 +59,16 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
-      lint.assert.equal(18, data.warningCount);
+      lint.assert.equal(22, data.warningCount);
       done();
     });
   });
 
-  it('with comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -76,7 +76,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': true,
-          'ignore-single-line-rulesets': true
+          'allow-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -85,7 +85,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: true, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -93,7 +93,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': true,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -102,7 +102,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: false, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -110,7 +110,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': true
+          'allow-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -119,7 +119,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: false, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -127,7 +127,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -141,7 +141,7 @@ describe('empty line between blocks - scss', function () {
 // Sass syntax tests
 //////////////////////////////
 describe('empty line between blocks - sass', function () {
-  it('without comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -152,7 +152,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('without comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -160,7 +160,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': true,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -169,7 +169,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('without comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: false, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -180,12 +180,12 @@ describe('empty line between blocks - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
 
-  it('without comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: false, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -193,16 +193,16 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
 
-  it('with comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -213,7 +213,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: true, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -221,7 +221,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': true,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -230,7 +230,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: false, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -238,7 +238,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': true
+          'allow-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -247,7 +247,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: false, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -255,7 +255,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': false,
-          'ignore-single-line-rulesets': false
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {

--- a/tests/rules/empty-line-between-blocks.js
+++ b/tests/rules/empty-line-between-blocks.js
@@ -6,7 +6,7 @@ var lint = require('./_lint');
 // SCSS syntax tests
 //////////////////////////////
 describe('empty line between blocks - scss', function () {
-  it('without comments - [include: true, allow-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -17,7 +17,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('without comments - [include: true, allow-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -25,7 +25,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': true,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -34,7 +34,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('without comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -42,7 +42,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': true
+          'ignore-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -51,7 +51,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('without comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
@@ -59,7 +59,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -68,7 +68,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: true, allow-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -76,7 +76,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': true,
-          'allow-single-line-rulesets': true
+          'ignore-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -85,7 +85,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: true, allow-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -93,7 +93,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': true,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -102,7 +102,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -110,7 +110,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': true
+          'ignore-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -119,7 +119,7 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
@@ -127,7 +127,7 @@ describe('empty line between blocks - scss', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -141,7 +141,7 @@ describe('empty line between blocks - scss', function () {
 // Sass syntax tests
 //////////////////////////////
 describe('empty line between blocks - sass', function () {
-  it('without comments - [include: true, allow-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -152,7 +152,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('without comments - [include: true, allow-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -160,7 +160,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': true,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -169,7 +169,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('without comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+  it('without comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -185,7 +185,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('without comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+  it('without comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -193,7 +193,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -202,7 +202,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: true, allow-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: true, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -213,7 +213,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: true, allow-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: true, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -221,7 +221,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': true,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -230,7 +230,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+  it('with comments - [include: false, ignore-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -238,7 +238,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': true
+          'ignore-single-line-rulesets': true
         }
       ]
     }, function (data) {
@@ -247,7 +247,7 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+  it('with comments - [include: false, ignore-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -255,7 +255,7 @@ describe('empty line between blocks - sass', function () {
         1,
         {
           'include': false,
-          'allow-single-line-rulesets': false
+          'ignore-single-line-rulesets': false
         }
       ]
     }, function (data) {

--- a/tests/rules/empty-line-between-blocks.js
+++ b/tests/rules/empty-line-between-blocks.js
@@ -6,25 +6,60 @@ var lint = require('./_lint');
 // SCSS syntax tests
 //////////////////////////////
 describe('empty line between blocks - scss', function () {
-  it('without comments - [include: true]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
       'empty-line-between-blocks': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(3, data.warningCount);
       done();
     });
   });
 
-  it('without comments - [include: false]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-between-blocks.scss');
 
     lint.test(file, {
       'empty-line-between-blocks': [
         1,
         {
-          'include': false
+          'include': true,
+          'allow-single-line-rulesets': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(4, data.warningCount);
+      done();
+    });
+  });
+
+  it('without comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+    var file = lint.file('empty-line-between-blocks.scss');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(17, data.warningCount);
+      done();
+    });
+  });
+
+  it('without comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+    var file = lint.file('empty-line-between-blocks.scss');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -33,25 +68,66 @@ describe('empty line between blocks - scss', function () {
     });
   });
 
-  it('with comments - [include: true]', function (done) {
-    var file = lint.file('empty-line-with-comments.scss');
-
-    lint.test(file, {
-      'empty-line-between-blocks': 1
-    }, function (data) {
-      lint.assert.equal(9, data.warningCount);
-      done();
-    });
-  });
-
-  it('with comments - [include: false]', function (done) {
+  it('with comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.scss');
 
     lint.test(file, {
       'empty-line-between-blocks': [
         1,
         {
-          'include': false
+          'include': true,
+          'allow-single-line-rulesets': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('with comments - [include: true, allow-single-line-rulesets: false]', function (done) {
+    var file = lint.file('empty-line-with-comments.scss');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': true,
+          'allow-single-line-rulesets': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
+      done();
+    });
+  });
+
+  it('with comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+    var file = lint.file('empty-line-with-comments.scss');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(25, data.warningCount);
+      done();
+    });
+  });
+
+  it('with comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+    var file = lint.file('empty-line-with-comments.scss');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {
@@ -65,7 +141,7 @@ describe('empty line between blocks - scss', function () {
 // Sass syntax tests
 //////////////////////////////
 describe('empty line between blocks - sass', function () {
-  it('without comments - [include: true]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -76,7 +152,24 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('without comments - [include: false]', function (done) {
+  it('without comments - [include: true, allow-single-line-rulesets: false]', function (done) {
+    var file = lint.file('empty-line-between-blocks.sass');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': true,
+          'allow-single-line-rulesets': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+
+  it('without comments - [include: false, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-between-blocks.sass');
 
     lint.test(file, {
@@ -92,7 +185,24 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: true]', function (done) {
+  it('without comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+    var file = lint.file('empty-line-between-blocks.sass');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('with comments - [include: true, allow-single-line-rulesets: true]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
@@ -103,14 +213,49 @@ describe('empty line between blocks - sass', function () {
     });
   });
 
-  it('with comments - [include: false]', function (done) {
+  it('with comments - [include: true, allow-single-line-rulesets: false]', function (done) {
     var file = lint.file('empty-line-with-comments.sass');
 
     lint.test(file, {
       'empty-line-between-blocks': [
         1,
         {
-          'include': false
+          'include': true,
+          'allow-single-line-rulesets': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
+      done();
+    });
+  });
+
+  it('with comments - [include: false, allow-single-line-rulesets: true]', function (done) {
+    var file = lint.file('empty-line-with-comments.sass');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(23, data.warningCount);
+      done();
+    });
+  });
+
+  it('with comments - [include: false, allow-single-line-rulesets: false]', function (done) {
+    var file = lint.file('empty-line-with-comments.sass');
+
+    lint.test(file, {
+      'empty-line-between-blocks': [
+        1,
+        {
+          'include': false,
+          'allow-single-line-rulesets': false
         }
       ]
     }, function (data) {

--- a/tests/sass/empty-line-between-blocks.sass
+++ b/tests/sass/empty-line-between-blocks.sass
@@ -1,63 +1,90 @@
-.block
-  content: 'bar'
-  .nested-block
-    content: 'bar'
+.foo
+  content: 'foo'
 
-  .nested-goodies
-    content: 'bar'
-  .nested-goodies
-    content: 'bar'
-
-  .nested-goodies
-    content: 'bar'
-
-h1
-  content: 'bar'
-h1,
-h2
-  content: 'bar'
-  +breakpoint($tab1)
-    &:after
-      content: '|'
-      padding-left: 12px
-
-h1, h2
+.foo
+  content: 'foo'
+.bar
   content: 'bar'
 
+.foo
+  @include bar
 
-[type=text]
-  content: 'bar'
-h1.foo
-  content: 'bar'
-
-
-h1.foo,
-h2.bar
-  content: 'bar'
-
-  .qux
-    content: 'bar'
-
-  &__element
+.foo
+  @include bar($qux)
     content: 'foo'
 
-  &--modifier
-    content: 'bar'
+
+.foo
+  @include bar($qux)
+    content: 'foo'
+
+
+.foo
+
+  @include bar($qux)
+    content: 'foo'
+
+
+.foo
+  @include bar($qux)
+    &:after
+      content: 'foo'
+
+
+
+.foo
+
+  &__bar
+    content: 'foo'
+
+
+  content: 'foo'
+
+.foo
+  content: 'foo'
+
+  &__bar
+    content: 'foo'
+
+
+.foo
+  content: 'foo'
+
+  &__bar
+    content: 'foo'
+
+
+
+.foo
+  &:before
+    content: 'foo'
+
+
+.foo
+  content: 'foo'
+
+  &::first-line
+    content: 'foo'
+
+
+h1
+  content: 'foo'
+h2
+  content: 'foo'
+h3
+  content: 'foo'
+h4
+  content: 'foo'
+
 
 .foo + .bar
-  content: 'bar'
+  content: 'foo'
 .foo + .bar,
 h2
   content: 'foo'
 
-.foo
-  .bar
-    &::first-letter
-      content: 'foo'
-    &::first-line
-      content: 'foo'
 
-  .qux
-    content: 'foo'
-  +baz($baz)
-    content: 'baz'
+[type=text]
+  content: 'foo'
+h1.foo
+  content: 'foo'

--- a/tests/sass/empty-line-between-blocks.scss
+++ b/tests/sass/empty-line-between-blocks.scss
@@ -83,6 +83,17 @@
 
 h1 { content: 'foo'; }
 h2 { content: 'foo'; }
+h3 { content: 'foo'; }
+h4 { content: 'foo'; }
+
+
+h1 { content: 'foo'; }
+
+h2 { content: 'foo'; }
+
+h3 { content: 'foo'; }
+
+h4 { content: 'foo'; }
 
 
 .foo + .bar {


### PR DESCRIPTION
As discussed in #282 - this PR adds the option to ignore single line rulesets from the rule with the option `ignore-single-line-rulesets` and the default value being set to `true`.

This fixes #282 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com