### PR TITLE
Add rule: function-name-format

### DIFF
--- a/docs/rules/function-name-format.md
+++ b/docs/rules/function-name-format.md
@@ -1,0 +1,122 @@
+# Function Name Format
+
+Rule `function-name-format` will enforce a convention for function names.
+
+## Options
+
+* `allow-leading-underscore`: `true`/`false` (defaults to `true`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the function name must match (e.g. `^[_A-Z]+$`)
+* `convention-explanation`: Custom explanation to display to the user if a function doesn't adhere to the convention
+
+## Example 1
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+$foo: hyphenated-lowercase();
+$foo: _leading-underscore();
+
+.foo {
+  content: hyphenated-lowercase();
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$foo: HYPHENATED-UPPERCASE();
+$foo: _camelCaseWithLeadingUnderscore();
+
+.foo {
+  content: snake_case();
+}
+```
+
+## Example 2
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: camelcase`
+
+When enabled, the following are allowed:
+
+```scss
+$foo: camelCase();
+
+.foo {
+  content: anotherCamelCase();
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$foo: HYPHENATED-UPPERCASE();
+$foo: _camelCaseWithLeadingUnderscore();
+
+.foo {
+  content: snake_case();
+}
+```
+
+## Example 3
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: snakecase`
+
+When enabled, the following are allowed:
+
+```scss
+$foo: snake_case();
+
+.foo {
+  content: another_snake_case();
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$foo: HYPHENATED-UPPERCASE();
+$foo: _snake_case_with_leading_underscore();
+
+.foo {
+  content: camelCase();
+}
+```
+
+## Example 4
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: '^[_A-Z]+$'`
+- `convention-explanation: 'Variables must contain only uppercase letters and underscores'`
+
+When enabled, the following are allowed:
+
+```scss
+$foo: SCREAMING_SNAKE_CASE();
+
+.foo {
+  content: _LEADING_UNDERSCORE();
+}
+```
+
+When enabled, the following are disallowed:
+
+(Each line with a variable will report `Variables must contain only uppercase letters and underscores` when linted.)
+
+```scss
+$foo: HYPHENATED-UPPERCASE();
+$foo: _snake_case_with_leading_underscore();
+
+.foo {
+  content: camelCase();
+}
+```

--- a/docs/rules/function-name-format.md
+++ b/docs/rules/function-name-format.md
@@ -17,20 +17,29 @@ Settings:
 When enabled, the following are allowed:
 
 ```scss
-$foo: hyphenated-lowercase();
-$foo: _leading-underscore();
-
-.foo {
-  content: hyphenated-lowercase();
+@function hyphenated-lowercase() {
+  @return "foo";
 }
 
+@function _leading-underscore($x) {
+  @return $x;
+}
+
+.foo {
+  content: hyphenated-lowercase("bar");
+}
 ```
 
 When enabled, the following are disallowed:
 
 ```scss
-$foo: HYPHENATED-UPPERCASE();
-$foo: _camelCaseWithLeadingUnderscore();
+@function HYPHENATED-UPPERCASE() {
+  @return "foo";
+}
+
+@function _camelCaseWithLeadingUnderscore($x) {
+  @return $x;
+}
 
 .foo {
   content: snake_case();
@@ -46,7 +55,9 @@ Settings:
 When enabled, the following are allowed:
 
 ```scss
-$foo: camelCase();
+@function camelCase() {
+  @return "foo";
+}
 
 .foo {
   content: anotherCamelCase();
@@ -56,8 +67,13 @@ $foo: camelCase();
 When enabled, the following are disallowed:
 
 ```scss
-$foo: HYPHENATED-UPPERCASE();
-$foo: _camelCaseWithLeadingUnderscore();
+@function HYPHENATED-UPPERCASE() {
+  @return "foo";
+}
+
+@function _camelCaseWithLeadingUnderscore() {
+  @return "foo";
+}
 
 .foo {
   content: snake_case();
@@ -73,7 +89,9 @@ Settings:
 When enabled, the following are allowed:
 
 ```scss
-$foo: snake_case();
+@function snake_case() {
+  @return "foo";
+}
 
 .foo {
   content: another_snake_case();
@@ -83,8 +101,13 @@ $foo: snake_case();
 When enabled, the following are disallowed:
 
 ```scss
-$foo: HYPHENATED-UPPERCASE();
-$foo: _snake_case_with_leading_underscore();
+@function HYPHENATED-UPPERCASE() {
+  @return "foo";
+}
+
+@function _snake_case_with_leading_underscore() {
+  @return "foo";
+}
 
 .foo {
   content: camelCase();
@@ -96,12 +119,14 @@ $foo: _snake_case_with_leading_underscore();
 Settings:
 - `allow-leading-underscore: true`
 - `convention: '^[_A-Z]+$'`
-- `convention-explanation: 'Variables must contain only uppercase letters and underscores'`
+- `convention-explanation: 'Functions must contain only uppercase letters and underscores'`
 
 When enabled, the following are allowed:
 
 ```scss
-$foo: SCREAMING_SNAKE_CASE();
+@function SCREAMING_SNAKE_CASE() {
+  @return "foo";
+}
 
 .foo {
   content: _LEADING_UNDERSCORE();
@@ -110,11 +135,16 @@ $foo: SCREAMING_SNAKE_CASE();
 
 When enabled, the following are disallowed:
 
-(Each line with a variable will report `Variables must contain only uppercase letters and underscores` when linted.)
+(Each line with a function call/declaration will report `Functions must contain only uppercase letters and underscores` when linted.)
 
 ```scss
-$foo: HYPHENATED-UPPERCASE();
-$foo: _snake_case_with_leading_underscore();
+@function HYPHENATED-UPPERCASE() {
+  @return "foo";
+}
+
+@function _snake_case_with_leading_underscore() {
+  @return "foo";
+}
 
 .foo {
   content: camelCase();

--- a/lib/rules/function-name-format.js
+++ b/lib/rules/function-name-format.js
@@ -1,0 +1,67 @@
+// Note that this file is nearly identical to mixin-name-format.js, placeholder-name-format.js, and variable-name-format.js
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'function-name-format',
+  'defaults': {
+    'allow-leading-underscore': true,
+    'convention': 'hyphenatedlowercase',
+    'convention-explanation': false
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('function', function (node) {
+      var name = node.first('ident').content,
+          strippedName,
+          violationMessage = false;
+
+      strippedName = name;
+
+      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+        strippedName = name.slice(1);
+      }
+
+      switch (parser.options.convention) {
+      case 'hyphenatedlowercase':
+        if (!helpers.isHyphenatedLowercase(strippedName)) {
+          violationMessage = 'Function \'' + name + '\' should be written in lowercase with hyphens';
+        }
+        break;
+      case 'camelcase':
+        if (!helpers.isCamelCase(strippedName)) {
+          violationMessage = 'Function \'' + name + '\' should be written in camelCase';
+        }
+        break;
+      case 'snakecase':
+        if (!helpers.isSnakeCase(strippedName)) {
+          violationMessage = 'Function \'' + name + '\' should be written in snake_case';
+        }
+        break;
+      default:
+        if (!(new RegExp(parser.options.convention).test(strippedName))) {
+          violationMessage = 'Function \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+          // convention-message overrides violationMessage
+          if (parser.options['convention-explanation']) {
+            violationMessage = parser.options['convention-explanation'];
+          }
+        }
+      }
+
+      if (violationMessage) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': violationMessage,
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/function-name-format.js
+++ b/tests/rules/function-name-format.js
@@ -1,0 +1,143 @@
+'use strict';
+
+var lint = require('./_lint');
+
+describe('function name format - scss', function () {
+  var file = lint.file('function-name-format.scss');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'function-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});
+
+describe('function name format - sass', function () {
+  var file = lint.file('function-name-format.sass');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'function-name-format': 1
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: allow-leading-underscore false]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'allow-leading-underscore': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/rules/function-name-format.js
+++ b/tests/rules/function-name-format.js
@@ -9,7 +9,7 @@ describe('function name format - scss', function () {
     lint.test(file, {
       'function-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -37,7 +37,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -52,7 +52,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -66,7 +66,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -79,7 +79,7 @@ describe('function name format - sass', function () {
     lint.test(file, {
       'function-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -93,7 +93,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -107,7 +107,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -122,7 +122,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -136,7 +136,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });

--- a/tests/rules/function-name-format.js
+++ b/tests/rules/function-name-format.js
@@ -9,7 +9,7 @@ describe('function name format - scss', function () {
     lint.test(file, {
       'function-name-format': 1
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -52,7 +52,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -66,7 +66,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -79,7 +79,7 @@ describe('function name format - sass', function () {
     lint.test(file, {
       'function-name-format': 1
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -93,7 +93,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -122,7 +122,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -136,7 +136,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });

--- a/tests/sass/function-name-format.sass
+++ b/tests/sass/function-name-format.sass
@@ -1,0 +1,11 @@
+$foo: kabab-case()
+$foo: snake_case()
+$foo: camelCase()
+$foo: PascalCase()
+$foo: Camel_Snake_Case()
+$foo: SCREAMING_SNAKE_CASE()
+$foo: _with-leading-underscore()
+$foo: _does_NOT-fitSTANDARD()
+
+.class
+  content: snake_case()

--- a/tests/sass/function-name-format.sass
+++ b/tests/sass/function-name-format.sass
@@ -9,3 +9,6 @@ $foo: _does_NOT-fitSTANDARD()
 
 .class
   content: snake_case()
+
+@function camelCase($x, $y)
+  @return kabab-case($x, $y)

--- a/tests/sass/function-name-format.sass
+++ b/tests/sass/function-name-format.sass
@@ -1,14 +1,30 @@
-$foo: kabab-case()
-$foo: snake_case()
-$foo: camelCase()
-$foo: PascalCase()
-$foo: Camel_Snake_Case()
+@function kabab-case()
+  @return 'foo'
+
+@function snake_case()
+  @return 'foo'
+
+@function camelCase()
+  @return 'foo'
+
+@function PascalCase()
+  @return 'foo'
+
+@function Camel_Snake_Case()
+  @return 'foo'
+
+@function SCREAMING_SNAKE_CASE()
+  @return 'foo'
+
+@function _with-leading-underscore()
+  @return 'foo'
+
+@function _does_NOT-fitSTANDARD($x)
+  @return $x
+
 $foo: SCREAMING_SNAKE_CASE()
-$foo: _with-leading-underscore()
-$foo: _does_NOT-fitSTANDARD()
 
 .class
   content: snake_case()
-
-@function camelCase($x, $y)
-  @return kabab-case($x, $y)
+  color: _does_NOT-fitSTANDARD('bar')
+  border-color: $foo

--- a/tests/sass/function-name-format.scss
+++ b/tests/sass/function-name-format.scss
@@ -10,3 +10,8 @@ $foo: _does_NOT-fitSTANDARD();
 .class {
   content: snake_case();
 }
+
+@function camelCase($x, $y) {
+  @return kabab-case($x, $y);
+}
+

--- a/tests/sass/function-name-format.scss
+++ b/tests/sass/function-name-format.scss
@@ -1,0 +1,12 @@
+$foo: kabab-case();
+$foo: snake_case();
+$foo: camelCase();
+$foo: PascalCase();
+$foo: Camel_Snake_Case();
+$foo: SCREAMING_SNAKE_CASE();
+$foo: _with-leading-underscore();
+$foo: _does_NOT-fitSTANDARD();
+
+.class {
+  content: snake_case();
+}

--- a/tests/sass/function-name-format.scss
+++ b/tests/sass/function-name-format.scss
@@ -1,17 +1,39 @@
-$foo: kabab-case();
-$foo: snake_case();
-$foo: camelCase();
-$foo: PascalCase();
-$foo: Camel_Snake_Case();
+@function kabab-case() {
+  @return 'foo';
+}
+
+@function snake_case() {
+  @return 'foo';
+}
+
+@function camelCase() {
+  @return 'foo';
+}
+
+@function PascalCase() {
+  @return 'foo';
+}
+
+@function Camel_Snake_Case() {
+  @return 'foo';
+}
+
+@function SCREAMING_SNAKE_CASE() {
+  @return 'foo';
+}
+
+@function _with-leading-underscore() {
+  @return 'foo';
+}
+
+@function _does_NOT-fitSTANDARD($x) {
+  @return $x;
+}
+
 $foo: SCREAMING_SNAKE_CASE();
-$foo: _with-leading-underscore();
-$foo: _does_NOT-fitSTANDARD();
 
 .class {
   content: snake_case();
+  color: _does_NOT-fitSTANDARD('bar');
+  border-color: $foo;
 }
-
-@function camelCase($x, $y) {
-  @return kabab-case($x, $y);
-}
-


### PR DESCRIPTION
Add rule: function-name-format which validates that all functions adhere to a convention

Options:
`allow-leading-underscore`: Allow functions to begin with an underscore (default true)
`convention`: one of `hyphenatedlowercase` (default), `camelcase`, `snakecase`, or a RegExp
`convention-explanation`: defaults to `should match regular expression /[regex]/[flags]`, explanation if the RegExp from `convention` fails

Closes #277 

I'd like to note that I feel dirty copy/pasting this much code...

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>