### PR TITLE
Add rule: placeholder-name-format

### DIFF
--- a/docs/rules/placeholder-name-format.md
+++ b/docs/rules/placeholder-name-format.md
@@ -1,6 +1,6 @@
 # Placeholder Name Format
 
-Rule `placeholder-name-format` will enforce the use of hexadecimal color values rather than literals.
+Rule `placeholder-name-format` will enforce a convention for placeholder names.
 
 ## Options
 

--- a/docs/rules/placeholder-name-format.md
+++ b/docs/rules/placeholder-name-format.md
@@ -1,0 +1,153 @@
+# Placeholder Name Format
+
+Rule `placeholder-name-format` will enforce the use of hexadecimal color values rather than literals.
+
+## Options
+
+* `allow-leading-underscore`: `true`/`false` (defaults to `true`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
+* `convention-explanation`: Custom explanation to display to the user if a placeholder doesn't adhere to the convention
+
+## Example 1
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+%hyphenated-lowercase {
+  content: '';
+}
+
+%_leading-underscore {
+  content: '';
+}
+
+.foo {
+  @extend %hyphenated-lowercase;
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+%HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+%_camelCaseWithLeadingUnderscore {
+  content: '';
+}
+
+.foo {
+  @extend %snake_case;
+}
+```
+
+## Example 2
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: camelcase`
+
+When enabled, the following are allowed:
+
+```scss
+%camelCase {
+  content: '';
+}
+
+.foo {
+  @extend %anotherCamelCase;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+%HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+%_camelCaseWithLeadingUnderscore {
+  content: '';
+}
+
+.foo {
+  @extend %snake_case;
+}
+```
+
+## Example 3
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: snakecase`
+
+When enabled, the following are allowed:
+
+```scss
+%snake_case {
+  content: '';
+}
+
+.foo {
+  @extend %another_snake_case;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+%HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+%_snake_case_with_leading_underscore {
+  content: '';
+}
+
+.foo {
+  @extend %camelCase;
+}
+```
+
+## Example 4
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: ^[_A-Z]+$`
+- `convention-explanation: 'Mixins must contain only uppercase letters and underscores'`
+
+When enabled, the following are allowed:
+
+```scss
+%SCREAMING_SNAKE_CASE {
+  content: '';
+}
+
+.foo {
+  @extend %_LEADING_UNDERSCORE;
+}
+```
+
+When enabled, the following are disallowed:
+
+(Each line with a variable will report `Mixins must contain only uppercase letters and underscores` when linted.)
+
+```scss
+%HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+%_snake_case_with_leading_underscore {
+  content: '';
+}
+
+.foo {
+  @extend %camelCase;
+}
+```

--- a/lib/rules/placeholder-name-format.js
+++ b/lib/rules/placeholder-name-format.js
@@ -1,0 +1,67 @@
+// Note that this file is nearly identical to function-name-format.js, mixin-name-format.js, and variable-name-format.js
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'placeholder-name-format',
+  'defaults': {
+    'allow-leading-underscore': true,
+    'convention': 'hyphenatedlowercase',
+    'convention-explanation': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('placeholder', function (node) {
+      var name = node.first().content,
+          strippedName,
+          violationMessage = false;
+
+      strippedName = name;
+
+      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+        strippedName = name.slice(1);
+      }
+
+      switch (parser.options.convention) {
+      case 'hyphenatedlowercase':
+        if (!helpers.isHyphenatedLowercase(strippedName)) {
+          violationMessage = 'Placeholder \'%' + name + '\' should be written in lowercase with hyphens';
+        }
+        break;
+      case 'camelcase':
+        if (!helpers.isCamelCase(strippedName)) {
+          violationMessage = 'Placeholder \'%' + name + '\' should be written in camelCase';
+        }
+        break;
+      case 'snakecase':
+        if (!helpers.isSnakeCase(strippedName)) {
+          violationMessage = 'Placeholder \'%' + name + '\' should be written in snake_case';
+        }
+        break;
+      default:
+        if (!(new RegExp(parser.options.convention).test(strippedName))) {
+          violationMessage = 'Placeholder \'%' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+          // convention-message overrides violationMessage
+          if (parser.options['convention-explanation']) {
+            violationMessage = parser.options['convention-explanation'];
+          }
+        }
+      }
+
+      if (violationMessage) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': violationMessage,
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/placeholder-name-format.js
+++ b/tests/rules/placeholder-name-format.js
@@ -1,0 +1,143 @@
+'use strict';
+
+var lint = require('./_lint');
+
+describe('placeholder name format - scss', function () {
+  var file = lint.file('placeholder-name-format.scss');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});
+
+describe('placeholder name format - sass', function () {
+  var file = lint.file('placeholder-name-format.sass');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/placeholder-name-format.sass
+++ b/tests/sass/placeholder-name-format.sass
@@ -1,0 +1,26 @@
+%hyphenated-lowercase
+  content: ''
+
+%snake_case
+  content: ''
+
+%camelCase
+  content: ''
+
+%PascalCase
+  content: ''
+
+%Camel_Snake_Case
+  content: ''
+
+%SCREAMING_SNAKE_CASE
+  content: ''
+
+%_with-leading-underscore
+  content: ''
+
+%_does_NOT-fitSTANDARD
+  content: ''
+
+.class
+  @extend %snake_case

--- a/tests/sass/placeholder-name-format.scss
+++ b/tests/sass/placeholder-name-format.scss
@@ -1,0 +1,35 @@
+%hyphenated-lowercase {
+  content: '';
+}
+
+%snake_case {
+  content: '';
+}
+
+%camelCase {
+  content: '';
+}
+
+%PascalCase {
+  content: '';
+}
+
+%Camel_Snake_Case {
+  content: '';
+}
+
+%SCREAMING_SNAKE_CASE {
+  content: '';
+}
+
+%_with-leading-underscore {
+  content: '';
+}
+
+%_does_NOT-fitSTANDARD {
+  content: '';
+}
+
+.class {
+  @extend %snake_case;
+}


### PR DESCRIPTION
Add rule: placeholder-name-format which validates that all placeholders adhere to a convention

Options:
`allow-leading-underscore`: Allow placeholders to begin with an underscore (default true)
`convention`: one of `hyphenatedlowercase` (default), `camelcase`, `snakecase`, or a RegExp
`convention-explanation`: defaults to `should match regular expression /[regex]/[flags]`, explanation if the RegExp from `convention` fails

Closes #286

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>