### PR TITLE
Hotfix/no duplicate properties

### DIFF
--- a/docs/rules/no-duplicate-properties.md
+++ b/docs/rules/no-duplicate-properties.md
@@ -20,7 +20,7 @@ When enabled, the following are disallowed:
 
 ### Exclude
 
-When a property is added to the exclude array as show below then you may place duplicate properties immediately after each other, this is to prevent accidental duplication of properties.
+When a property is added to the exclude array as shown below then you may place duplicate properties immediately after one another, this is to prevent accidental duplication of properties.
 
 ```yml
 no-duplicate-properties:

--- a/docs/rules/no-duplicate-properties.md
+++ b/docs/rules/no-duplicate-properties.md
@@ -17,3 +17,35 @@ When enabled, the following are disallowed:
   margin: 0;
 }
 ```
+
+### Exclude
+
+When a property is added to the exclude array as show below then you may place duplicate properties immediately after each other, this is to prevent accidental duplication of properties.
+
+```yml
+no-duplicate-properties:
+  - 1
+  -
+    exclude:
+      - display
+```
+
+When `display` is added to the exclude array the following would be allowed:
+
+```scss
+.display-block {
+  display: flex;
+  display: inline-block;
+  float: right;
+}
+```
+
+When `display` is added to the exclude array the following would be still be disallowed as the duplicate properties are separated by another property:
+
+```scss
+.display-block {
+  display: flex;
+  float: right;
+  display: inline-block;
+}
+```

--- a/lib/rules/no-duplicate-properties.js
+++ b/lib/rules/no-duplicate-properties.js
@@ -12,7 +12,8 @@ module.exports = {
 
     ast.traverseByType('block', function (block) {
       var properties = [],
-          items = [];
+          items = [],
+          warnMessage = false;
 
       block.eachFor('declaration', function (declaration) {
         items.push(declaration);
@@ -21,22 +22,30 @@ module.exports = {
       items.reverse();
 
       items.forEach(function (declaration) {
+        warnMessage = false;
+
         declaration.eachFor('property', function (item) {
           var property = item.content[0].content;
 
-          if (properties.indexOf(property) === -1) {
-            properties.push(property);
-          }
-          else {
-            if (parser.options.exclude.indexOf(property) === -1) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': item.start.line,
-                'column': item.start.column,
-                'message': 'Duplicate properties are not allowed within a block',
-                'severity': parser.severity
-              });
+          if (properties.indexOf(property) !== -1 && properties.length >= 1) {
+            if (parser.options.exclude.indexOf(property) !== -1 && properties[properties.length - 1] !== property) {
+              warnMessage = 'Excluded duplicate properties must directly follow each other.';
             }
+            else if (parser.options.exclude.indexOf(property) === -1) {
+              warnMessage = 'Duplicate properties are not allowed within a block';
+            }
+          }
+
+          properties.push(property);
+
+          if (warnMessage) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': item.start.line,
+              'column': item.start.column,
+              'message': warnMessage,
+              'severity': parser.severity
+            });
           }
         });
       });

--- a/tests/rules/no-duplicate-properties.js
+++ b/tests/rules/no-duplicate-properties.js
@@ -33,7 +33,7 @@ describe('no duplicate properties - scss', function () {
     });
   });
 
-  it('enforce - [exclude: background]', function (done) {
+  it('enforce - [exclude: background, display]', function (done) {
     lint.test(file, {
       'no-duplicate-properties': [
         1,
@@ -82,7 +82,7 @@ describe('no duplicate properties - sass', function () {
     });
   });
 
-  it('enforce - [exclude: background]', function (done) {
+  it('enforce - [exclude: background, display]', function (done) {
     lint.test(file, {
       'no-duplicate-properties': [
         1,

--- a/tests/rules/no-duplicate-properties.js
+++ b/tests/rules/no-duplicate-properties.js
@@ -12,7 +12,7 @@ describe('no duplicate properties - scss', function () {
     lint.test(file, {
       'no-duplicate-properties': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,24 @@ describe('no duplicate properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(3, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  it('enforce - [exclude: background]', function (done) {
+    lint.test(file, {
+      'no-duplicate-properties': [
+        1,
+        {
+          'exclude': [
+            'background',
+            'display'
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });
@@ -44,7 +61,7 @@ describe('no duplicate properties - sass', function () {
     lint.test(file, {
       'no-duplicate-properties': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -60,7 +77,24 @@ describe('no duplicate properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(3, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  it('enforce - [exclude: background]', function (done) {
+    lint.test(file, {
+      'no-duplicate-properties': [
+        1,
+        {
+          'exclude': [
+            'background',
+            'display'
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-duplicate-properties.sass
+++ b/tests/sass/no-duplicate-properties.sass
@@ -3,19 +3,30 @@
   padding: 10px
   margin: 0
 
-
+// excluded display will still fail here due to it not
+// following the previous display declaration
 .bar
   display: block
   width: 100%
   display: none
 
+  // excluded display will still fail here due to it not
+  // following the previous display declaration
   .baz
     display: block
     width: 50%
     display: none
 
-
-
 .qux
   background: rgb(200, 54, 54)
   background: rgba(200, 54, 54, 0.5)
+
+.break
+  background: rgb(200, 54, 54)
+  content: 'dec between background'
+  background: rgba(200, 54, 54, 0.5)
+
+.display
+  content: 'display'
+  display: flex
+  display: inline-block

--- a/tests/sass/no-duplicate-properties.scss
+++ b/tests/sass/no-duplicate-properties.scss
@@ -4,11 +4,15 @@
   margin: 0;
 }
 
+// excluded display will still fail here due to it not
+// following the previous display declaration
 .bar {
   display: block;
   width: 100%;
   display: none;
 
+  // excluded display will still fail here due to it not
+  // following the previous display declaration
   .baz {
     display: block;
     width: 50%;
@@ -19,4 +23,17 @@
 .qux {
   background: rgb(200, 54, 54);
   background: rgba(200, 54, 54, 0.5);
+}
+
+.break {
+  background: rgb(200, 54, 54);
+  content: 'dec between background';
+  background: rgba(200, 54, 54, 0.5);
+}
+
+.display {
+  content: 'display';
+  display: flex;
+  display: inline-block;
+
 }


### PR DESCRIPTION
This PR updates the no-duplicate-properties rule as discussed in #280 

Excluded duplicate properties must now immediately follow each other when used.

Extra tests are added to check for these new cases.

Documentation is also updated to add examples.

Closes #280

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com