### PR TITLE
Hotfix: Fix indentation errors

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -72,6 +72,8 @@ module.exports = {
           }
         }
 
+        // if a delimeter is encountered we check if it's directly after a parenthesis node
+        // if it is we know next node will be the same level of indentation
         var prevNode = node.get(i - 1);
         if (n.is('operator')) {
           if (n.content === ',' && prevNode.is('parentheses')) {
@@ -79,6 +81,10 @@ module.exports = {
           }
         }
 
+        // if a block node is encountered we first check to see if it's within an include/function
+        // by checking if the node also contains argumentts, if it does we skip the block as we add a level
+        // for arguments anyway. If not the the block is a usual ruleset block and should be treated accordingly
+        // The other checks are kept from 1.0 and work for their respective types.
         if ((n.is('block') && !node.contains('arguments'))
           || n.is('atrulers')
           || n.is('arguments')

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -13,10 +13,10 @@ module.exports = {
     var processNode = function (node, level) {
       var i,
           n,
+          prevNode,
           space,
           spaceLength,
           count;
-
 
       level = level || 0;
 
@@ -26,6 +26,7 @@ module.exports = {
 
       for (i = 0; i < node.length; i++) {
         n = node.get(i);
+        prevNode = node.get(i - 1);
 
         if (!n) {
           continue;
@@ -74,7 +75,6 @@ module.exports = {
 
         // if a delimeter is encountered we check if it's directly after a parenthesis node
         // if it is we know next node will be the same level of indentation
-        var prevNode = node.get(i - 1);
         if (n.is('operator')) {
           if (n.content === ',' && prevNode.is('parentheses')) {
             level--;

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -72,9 +72,18 @@ module.exports = {
           }
         }
 
+        var prevNode = node.get(i - 1);
+        if (n.is('operator')) {
+          if (n.content === ',' && prevNode.is('parentheses')) {
+            level--;
+          }
+        }
 
-
-        if (n.is('block') || n.is('atrulers') || (n.is('parentheses') && !node.is('atruleb'))) {
+        if ((n.is('block') && !node.contains('arguments'))
+          || n.is('atrulers')
+          || n.is('arguments')
+          || (n.is('parentheses') && !node.is('atruleb'))
+        ) {
           level++;
         }
 

--- a/tests/rules/indentation.js
+++ b/tests/rules/indentation.js
@@ -12,7 +12,7 @@ describe('indentation - scss', function () {
     lint.test(file, {
       'indentation': 1
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });

--- a/tests/sass/indentation.scss
+++ b/tests/sass/indentation.scss
@@ -5,6 +5,14 @@ $foo: (
   )
 );
 
+.parent {
+  &__child {
+    p::first-line {
+      content: '';
+    }
+  }
+}
+
 .foo,
 .bar {
   content: 'bar';
@@ -15,6 +23,16 @@ content: 'bar';
   @include breakpoint(500) {
     content: 'baz';
   content: 'qux';
+  }
+
+  @include mixin-extra {
+    content: 'baz';
+    content: 'qux';
+  }
+
+  @include mixin-empty-args() {
+    content: 'baz';
+    content: 'qux';
   }
 
     .qux {
@@ -29,4 +47,71 @@ content: 'bar';
 @mixin bar {
     content: 'bar';
 	content: 'baz';
+}
+
+.color {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+$colors: (
+  base: (
+    red: #fff,
+    blue: #fff
+  ),
+  text: (
+    default: #fff,
+    light: (
+      brap: #987
+    ),
+    not: (
+      test: #fff
+    )
+  )
+);
+
+.multilineprops {
+  background: transparent linear-gradient(
+    to bottom,
+      #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  );
+}
+
+.multilineprops-extra {
+  background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%);
+}
+
+// Top-level mixin
+@include hello(
+  $foo,
+  $bar,
+  $baz
+);
+
+.foo {
+  // Nested Mixin
+  @include hello(
+    $foo,
+    $bar,
+    $baz
+  );
+
+  // CSS built-in function
+  background: transparent linear-gradient(
+    to bottom,
+    #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  );
+
+  // User-defined function
+  content: goodbye(
+    $foo,
+    $bar
+  );
+}
+
+@function cp($target, $container) {
+  @return calc-percent($target, $container);
 }


### PR DESCRIPTION
This fixes the reported issues with the indentation rule. This is meant as a temporary stopgap until either the rule is re written for the new `gonzales-pe` version or for it's use within the `.sass` syntax.

Also add each of the test cases from these issues and updated the reported warning count accordingly.

Fixes #104 
Fixes #260 

Due to the impending release of 1.3.0 i've rolled this off of develop and skipped master with the intention of it being released alongside 1.3.0.

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com

