### PR TITLE
Hotfix develop - Add name format rules to config

### DIFF
--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -36,30 +36,32 @@ rules:
   no-vendor-prefixes: 1
   no-warn: 1
 
-  # nesting
+  # Nesting
   force-attribute-nesting: 1
   force-element-nesting: 1
   force-pseudo-nesting: 1
+
+  # Name Formats
+  function-name-format: 1
+  mixin-name-format: 1
+  placeholder-name-format: 1
+  variable-name-format: 1
 
   # Style Guide
   border-zero: 1
   brace-style: 1
   clean-import-paths: 1
   empty-args: 1
-  function-name-format: 1
   hex-length: 1
   hex-notation: 1
   indentation: 1
   leading-zero: 1
   nesting-depth: 1
-  mixin-name-format: 1
-  placeholder-name-format: 1
   property-sort-order: 1
   quotes: 1
   shorthand-values: 1
   url-quotes: 1
   variable-for-property: 1
-  variable-name-format: 1
   zero-unit: 1
 
   # Inner Spacing

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -46,16 +46,20 @@ rules:
   brace-style: 1
   clean-import-paths: 1
   empty-args: 1
+  function-name-format: 1
   hex-length: 1
   hex-notation: 1
   indentation: 1
   leading-zero: 1
   nesting-depth: 1
+  mixin-name-format: 1
+  placeholder-name-format: 1
   property-sort-order: 1
   quotes: 1
   shorthand-values: 1
   url-quotes: 1
   variable-for-property: 1
+  variable-name-format: 1
   zero-unit: 1
 
   # Inner Spacing


### PR DESCRIPTION
Adds the new name-format rules to the config.

function-name-format, mixin-name-format, placeholder-name-format and variable-name-format.

Fixes #315

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com