### PR TITLE
Hotfix Develop - Improve structure of variable-name-format and fix how regexps are handled

### DIFF
--- a/docs/rules/variable-name-format.md
+++ b/docs/rules/variable-name-format.md
@@ -5,7 +5,7 @@ Rule `variable-name-format` will enforce the use of hexadecimal color values rat
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `/^[_A-Z]+$/`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a variable doesn't adhere to the convention
 
 ## Example 1
@@ -95,7 +95,7 @@ $_snake_case_with_leading_underscore: 1px;
 
 Settings:
 - `allow-leading-underscore: true`
-- `convention: /^[_A-Z]+$/`
+- `convention: ^[_A-Z]+$`
 - `convention-explanation: 'Variables must contain only uppercase letters and underscores'`
 
 When enabled, the following are allowed:

--- a/docs/rules/variable-name-format.md
+++ b/docs/rules/variable-name-format.md
@@ -1,6 +1,6 @@
 # Variable Name Format
 
-Rule `variable-name-format` will enforce the use of hexadecimal color values rather than literals.
+Rule `variable-name-format` will enforce a convention for variable names.
 
 ## Options
 

--- a/lib/rules/variable-name-format.js
+++ b/lib/rules/variable-name-format.js
@@ -1,3 +1,4 @@
+// Note that this file is nearly identical to function-name-format.js, mixin-name-format.js, and placeholder-name-format.js
 'use strict';
 
 var helpers = require('../helpers');
@@ -6,58 +7,56 @@ module.exports = {
   'name': 'variable-name-format',
   'defaults': {
     'allow-leading-underscore': true,
-    'convention': 'hyphenatedlowercase'
+    'convention': 'hyphenatedlowercase',
+    'convention-explanation': false
   },
   'detect': function (ast, parser) {
     var result = [];
 
     ast.traverseByType('variable', function (variable) {
-      var name = variable.first().content;
+      var strippedName,
+          violationMessage = false,
+          name = variable.first().content;
+
+      strippedName = name;
 
       if (parser.options['allow-leading-underscore'] && name[0] === '_') {
-        name = name.slice(1);
+        strippedName = strippedName.slice(1);
       }
 
-      if (parser.options.convention === 'hyphenatedlowercase' && !helpers.isHyphenatedLowercase(name)) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': variable.start.line,
-          'column': variable.start.column,
-          'message': 'Variable \'' + variable.first().content + '\' should be written in lowercase with hyphens',
-          'severity': parser.severity
-        });
-      }
-      else if (parser.options.convention === 'camelcase' && !helpers.isCamelCase(name)) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': variable.start.line,
-          'column': variable.start.column,
-          'message': 'Variable \'' + variable.first().content + '\' should be written in camelCase',
-          'severity': parser.severity
-        });
-      }
-      else if (parser.options.convention === 'snakecase' && !helpers.isSnakeCase(name)) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': variable.start.line,
-          'column': variable.start.column,
-          'message': 'Variable \'' + variable.first().content + '\' should be written in snake_case',
-          'severity': parser.severity
-        });
-      }
-      else if (parser.options.convention instanceof RegExp && !parser.options.convention.test(name)) {
-        var message = parser.options['convention-explanation'];
-
-        if (!message) {
-          message = 'should match regular expression /' + parser.options.convention.source + '/' +
-                    (parser.options.convention.ignoreCase ? 'i' : '');
+      switch (parser.options.convention) {
+      case 'hyphenatedlowercase':
+        if (!helpers.isHyphenatedLowercase(strippedName)) {
+          violationMessage = 'Variable \'' + name + '\' should be written in lowercase with hyphens';
         }
+        break;
+      case 'camelcase':
+        if (!helpers.isCamelCase(strippedName)) {
+          violationMessage = 'Variable \'' + name + '\' should be written in camelCase';
+        }
+        break;
+      case 'snakecase':
+        if (!helpers.isSnakeCase(strippedName)) {
+          violationMessage = 'Variable \'' + name + '\' should be written in snake_case';
+        }
+        break;
+      default:
+        if (!(new RegExp(parser.options.convention).test(strippedName))) {
+          violationMessage = 'Variable \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
 
+          // convention-message overrides violationMessage
+          if (parser.options['convention-explanation']) {
+            violationMessage = parser.options['convention-explanation'];
+          }
+        }
+      }
+
+      if (violationMessage) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': variable.start.line,
           'column': variable.start.column,
-          'message': 'Variable \'' + variable.first().content + '\' ' + message,
+          'message': violationMessage,
           'severity': parser.severity
         });
       }

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -42,12 +42,12 @@ describe('variable name format - scss', function () {
     });
   });
 
-  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
     lint.test(file, {
       'variable-name-format': [
         1,
         {
-          'convention': /^[_A-Z]+$/,
+          'convention': '^[_A-Z]+$',
           'convention-explanation': 'Its bad and you should feel bad.'
         }
       ]
@@ -112,12 +112,12 @@ describe('variable name format - sass', function () {
     });
   });
 
-  it('[convention: RegExp /^[_A-Z]+$/]', function (done) {
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
     lint.test(file, {
       'variable-name-format': [
         1,
         {
-          'convention': /^[_A-Z]+$/,
+          'convention': '^[_A-Z]+$',
           'convention-explanation': 'Its bad and you should feel bad.'
         }
       ]


### PR DESCRIPTION
See #281 For a discussion of the fixes that are made here.

- `convention-explanation` has a default value
- code is structured more sensibly
- RegExps are handled correctly

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>