### PR TITLE
Add rule: class-name-format

### DIFF
--- a/docs/rules/class-name-format.md
+++ b/docs/rules/class-name-format.md
@@ -1,0 +1,205 @@
+# Class Name Format
+
+Rule `class-name-format` will enforce a convention for class names.
+
+## Options
+
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
+[`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/),
+or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
+* `convention-explanation`: Custom explanation to display to the user if a class doesn't adhere to the convention
+* `ignore`: Array of names to ignore
+
+## Example 1
+
+Settings:
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+.hyphenated-lowercase {
+  content: '';
+
+  &.another-hyphenated-lowercase {
+    content: '';
+  }
+}
+
+.foo {
+  @extend .hyphenated-lowercase;
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.camelCase {
+  content: '';
+
+  @extend .snake_case;
+}
+```
+
+## Example 2
+
+Settings:
+- `convention: camelcase`
+
+When enabled, the following are allowed:
+
+```scss
+.camelCase {
+  content: '';
+}
+
+.foo {
+  @extend .anotherCamelCase;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @extend .snake_case;
+}
+```
+
+## Example 3
+
+Settings:
+- `convention: snakecase`
+
+When enabled, the following are allowed:
+
+```scss
+.snake_case {
+  content: '';
+}
+
+.foo {
+  @extend .another_snake_case;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @extend .camelCase;
+}
+```
+
+## Example 4
+
+Settings:
+- `convention: strictbem`
+
+When enabled, the following are allowed:
+
+```scss
+.block-name__elem-name {
+  content: '';
+}
+
+.owner-name_mod-name_mod-val {
+  content: '';
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @extend .camelCase;
+}
+```
+
+## Example 5
+
+Settings:
+- `convention: hyphenatedbem`
+
+When enabled, the following are allowed:
+
+```scss
+.site-search {
+  color: blue;
+  width: 50px;
+  height: 100%;
+}
+
+.site-search__field {
+  text-decoration: underline;
+}
+
+.site-search--full {
+  color: green;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @extend .camelCase;
+}
+```
+
+## Example 6
+
+Settings:
+- `convention: ^[_A-Z]+$`
+- `convention-explanation: 'Class must contain only uppercase letters and underscores'`
+
+When enabled, the following are allowed:
+
+```scss
+.SCREAMING_SNAKE_CASE {
+  content: '';
+}
+
+.foo {
+  @extend .SCREAMING_SNAKE_CASE;
+}
+```
+
+When enabled, the following are disallowed:
+
+(Each line with a variable will report `Class must contain only uppercase letters and underscores` when linted.)
+
+```scss
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.snake_case {
+  content: '';
+}
+
+.foo {
+  @extend .camelCase;
+}
+```

--- a/docs/rules/class-name-format.md
+++ b/docs/rules/class-name-format.md
@@ -7,7 +7,7 @@ Rule `class-name-format` will enforce a convention for class names.
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
 * `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
 [`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/),
-or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
+or a Regular Expression that the class name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a class doesn't adhere to the convention
 * `ignore`: Array of names to ignore
 
@@ -231,7 +231,7 @@ When enabled, the following are allowed:
 
 When enabled, the following are disallowed:
 
-(Each line with a variable will report `Class must contain only uppercase letters and underscores` when linted.)
+(Each line with a class will report `Class must contain only uppercase letters and underscores` when linted.)
 
 ```scss
 .HYPHENATED-UPPERCASE {

--- a/docs/rules/class-name-format.md
+++ b/docs/rules/class-name-format.md
@@ -4,6 +4,7 @@ Rule `class-name-format` will enforce a convention for class names.
 
 ## Options
 
+* `allow-leading-underscore`: `true`/`false` (defaults to `true`)
 * `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
 [`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/),
 or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
@@ -13,6 +14,7 @@ or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
 ## Example 1
 
 Settings:
+- `allow-leading-underscore: true`
 - `convention: hyphenatedlowercase`
 
 When enabled, the following are allowed:
@@ -21,7 +23,7 @@ When enabled, the following are allowed:
 .hyphenated-lowercase {
   content: '';
 
-  &.another-hyphenated-lowercase {
+  &._with-leading-underscore {
     content: '';
   }
 }
@@ -47,6 +49,47 @@ When enabled, the following are disallowed:
 ```
 
 ## Example 2
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+.hyphenated-lowercase {
+  content: '';
+
+  &.another-hyphenated-lowercase {
+    content: '';
+  }
+}
+
+.foo {
+  @extend .hyphenated-lowercase;
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+._with-leading-underscore {
+  content: '';
+}
+
+.HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.camelCase {
+  content: '';
+
+  @extend .snake_case;
+}
+```
+
+## Example 3
 
 Settings:
 - `convention: camelcase`
@@ -75,7 +118,7 @@ When enabled, the following are disallowed:
 }
 ```
 
-## Example 3
+## Example 4
 
 Settings:
 - `convention: snakecase`
@@ -104,7 +147,7 @@ When enabled, the following are disallowed:
 }
 ```
 
-## Example 4
+## Example 5
 
 Settings:
 - `convention: strictbem`
@@ -133,7 +176,7 @@ When enabled, the following are disallowed:
 }
 ```
 
-## Example 5
+## Example 6
 
 Settings:
 - `convention: hyphenatedbem`
@@ -168,7 +211,7 @@ When enabled, the following are disallowed:
 }
 ```
 
-## Example 6
+## Example 7
 
 Settings:
 - `convention: ^[_A-Z]+$`

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -43,6 +43,7 @@ rules:
   force-pseudo-nesting: 1
 
   # Name Formats
+  class-name-format: 1
   function-name-format: 1
   mixin-name-format: 1
   placeholder-name-format: 1

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -139,7 +139,7 @@ helpers.isSnakeCase = function (str) {
 };
 
 helpers.isStrictBEM = function (str) {
-  return /^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?((_[a-z0-9]([-]?[a-z0-9]+)*){2})?$/.test(str);
+  return /^[a-z](\-?[a-z0-9]+)*(__[a-z0-9](\-?[a-z0-9]+)*)?((_[a-z0-9](\-?[a-z0-9]+)*){2})?$/.test(str);
 };
 
 helpers.isHyphenatedBEM = function (str) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -331,4 +331,74 @@ helpers.isNestable = function (currentVal, previousVal, elements, nestable) {
   return false;
 };
 
+/**
+ * Tries to traverse the AST, following a specified path
+ * @param   {ASTNode} node           Starting node
+ * @param   {Array}   traversalPath  Array of Node types to traverse, starting from the first element
+ * @returns {Array-of-ASTNode}       Nodes at the end of the path. Empty array if the traversal failed
+ */
+helpers.attemptTraversal = function (node, traversalPath) {
+  var tmp = [],
+      traversalPathRest = traversalPath.slice(1);
+
+  if (traversalPath.length === 0) {
+    return [node];
+  }
+
+  node.forEach(traversalPath[0], function (child) {
+    tmp = tmp.concat(helpers.attemptTraversal(child, traversalPathRest));
+  });
+
+  return tmp;
+};
+
+/**
+ * Collects all suffix extensions for a selector
+ * @param   {ASTNode} ruleset      ASTNode of type ruleset, containing a selector with nested suffix extensions
+ * @param   {string}  selectorType Node type of the selector (e.g. class, id)
+ * @returns {Array}                Array of all selectors (not including prefixed '.', '#' etc) that result from
+ *                                      the suffix extensions
+ */
+helpers.collectSuffixExtensions = function (ruleset, selectorType) {
+  var parentSelectors = helpers.attemptTraversal(ruleset, ['selector', 'simpleSelector', selectorType, 'ident'])
+        .map(function (node) {
+          return node.content;
+        }),
+      childSuffixes = helpers.attemptTraversal(ruleset, ['block', 'ruleset']),
+      selectorList = [];
+
+  if (parentSelectors.length === 0) {
+    return [];
+  }
+
+  var processChildSuffix = function (child, parents) {
+    var currentParents = [],
+        selectors = helpers.attemptTraversal(child, ['selector', 'simpleSelector']),
+        nestedChildSuffixes = helpers.attemptTraversal(child, ['block', 'ruleset']);
+
+    selectors.forEach(function (childSuffixNode) {
+      if (childSuffixNode.length >= 2 &&
+        childSuffixNode.content[0].is('parentSelector') &&
+        childSuffixNode.content[1].is('ident')) {
+
+        parents.forEach(function (parent) {
+          currentParents.push(parent + childSuffixNode.content[1].content);
+        });
+      }
+    });
+
+    selectorList = selectorList.concat(currentParents);
+
+    nestedChildSuffixes.forEach(function (childSuffix) {
+      processChildSuffix(childSuffix, currentParents);
+    });
+  };
+
+  childSuffixes.forEach(function (childSuffix) {
+    processChildSuffix(childSuffix, parentSelectors);
+  });
+
+  return parentSelectors.concat(selectorList);
+};
+
 module.exports = helpers;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,11 @@ var util = require('util'),
     yaml = require('js-yaml'),
     merge = require('merge');
 
+/**
+ * Easy access to the 'merge' library's cloning functionality
+ * @param   {object} obj Object to clone
+ * @returns {object}     Clone of obj
+ */
 var clone = function (obj) {
   return merge(true, obj);
 };
@@ -131,22 +136,47 @@ helpers.isLowerCase = function (str) {
   return false;
 };
 
+/**
+ * Determines if a given string adheres to camel-case format
+ * @param   {string}  str String to test
+ * @returns {boolean}     Whether str adheres to camel-case format
+ */
 helpers.isCamelCase = function (str) {
   return /^[a-z][a-zA-Z0-9]*$/.test(str);
 };
 
+/**
+ * Determines if a given string adheres to hyphenated-lowercase format
+ * @param   {string}  str String to test
+ * @returns {boolean}     Whether str adheres to hyphenated-lowercase format
+ */
 helpers.isHyphenatedLowercase = function (str) {
   return !(/[^\-a-z0-9]/.test(str));
 };
 
+/**
+ * Determines if a given string adheres to snake-case format
+ * @param   {string}  str String to test
+ * @returns {boolean}     Whether str adheres to snake-case format
+ */
 helpers.isSnakeCase = function (str) {
   return !(/[^_a-z0-9]/.test(str));
 };
 
+/**
+ * Determines if a given string adheres to strict-BEM format
+ * @param   {string}  str String to test
+ * @returns {boolean}     Whether str adheres to strict-BEM format
+ */
 helpers.isStrictBEM = function (str) {
   return /^[a-z](\-?[a-z0-9]+)*(__[a-z0-9](\-?[a-z0-9]+)*)?((_[a-z0-9](\-?[a-z0-9]+)*){2})?$/.test(str);
 };
 
+/**
+ * Determines if a given string adheres to hyphenated-BEM format
+ * @param   {string}  str String to test
+ * @returns {boolean}     Whether str adheres to hyphenated-BEM format
+ */
 helpers.isHyphenatedBEM = function (str) {
   return !(/[A-Z]|-{3}|_{3}|[^_]_[^_]/.test(str));
 };
@@ -338,12 +368,14 @@ helpers.isNestable = function (currentVal, previousVal, elements, nestable) {
 
 /**
  * Tries to traverse the AST, following a specified path
- * @param   {ASTNode} node           Starting node
- * @param   {Array}   traversalPath  Array of Node types to traverse, starting from the first element
- * @returns {Array}                  Nodes at the end of the path. Empty array if the traversal failed
+ * @param   {object}  node           Starting node
+ * @param   {array}   traversalPath  Array of Node types to traverse, starting from the first element
+ * @returns {array}                  Nodes at the end of the path. Empty array if the traversal failed
  */
 helpers.attemptTraversal = function (node, traversalPath) {
-  var i, nextNodeList, currentNodeList = [],
+  var i,
+      nextNodeList,
+      currentNodeList = [],
       processChildNode = function processChildNode (child) {
         child.forEach(traversalPath[i], function (n) {
           nextNodeList.push(n);
@@ -369,9 +401,9 @@ helpers.attemptTraversal = function (node, traversalPath) {
 
 /**
  * Collects all suffix extensions for a selector
- * @param   {ASTNode} ruleset      ASTNode of type ruleset, containing a selector with nested suffix extensions
+ * @param   {object}  ruleset      ASTNode of type ruleset, containing a selector with nested suffix extensions
  * @param   {string}  selectorType Node type of the selector (e.g. class, id)
- * @returns {Array}                Array of Nodes with the content property replaced by the complete selector
+ * @returns {array}                Array of Nodes with the content property replaced by the complete selector
  *                                       (without '.', '#', etc) resulting from suffix extensions
  */
 helpers.collectSuffixExtensions = function (ruleset, selectorType) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -131,7 +131,7 @@ helpers.isCamelCase = function (str) {
 };
 
 helpers.isHyphenatedLowercase = function (str) {
-  return !(/[_A-Z]/.test(str));
+  return !(/[^\-a-z0-9]/.test(str));
 };
 
 helpers.isSnakeCase = function (str) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -138,6 +138,14 @@ helpers.isSnakeCase = function (str) {
   return !(/[^_a-z0-9]/.test(str));
 };
 
+helpers.isStrictBEM = function (str) {
+  return /^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?((_[a-z0-9]([-]?[a-z0-9]+)*){2})?$/.test(str);
+};
+
+helpers.isHyphenatedBEM = function (str) {
+  return !(/[A-Z]|-{3}|_{3}|[^_]_[^_]/.test(str));
+};
+
 helpers.isValidHex = function (str) {
   if (str.match(/^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
     return true;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,12 @@
 var util = require('util'),
     fs = require('fs'),
     path = require('path'),
-    yaml = require('js-yaml');
+    yaml = require('js-yaml'),
+    merge = require('merge');
+
+var clone = function (obj) {
+  return merge(true, obj);
+};
 
 var helpers = {};
 
@@ -335,35 +340,42 @@ helpers.isNestable = function (currentVal, previousVal, elements, nestable) {
  * Tries to traverse the AST, following a specified path
  * @param   {ASTNode} node           Starting node
  * @param   {Array}   traversalPath  Array of Node types to traverse, starting from the first element
- * @returns {Array-of-ASTNode}       Nodes at the end of the path. Empty array if the traversal failed
+ * @returns {Array}                  Nodes at the end of the path. Empty array if the traversal failed
  */
 helpers.attemptTraversal = function (node, traversalPath) {
-  var tmp = [],
-      traversalPathRest = traversalPath.slice(1);
+  var i, nextNodeList, currentNodeList = [],
+      processChildNode = function processChildNode (child) {
+        child.forEach(traversalPath[i], function (n) {
+          nextNodeList.push(n);
+        });
+      };
 
-  if (traversalPath.length === 0) {
-    return [node];
-  }
-
-  node.forEach(traversalPath[0], function (child) {
-    tmp = tmp.concat(helpers.attemptTraversal(child, traversalPathRest));
+  node.forEach(traversalPath[0], function (n) {
+    currentNodeList.push(n);
   });
 
-  return tmp;
+  for (i = 1; i < traversalPath.length; i++) {
+    if (currentNodeList.length === 0) {
+      return [];
+    }
+
+    nextNodeList = [];
+    currentNodeList.forEach(processChildNode);
+    currentNodeList = nextNodeList;
+  }
+
+  return currentNodeList;
 };
 
 /**
  * Collects all suffix extensions for a selector
  * @param   {ASTNode} ruleset      ASTNode of type ruleset, containing a selector with nested suffix extensions
  * @param   {string}  selectorType Node type of the selector (e.g. class, id)
- * @returns {Array}                Array of all selectors (not including prefixed '.', '#' etc) that result from
- *                                      the suffix extensions
+ * @returns {Array}                Array of Nodes with the content property replaced by the complete selector
+ *                                       (without '.', '#', etc) resulting from suffix extensions
  */
 helpers.collectSuffixExtensions = function (ruleset, selectorType) {
-  var parentSelectors = helpers.attemptTraversal(ruleset, ['selector', 'simpleSelector', selectorType, 'ident'])
-        .map(function (node) {
-          return node.content;
-        }),
+  var parentSelectors = helpers.attemptTraversal(ruleset, ['selector', 'simpleSelector', selectorType, 'ident']),
       childSuffixes = helpers.attemptTraversal(ruleset, ['block', 'ruleset']),
       selectorList = [];
 
@@ -371,18 +383,27 @@ helpers.collectSuffixExtensions = function (ruleset, selectorType) {
     return [];
   }
 
+  // Goes recursively through all nodes that look like suffix extensions. There may be multiple parents that are
+  // extended, so lots of looping is required.
   var processChildSuffix = function (child, parents) {
     var currentParents = [],
         selectors = helpers.attemptTraversal(child, ['selector', 'simpleSelector']),
         nestedChildSuffixes = helpers.attemptTraversal(child, ['block', 'ruleset']);
 
     selectors.forEach(function (childSuffixNode) {
-      if (childSuffixNode.length >= 2 &&
-        childSuffixNode.content[0].is('parentSelector') &&
-        childSuffixNode.content[1].is('ident')) {
+      var extendedNode;
 
+      if (childSuffixNode.length >= 2 &&
+        childSuffixNode.contains('parentSelector') &&
+        childSuffixNode.contains('ident')) {
+
+        // append suffix extension to all parent selectors
         parents.forEach(function (parent) {
-          currentParents.push(parent + childSuffixNode.content[1].content);
+          // clone so we don't modify the actual AST
+          extendedNode = clone(childSuffixNode.first('ident'));
+          extendedNode.content = parent.content + extendedNode.content;
+
+          currentParents.push(extendedNode);
         });
       }
     });

--- a/lib/rules/class-name-format.js
+++ b/lib/rules/class-name-format.js
@@ -1,0 +1,74 @@
+// Note that this file is nearly identical to id-name-format.js and attribute-name-format.js
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'class-name-format',
+  'defaults': {
+    'convention': 'hyphenatedlowercase',
+    'convention-explanation': false,
+    'ignore': []
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('class', function (node) {
+      var name = node.first().content,
+          violationMessage = false;
+
+      if (parser.options.ignore.indexOf(name) !== -1) {
+        return;
+      }
+
+      switch (parser.options.convention) {
+      case 'hyphenatedlowercase':
+        if (!helpers.isHyphenatedLowercase(name)) {
+          violationMessage = 'Class \'.' + name + '\' should be written in lowercase with hyphens';
+        }
+        break;
+      case 'camelcase':
+        if (!helpers.isCamelCase(name)) {
+          violationMessage = 'Class \'.' + name + '\' should be written in camelCase';
+        }
+        break;
+      case 'snakecase':
+        if (!helpers.isSnakeCase(name)) {
+          violationMessage = 'Class \'.' + name + '\' should be written in snake_case';
+        }
+        break;
+      case 'strictbem':
+        if (!helpers.isStrictBEM(name)) {
+          violationMessage = 'Class \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+        }
+        break;
+      case 'hyphenatedbem':
+        if (!helpers.isHyphenatedBEM(name)) {
+          violationMessage = 'Class \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+        }
+        break;
+      default:
+        if (!(new RegExp(parser.options.convention).test(name))) {
+          violationMessage = 'Class \'.' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+          // convention-message overrides violationMessage
+          if (parser.options['convention-explanation']) {
+            violationMessage = parser.options['convention-explanation'];
+          }
+        }
+      }
+
+      if (violationMessage) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': violationMessage,
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/class-name-format.js
+++ b/lib/rules/class-name-format.js
@@ -14,67 +14,71 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('class', function (node) {
-      var name = node.first().content,
-          strippedName,
-          violationMessage = false;
+    ast.traverseByType('ruleset', function (ruleset) {
+      var selectorAndExtensions = helpers.collectSuffixExtensions(ruleset, 'class');
 
-      if (parser.options.ignore.indexOf(name) !== -1) {
-        return;
-      }
+      selectorAndExtensions.forEach(function (node) {
+        var name = node.content,
+            strippedName,
+            violationMessage = false;
 
-      strippedName = name;
+        if (parser.options.ignore.indexOf(name) !== -1) {
+          return;
+        }
 
-      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
-        strippedName = name.slice(1);
-      }
+        strippedName = name;
 
-      switch (parser.options.convention) {
-      case 'hyphenatedlowercase':
-        if (!helpers.isHyphenatedLowercase(strippedName)) {
-          violationMessage = 'Class \'.' + name + '\' should be written in lowercase with hyphens';
+        if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+          strippedName = name.slice(1);
         }
-        break;
-      case 'camelcase':
-        if (!helpers.isCamelCase(strippedName)) {
-          violationMessage = 'Class \'.' + name + '\' should be written in camelCase';
-        }
-        break;
-      case 'snakecase':
-        if (!helpers.isSnakeCase(strippedName)) {
-          violationMessage = 'Class \'.' + name + '\' should be written in snake_case';
-        }
-        break;
-      case 'strictbem':
-        if (!helpers.isStrictBEM(strippedName)) {
-          violationMessage = 'Class \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
-        }
-        break;
-      case 'hyphenatedbem':
-        if (!helpers.isHyphenatedBEM(strippedName)) {
-          violationMessage = 'Class \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
-        }
-        break;
-      default:
-        if (!(new RegExp(parser.options.convention).test(strippedName))) {
-          violationMessage = 'Class \'.' + name + '\' should match regular expression /' + parser.options.convention + '/';
 
-          // convention-message overrides violationMessage
-          if (parser.options['convention-explanation']) {
-            violationMessage = parser.options['convention-explanation'];
+        switch (parser.options.convention) {
+        case 'hyphenatedlowercase':
+          if (!helpers.isHyphenatedLowercase(strippedName)) {
+            violationMessage = 'Class \'.' + name + '\' should be written in lowercase with hyphens';
+          }
+          break;
+        case 'camelcase':
+          if (!helpers.isCamelCase(strippedName)) {
+            violationMessage = 'Class \'.' + name + '\' should be written in camelCase';
+          }
+          break;
+        case 'snakecase':
+          if (!helpers.isSnakeCase(strippedName)) {
+            violationMessage = 'Class \'.' + name + '\' should be written in snake_case';
+          }
+          break;
+        case 'strictbem':
+          if (!helpers.isStrictBEM(strippedName)) {
+            violationMessage = 'Class \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+          }
+          break;
+        case 'hyphenatedbem':
+          if (!helpers.isHyphenatedBEM(strippedName)) {
+            violationMessage = 'Class \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+          }
+          break;
+        default:
+          if (!(new RegExp(parser.options.convention).test(strippedName))) {
+            violationMessage = 'Class \'.' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+            // convention-message overrides violationMessage
+            if (parser.options['convention-explanation']) {
+              violationMessage = parser.options['convention-explanation'];
+            }
           }
         }
-      }
 
-      if (violationMessage) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': node.start.line,
-          'column': node.start.column,
-          'message': violationMessage,
-          'severity': parser.severity
-        });
-      }
+        if (violationMessage) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': violationMessage,
+            'severity': parser.severity
+          });
+        }
+      });
     });
 
     return result;

--- a/lib/rules/class-name-format.js
+++ b/lib/rules/class-name-format.js
@@ -6,6 +6,7 @@ var helpers = require('../helpers');
 module.exports = {
   'name': 'class-name-format',
   'defaults': {
+    'allow-leading-underscore': true,
     'convention': 'hyphenatedlowercase',
     'convention-explanation': false,
     'ignore': []
@@ -15,40 +16,47 @@ module.exports = {
 
     ast.traverseByType('class', function (node) {
       var name = node.first().content,
+          strippedName,
           violationMessage = false;
 
       if (parser.options.ignore.indexOf(name) !== -1) {
         return;
       }
 
+      strippedName = name;
+
+      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+        strippedName = name.slice(1);
+      }
+
       switch (parser.options.convention) {
       case 'hyphenatedlowercase':
-        if (!helpers.isHyphenatedLowercase(name)) {
+        if (!helpers.isHyphenatedLowercase(strippedName)) {
           violationMessage = 'Class \'.' + name + '\' should be written in lowercase with hyphens';
         }
         break;
       case 'camelcase':
-        if (!helpers.isCamelCase(name)) {
+        if (!helpers.isCamelCase(strippedName)) {
           violationMessage = 'Class \'.' + name + '\' should be written in camelCase';
         }
         break;
       case 'snakecase':
-        if (!helpers.isSnakeCase(name)) {
+        if (!helpers.isSnakeCase(strippedName)) {
           violationMessage = 'Class \'.' + name + '\' should be written in snake_case';
         }
         break;
       case 'strictbem':
-        if (!helpers.isStrictBEM(name)) {
+        if (!helpers.isStrictBEM(strippedName)) {
           violationMessage = 'Class \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
         }
         break;
       case 'hyphenatedbem':
-        if (!helpers.isHyphenatedBEM(name)) {
+        if (!helpers.isHyphenatedBEM(strippedName)) {
           violationMessage = 'Class \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
         }
         break;
       default:
-        if (!(new RegExp(parser.options.convention).test(name))) {
+        if (!(new RegExp(parser.options.convention).test(strippedName))) {
           violationMessage = 'Class \'.' + name + '\' should match regular expression /' + parser.options.convention + '/';
 
           // convention-message overrides violationMessage

--- a/lib/rules/class-name-format.js
+++ b/lib/rules/class-name-format.js
@@ -1,4 +1,3 @@
-// Note that this file is nearly identical to id-name-format.js and attribute-name-format.js
 'use strict';
 
 var helpers = require('../helpers');

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1573,6 +1573,25 @@ describe('helpers', function () {
     done();
   });
 
+  it('collectSuffixExtensions - no extensions', function () {
+    var ruleset = gonzales.parse(['',
+      '.a {\n',
+      '  .b {\n',
+      '    .c {\n',
+      '      width: 2px;\n',
+      '    }\n',
+      '  }\n',
+      '}\n'].join(''), { syntax: 'scss' })
+      .first('ruleset');
+
+    assert.deepEqual(
+      helpers.collectSuffixExtensions(ruleset, 'class').map(function (node) {
+        return node.content;
+      }),
+      ['a']
+    );
+  });
+
   it('collectSuffixExtensions - BEM example', function () {
     var ruleset = gonzales.parse(['',
       '.block {\n',
@@ -1585,8 +1604,32 @@ describe('helpers', function () {
       .first('ruleset');
 
     assert.deepEqual(
-      helpers.collectSuffixExtensions(ruleset, 'class'),
+      helpers.collectSuffixExtensions(ruleset, 'class').map(function (node) {
+        return node.content;
+      }),
       ['block', 'block__element', 'block__element--modifier']
+    );
+  });
+
+  it('collectSuffixExtensions - many parents and children', function () {
+    var ruleset = gonzales.parse(['',
+      '.a,\n',
+      '.b {\n',
+      '  &c,\n',
+      '  &d {\n',
+      '    &e,\n',
+      '    &f {\n',
+      '      width: 2px;\n',
+      '    }\n',
+      '  }\n',
+      '}\n'].join(''), { syntax: 'scss' })
+      .first('ruleset');
+
+    assert.deepEqual(
+      helpers.collectSuffixExtensions(ruleset, 'class').map(function (node) {
+        return node.content;
+      }),
+      ['a', 'b', 'ac', 'bc', 'ad', 'bd', 'ace', 'bce', 'ade', 'bde', 'acf', 'bcf', 'adf', 'bdf']
     );
   });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1574,6 +1574,44 @@ describe('helpers', function () {
   });
 
   //////////////////////////////
+  // attemptTraversal
+  //////////////////////////////
+  it('attemptTraversal - collect all nodes', function () {
+    var stylesheet = gonzales.parse(['',
+      '.a {',
+      '  .b {',
+      '    color: red;',
+      '  }',
+      '  .c {',
+      '    color: blue;',
+      '  }',
+      '  .d {',
+      '    color: green;',
+      '  }',
+      '}'].join('\n'), { syntax: 'scss' });
+
+    assert.deepEqual(
+      helpers.attemptTraversal(stylesheet, ['ruleset', 'block', 'ruleset', 'block', 'declaration', 'property', 'ident'])
+        .map(function (node) {
+          return node.content;
+        }),
+      ['color', 'color', 'color']
+    );
+  });
+
+  it('attemptTraversal - empty array when traversal fails', function () {
+    var stylesheet = gonzales.parse(['',
+      '.a {',
+      '  color: red;',
+      '}'].join('\n'), { syntax: 'scss' });
+
+    assert.equal(
+      helpers.attemptTraversal(stylesheet, ['ruleset', 'block', 'ruleset', 'block']).length,
+      0
+    );
+  });
+
+  //////////////////////////////
   // collectSuffixExtensions
   //////////////////////////////
   it('collectSuffixExtensions - no extensions', function () {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1572,4 +1572,21 @@ describe('helpers', function () {
     assert.equal(expect, result.type);
     done();
   });
+
+  it('collectSuffixExtensions - BEM example', function () {
+    var ruleset = gonzales.parse(['',
+      '.block {\n',
+      '  &__element {\n',
+      '    &--modifier {\n',
+      '      width: 2px;\n',
+      '    }\n',
+      '  }\n',
+      '}\n'].join(''), { syntax: 'scss' })
+      .first('ruleset');
+
+    assert.deepEqual(
+      helpers.collectSuffixExtensions(ruleset, 'class'),
+      ['block', 'block__element', 'block__element--modifier']
+    );
+  });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -823,6 +823,22 @@ describe('helpers', function () {
     done();
   });
 
+  it('isHyphenatedLowercase - [\'abc-\\31\\32\\33\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('abc-\\31\\32\\33');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedLowercase - [\'abc-\\+\\*\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedLowercase('abc-\\+\\*');
+
+    assert.equal(false, result);
+    done();
+  });
+
   //////////////////////////////
   // isSnakeCase
   //////////////////////////////

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -892,6 +892,198 @@ describe('helpers', function () {
   });
 
   //////////////////////////////
+  // isHyphenatedBEM
+  //////////////////////////////
+
+  it('isHyphenatedBEM - [\'TEST\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('TEST');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'test\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('test');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [abcDEF - false]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('abcDEF');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'abc---def\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('abc---def');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'abc___def\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('abc___def');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'ab__cd__ef\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('ab__cd__ef');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'ab__cd--ef\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('ab__cd--ef');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'abc_def\' - false]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('abc_def');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'abc-def\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('abc-def');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isHyphenatedBEM - [\'ab-cd__ef\' - true]', function (done) {
+
+    var result = helpers.isHyphenatedBEM('ab-cd__ef');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  //////////////////////////////
+  // isStrictBEM
+  //////////////////////////////
+
+  it('isStrictBEM - [\'TEST\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('TEST');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'test\' - true]', function (done) {
+
+    var result = helpers.isStrictBEM('test');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isStrictBEM - [abcDEF - false]', function (done) {
+
+    var result = helpers.isStrictBEM('abcDEF');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'abc---def\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('abc---def');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'abc___def\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('abc___def');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'ab__cd__ef\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('ab__cd__ef');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'ab__cd--ef\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('ab__cd--ef');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'ab__cd_ef_gh\' - true]', function (done) {
+
+    var result = helpers.isStrictBEM('ab__cd_ef_gh');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'ab-cd-ef__gh-ij-kl_mn-op-qr_st-uv-wx\' - true]', function (done) {
+
+    var result = helpers.isStrictBEM('ab-cd-ef__gh-ij-kl_mn-op-qr_st-uv-wx');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'ab__cd_ef_gh_ij\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('ab__cd_ef_gh_ij');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'abc_def\' - false]', function (done) {
+
+    var result = helpers.isStrictBEM('abc_def');
+
+    assert.equal(false, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'abc-def\' - true]', function (done) {
+
+    var result = helpers.isStrictBEM('abc-def');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  it('isStrictBEM - [\'ab-cd__ef\' - true]', function (done) {
+
+    var result = helpers.isStrictBEM('ab-cd__ef');
+
+    assert.equal(true, result);
+    done();
+  });
+
+  //////////////////////////////
   // isValidHex
   //////////////////////////////
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1573,15 +1573,18 @@ describe('helpers', function () {
     done();
   });
 
+  //////////////////////////////
+  // collectSuffixExtensions
+  //////////////////////////////
   it('collectSuffixExtensions - no extensions', function () {
     var ruleset = gonzales.parse(['',
-      '.a {\n',
-      '  .b {\n',
-      '    .c {\n',
-      '      width: 2px;\n',
-      '    }\n',
-      '  }\n',
-      '}\n'].join(''), { syntax: 'scss' })
+      '.a {',
+      '  .b {',
+      '    .c {',
+      '      width: 2px;',
+      '    }',
+      '  }',
+      '}'].join('\n'), { syntax: 'scss' })
       .first('ruleset');
 
     assert.deepEqual(
@@ -1594,13 +1597,13 @@ describe('helpers', function () {
 
   it('collectSuffixExtensions - BEM example', function () {
     var ruleset = gonzales.parse(['',
-      '.block {\n',
-      '  &__element {\n',
-      '    &--modifier {\n',
-      '      width: 2px;\n',
-      '    }\n',
-      '  }\n',
-      '}\n'].join(''), { syntax: 'scss' })
+      '.block {',
+      '  &__element {',
+      '    &--modifier {',
+      '      width: 2px;',
+      '    }',
+      '  }',
+      '}'].join('\n'), { syntax: 'scss' })
       .first('ruleset');
 
     assert.deepEqual(
@@ -1613,16 +1616,16 @@ describe('helpers', function () {
 
   it('collectSuffixExtensions - many parents and children', function () {
     var ruleset = gonzales.parse(['',
-      '.a,\n',
-      '.b {\n',
-      '  &c,\n',
-      '  &d {\n',
-      '    &e,\n',
-      '    &f {\n',
-      '      width: 2px;\n',
-      '    }\n',
-      '  }\n',
-      '}\n'].join(''), { syntax: 'scss' })
+      '.a,',
+      '.b {',
+      '  &c,',
+      '  &d {',
+      '    &e,',
+      '    &f {',
+      '      width: 2px;',
+      '    }',
+      '  }',
+      '}'].join('\n'), { syntax: 'scss' })
       .first('ruleset');
 
     assert.deepEqual(

--- a/tests/rules/class-name-format.js
+++ b/tests/rules/class-name-format.js
@@ -2,6 +2,9 @@
 
 var lint = require('./_lint');
 
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
 describe('class name format - scss', function () {
   var file = lint.file('class-name-format.scss');
 
@@ -116,6 +119,9 @@ describe('class name format - scss', function () {
   });
 });
 
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
 describe('class name format - sass', function () {
   var file = lint.file('class-name-format.sass');
 

--- a/tests/rules/class-name-format.js
+++ b/tests/rules/class-name-format.js
@@ -9,7 +9,21 @@ describe('class name format - scss', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(21, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedlowercase with ignore]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'ignore': ['block__element--modifier']
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
       done();
     });
   });
@@ -23,7 +37,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(30, data.warningCount);
       done();
     });
   });
@@ -37,7 +51,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(25, data.warningCount);
       done();
     });
   });
@@ -51,7 +65,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -65,7 +79,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -75,12 +89,28 @@ describe('class name format - scss', function () {
       'class-name-format': [
         1,
         {
-          'convention': '^[_A-Z]+$',
-          'convention-explanation': 'Its bad and you should feel bad.'
+          'convention': '^[_A-Z]+$'
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(31, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$], with convention-explanation', function (done) {
+    var message = 'Its bad and you should feel bad.';
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': message
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(27, data.warningCount);
+      lint.assert.equal(data.messages[0].message, message);
       done();
     });
   });
@@ -93,7 +123,21 @@ describe('class name format - sass', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(21, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedlowercase with ignore]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'ignore': ['block__element--modifier']
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
       done();
     });
   });
@@ -107,7 +151,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(30, data.warningCount);
       done();
     });
   });
@@ -121,7 +165,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(25, data.warningCount);
       done();
     });
   });
@@ -135,7 +179,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -149,7 +193,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -159,12 +203,28 @@ describe('class name format - sass', function () {
       'class-name-format': [
         1,
         {
-          'convention': '^[_A-Z]+$',
-          'convention-explanation': 'Its bad and you should feel bad.'
+          'convention': '^[_A-Z]+$'
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(31, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$], with convention-explanation', function (done) {
+    var message = 'Its bad and you should feel bad.';
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': message
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(27, data.warningCount);
+      lint.assert.equal(data.messages[0].message, message);
       done();
     });
   });

--- a/tests/rules/class-name-format.js
+++ b/tests/rules/class-name-format.js
@@ -9,7 +9,7 @@ describe('class name format - scss', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -51,7 +51,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -93,7 +93,7 @@ describe('class name format - sass', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -135,7 +135,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });

--- a/tests/rules/class-name-format.js
+++ b/tests/rules/class-name-format.js
@@ -12,7 +12,7 @@ describe('class name format - scss', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(21, data.warningCount);
+      lint.assert.equal(24, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(20, data.warningCount);
+      lint.assert.equal(23, data.warningCount);
       done();
     });
   });
@@ -40,7 +40,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(30, data.warningCount);
+      lint.assert.equal(34, data.warningCount);
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(25, data.warningCount);
+      lint.assert.equal(29, data.warningCount);
       done();
     });
   });
@@ -68,7 +68,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(19, data.warningCount);
       done();
     });
   });
@@ -96,7 +96,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(31, data.warningCount);
+      lint.assert.equal(35, data.warningCount);
       done();
     });
   });
@@ -112,7 +112,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(27, data.warningCount);
+      lint.assert.equal(31, data.warningCount);
       lint.assert.equal(data.messages[0].message, message);
       done();
     });
@@ -129,7 +129,7 @@ describe('class name format - sass', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(21, data.warningCount);
+      lint.assert.equal(24, data.warningCount);
       done();
     });
   });
@@ -143,7 +143,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(20, data.warningCount);
+      lint.assert.equal(23, data.warningCount);
       done();
     });
   });
@@ -157,7 +157,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(30, data.warningCount);
+      lint.assert.equal(34, data.warningCount);
       done();
     });
   });
@@ -171,7 +171,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(25, data.warningCount);
+      lint.assert.equal(29, data.warningCount);
       done();
     });
   });
@@ -185,7 +185,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(19, data.warningCount);
       done();
     });
   });
@@ -213,7 +213,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(31, data.warningCount);
+      lint.assert.equal(35, data.warningCount);
       done();
     });
   });
@@ -229,7 +229,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(27, data.warningCount);
+      lint.assert.equal(31, data.warningCount);
       lint.assert.equal(data.messages[0].message, message);
       done();
     });

--- a/tests/rules/class-name-format.js
+++ b/tests/rules/class-name-format.js
@@ -1,0 +1,171 @@
+'use strict';
+
+var lint = require('./_lint');
+
+describe('class name format - scss', function () {
+  var file = lint.file('class-name-format.scss');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'class-name-format': 1
+    }, function (data) {
+      lint.assert.equal(11, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+});
+
+describe('class name format - sass', function () {
+  var file = lint.file('class-name-format.sass');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'class-name-format': 1
+    }, function (data) {
+      lint.assert.equal(11, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'class-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': 'Its bad and you should feel bad.'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/class-name-format.sass
+++ b/tests/sass/class-name-format.sass
@@ -29,6 +29,13 @@
   &__element
     &--modifier
       color: green
+  &__another-element
+    &--modifier
+      color: red
+    &--another-modifier
+      color: yellow
+  &--non-element-modifier
+    color: blue
 
 .owner-name_mod-name_mod-val
   content: ''

--- a/tests/sass/class-name-format.sass
+++ b/tests/sass/class-name-format.sass
@@ -10,11 +10,11 @@
 .PascalCase
   content: ''
 
-.Camel_Snake_Case
-  content: ''
+  .Camel_Snake_Case
+    content: ''
 
-.SCREAMING_SNAKE_CASE
-  content: ''
+    .SCREAMING_SNAKE_CASE
+      content: ''
 
 ._with-leading-underscore
   content: ''
@@ -25,8 +25,18 @@
 .block-name__elem-name
   content: ''
 
+.block
+  &__element
+    &--modifier
+      color: green
+
 .owner-name_mod-name_mod-val
   content: ''
+
+.owner-name
+  &_mod-name
+    &_mod-val
+      color: blue
 
 .site-search
   color: blue
@@ -38,3 +48,24 @@
 
 .site-search--full
   color: green
+
+.hyphentated-lowercase
+  color: blue
+
+  &-with-suffix-extension
+    color: green
+
+    &-and-another
+      color: red
+
+  &-INVALID
+    color: pink
+
+.one_parent,
+.two_parents,
+.third-invalid-parent
+  width: 10px
+
+  &_valid_child,
+  &-invalid-child
+    height: 10px

--- a/tests/sass/class-name-format.sass
+++ b/tests/sass/class-name-format.sass
@@ -1,0 +1,40 @@
+.hyphenated-lowercase
+  content: ''
+
+.snake_case
+  content: ''
+
+.camelCase
+  content: ''
+
+.PascalCase
+  content: ''
+
+.Camel_Snake_Case
+  content: ''
+
+.SCREAMING_SNAKE_CASE
+  content: ''
+
+._with-leading-underscore
+  content: ''
+
+._does_NOT-fitSTANDARD
+  @extend .snake_case
+
+.block-name__elem-name
+  content: ''
+
+.owner-name_mod-name_mod-val
+  content: ''
+
+.site-search
+  color: blue
+  width: 50px
+  height: 100%
+
+.site-search__field
+  text-decoration: underline
+
+.site-search--full
+  color: green

--- a/tests/sass/class-name-format.scss
+++ b/tests/sass/class-name-format.scss
@@ -40,6 +40,20 @@
       color: green;
     }
   }
+
+  &__another-element {
+    &--modifier {
+      color: red;
+    }
+
+    &--another-modifier {
+      color: yellow;
+    }
+  }
+
+  &--non-element-modifier {
+    color: blue;
+  }
 }
 
 .owner-name_mod-name_mod-val {

--- a/tests/sass/class-name-format.scss
+++ b/tests/sass/class-name-format.scss
@@ -34,8 +34,24 @@
   content: '';
 }
 
+.block {
+  &__element {
+    &--modifier {
+      color: green;
+    }
+  }
+}
+
 .owner-name_mod-name_mod-val {
   content: '';
+}
+
+.owner-name {
+  &_mod-name {
+    &_mod-val {
+      color: blue;
+    }
+  }
 }
 
 .site-search {
@@ -50,4 +66,31 @@
 
 .site-search--full {
   color: green;
+}
+
+.hyphentated-lowercase {
+  color: blue;
+
+  &-with-suffix-extension {
+    color: green;
+
+    &-and-another {
+      color: red;
+    }
+  }
+
+  &-INVALID {
+    color: pink;
+  }
+}
+
+.one_parent,
+.two_parents,
+.third-invalid-parent {
+  width: 10px;
+
+  &_valid_child,
+  &-invalid-child {
+    height: 10px;
+  }
 }

--- a/tests/sass/class-name-format.scss
+++ b/tests/sass/class-name-format.scss
@@ -1,0 +1,53 @@
+.hyphenated-lowercase {
+  content: '';
+}
+
+.snake_case {
+  content: '';
+}
+
+.camelCase {
+  content: '';
+}
+
+.PascalCase {
+  content: '';
+
+  .Camel_Snake_Case {
+    content: '';
+
+    .SCREAMING_SNAKE_CASE {
+      content: '';
+    }
+  }
+}
+
+._with-leading-underscore {
+  content: '';
+}
+
+._does_NOT-fitSTANDARD {
+  @extend .snake_case;
+}
+
+.block-name__elem-name {
+  content: '';
+}
+
+.owner-name_mod-name_mod-val {
+  content: '';
+}
+
+.site-search {
+  color: blue;
+  width: 50px;
+  height: 100%;
+}
+
+.site-search__field {
+  text-decoration: underline;
+}
+
+.site-search--full {
+  color: green;
+}

--- a/tests/yml/.merge-default-rules-false.yml
+++ b/tests/yml/.merge-default-rules-false.yml
@@ -1,0 +1,2 @@
+options:
+  merge-default-rules: false

--- a/tests/yml/.merge-default-rules-false.yml
+++ b/tests/yml/.merge-default-rules-false.yml
@@ -1,2 +1,0 @@
-options:
-  merge-default-rules: false


### PR DESCRIPTION
Slightly different than the other `name-format` rules. It adds `ignore`, an array of whitelisted names.

- [X] Add `allow-leading-underscore` back in
- [x] Add rule to `lib/config/sass-lint.yml`
- [x] Still need to add unit tests for the two helper functions I added.
- [x] More test examples
- [x] Handle suffix extensions to selectors

I welcome feedback on the documentation, as I'm not very familiar with BEM.

Will close #324 

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>