### PR TITLE
Hotfix Master: Fix overriding default rules

### DIFF
--- a/docs/options/merge-default-rules.md
+++ b/docs/options/merge-default-rules.md
@@ -25,9 +25,7 @@ rules:
 
   # Mixins
   mixins-before-declarations: 1
-  no-color-literals: 0
-
-  ~~~
+  no-color-literals: 1
 ```
 
 Below is a default user configured ruleset containing only one rule with `merge-default-rules: true`
@@ -40,10 +38,10 @@ files:
   include: '**/*.s+(a|c)ss'
 rules:
 
-  no-color-literals: 1
+  no-color-literals: 2
 ```
 
-With `merge-default-rules: true` the rules applied to the linter would be as follows. Notice that `no-color-literals` is now set to `1` and the default ruleset has been merged with our user config
+With `merge-default-rules: true` the rules applied to the linter would be as follows. Notice that `no-color-literals` is now set to `2` and the default ruleset has been merged with our user config
 
 ```yml
 options:
@@ -60,7 +58,7 @@ rules:
 
   # Mixins
   mixins-before-declarations: 1
-  no-color-literals: 1
+  no-color-literals: 2
 
   ~~~
 ```
@@ -90,6 +88,4 @@ files:
 rules:
 
   no-color-literals: 1
-
-  ~~~
 ```

--- a/docs/options/merge-default-rules.md
+++ b/docs/options/merge-default-rules.md
@@ -2,8 +2,94 @@
 
 Option `merge-default-rules` will determine whether the rules present in a user's external configuration file or passed directly in to Sass Lint will override or merge with the default rules present in Sass Lint. All other configuration options will still be merged.
 
-If an external configuration file has `merge-default-rules` set to `false`, its rules will override the default rules, but rules passed directly in to Sass Lint will be merged with the configuration file rules (unless they, to have `merge-default-rules` set to `false`, in which case they will override).
+If an external configuration file has `merge-default-rules` set to `false`, its rules will override the default rules, but rules passed directly in to Sass Lint will be merged with the configuration file rules (unless they too have `merge-default-rules` set to `false`, in which case they will override).
 
 ## Options
 
 * `true`/`false` (defaults to `true`)
+
+## Examples
+
+Below is a sample of sass-lints default rules. You can see the full default ruleset [here](https://github.com/sasstools/sass-lint/blob/develop/lib/config/sass-lint.yml).
+
+```yml
+options:
+  formatter: stylish
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 1
+  extends-before-declarations: 1
+  placeholder-in-extend: 1
+
+  # Mixins
+  mixins-before-declarations: 1
+  no-color-literals: 0
+
+  ~~~
+```
+
+Below is a default user configured ruleset containing only one rule with `merge-default-rules: true`
+
+```yml
+options:
+  formatter: stylish
+  merge-default-rules: true
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+
+  no-color-literals: 1
+```
+
+With `merge-default-rules: true` the rules applied to the linter would be as follows. Notice that `no-color-literals` is now set to `1` and the default ruleset has been merged with our user config
+
+```yml
+options:
+  formatter: stylish
+  merge-default-rules: true
+
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 1
+  extends-before-declarations: 1
+  placeholder-in-extend: 1
+
+  # Mixins
+  mixins-before-declarations: 1
+  no-color-literals: 1
+
+  ~~~
+```
+
+Below is a default user configured ruleset containing only one rule with `merge-default-rules: false`
+
+```yml
+options:
+  formatter: stylish
+  merge-default-rules: false
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+
+  no-color-literals: 1
+```
+
+With `merge-default-rules: false` the rules applied to the linter would be as follows. Notice that `no-color-literals` is now set to `1` but rules not present in the user configuration are not merged.
+
+```yml
+options:
+  formatter: stylish
+  merge-default-rules: false
+
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+
+  no-color-literals: 1
+
+  ~~~
+```

--- a/docs/options/merge-default-rules.md
+++ b/docs/options/merge-default-rules.md
@@ -59,8 +59,6 @@ rules:
   # Mixins
   mixins-before-declarations: 1
   no-color-literals: 2
-
-  ~~~
 ```
 
 Below is a default user configured ruleset containing only one rule with `merge-default-rules: false`

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,11 +34,15 @@ module.exports = function (options, configPath) {
   var meta,
       metaPath,
       configMerge = false,
+      configMergeExists = false,
       optionsMerge = false,
+      optionsMergeExists = false,
       config = {},
       finalConfig = {};
 
+  // ensure our inline options and rules are not undefined
   options = options ? options : {};
+  options.rules = options.rules ? options.rules : {};
 
   if (options.options && options.options['config-file']) {
     configPath = options.options['config-file'];
@@ -62,27 +66,44 @@ module.exports = function (options, configPath) {
 
   if (configPath) {
     if (fs.existsSync(configPath)) {
-      config = yaml.safeLoad(fs.readFileSync(configPath, 'utf8'));
+      config = yaml.safeLoad(fs.readFileSync(configPath, 'utf8')) || {};
+      config.rules = config.rules ? config.rules : {};
     }
   }
 
-  configMerge = (config.options && config.options['merge-default-rules'] === false) ? false : true;
-  optionsMerge = (options.options && options.options['merge-default-rules'] === false) ? false : true;
+  // check to see if user config contains an options property and whether property has a property called merge-default-rules
+  configMergeExists = (config.options && typeof config.options['merge-default-rules'] !== 'undefined');
 
-  finalConfig = defaults;
+  // If it does then retrieve the value of it here or return false
+  configMerge = configMergeExists ? config.options['merge-default-rules'] : false;
 
-  if (configMerge) {
-    finalConfig = merge.recursive(defaults, config);
-  }
-  else if (!configMerge) {
-    finalConfig.rules = config.rules ? config.rules : {};
+  // check to see if inline options contains an options property and whether property has a property called merge-default-rules
+  optionsMergeExists = (options.options && typeof options.options['merge-default-rules'] !== 'undefined');
+
+  // If it does then retrieve the value of it here or return false
+  optionsMerge = optionsMergeExists ? options.options['merge-default-rules'] : false;
+
+
+  // order of preference is inline options > user config > default config
+  // merge-default-rules defaults to true so each step above should merge with the previous. If at any step merge-default-rules is set to
+  // false it should skip that steps merge.
+
+  finalConfig = merge.recursive(defaults, config, options);
+
+  // if merge-default-rules is set to false in user config file then we essentially skip the merging with default rules by overwriting our
+  // final rules with the content of our user config otherwise we don't take action here as the default merging has already happened
+  if (configMergeExists && !configMerge) {
+    finalConfig.rules = config.rules;
   }
 
-  if (options && optionsMerge) {
-    finalConfig = merge.recursive(finalConfig, options);
+  // if merge-default-rules is set to false in inline options we essentially skip the merging with our current rules by overwriting our
+  // final rules with the content of our user config otherwise we check to see if merge-default-rules is true OR that we have any inline
+  // rules, if we do then we want to merge these into our final ruleset.
+  if (optionsMergeExists && !optionsMerge) {
+    finalConfig.rules = options.rules;
   }
-  else if (options && !optionsMerge) {
-    finalConfig.rules = options.rules ? options.rules : {};
+  else if ((optionsMergeExists && optionsMerge) || options.rules && Object.keys(options.rules).length > 0) {
+    finalConfig.rules = merge.recursive(finalConfig.rules, options.rules);
   }
 
   return finalConfig;

--- a/lib/config.js
+++ b/lib/config.js
@@ -74,7 +74,7 @@ module.exports = function (options, configPath) {
   if (configMerge) {
     finalConfig = merge.recursive(defaults, config);
   }
-  else if (configMerge) {
+  else if (!configMerge) {
     finalConfig.rules = config.rules ? config.rules : {};
   }
 


### PR DESCRIPTION
Fixes an issue with default rules always being merged into user defined configurations even if `merge-default-rules` is set to false.

Fixes #309

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com