### PR TITLE
Update property sort order

### DIFF
--- a/docs/rules/property-sort-order.md
+++ b/docs/rules/property-sort-order.md
@@ -5,6 +5,7 @@ Rule `property-sort-order` will enforce the order in which declarations are writ
 ## Options
 
 * `order`: `'alphabetical'`, [`'concentric'`](http://rhodesmill.org/brandon/2011/concentric-css/), [`'recess'`](http://twitter.github.io/recess/), [`'smacss'`](http://smacss.com/book/formatting), or `[array of properties]` (defaults to `alphabetical`. Unknown properties are sorted alphabetically)
+* `ignore-custom-properties`: `true`/`false` (defaults to `false`)
 
 Property orders: https://github.com/sasstools/sass-lint/tree/develop/lib/config/property-sort-orders
 
@@ -27,5 +28,74 @@ When enabled (assuming `order: alphabetical`), the following are disallowed:
   width: 100vw;
   height: 100vh;
   content: 'baz';
+}
+```
+
+### Custom Sort Orders
+
+You have the option to create your own custom property sort orders. These are specified in your `.sass-lint.yml` file as below:
+
+```yaml
+property-sort-order:
+  - 1
+  -
+    order:
+      - border
+      - display
+      - color
+```
+
+When the custom order is specified as above, the following are allowed:
+
+```scss
+.foo {
+  border: 1px solid blue;
+  display: block;
+  color: red;
+}
+```
+
+When the custom order is specified as above, the following are disallowed:
+
+```scss
+.foo {
+  display: block;
+  color: red;
+  border: 1px solid blue;
+}
+```
+
+### Ignore Custom Properties
+
+When `ignore-custom-properties: false` (assume `order: 'alphabetical'`) the following would be allowed
+
+```scss
+.foo {
+  border: 1px solid blue;
+  color: red;
+  composes: heading;
+  display: block;
+}
+```
+
+When `ignore-custom-properties: false` (assume `order: 'alphabetical'`) the following would be disallowed
+
+```scss
+.foo {
+  composes: heading; // not in alphabetical order
+  border: 1px solid blue;
+  color: red;
+  display: block;
+}
+```
+
+When `ignore-custom-properties: true` (assume `order: 'alphabetical'`) the following would be allowed
+
+```scss
+.foo {
+  composes: heading; // custom properties ignored
+  border: 1px solid blue;
+  color: red;
+  display: block;
 }
 ```

--- a/docs/sass-lint.yml
+++ b/docs/sass-lint.yml
@@ -38,6 +38,13 @@ rules:
     - 2
     -
       size: 2
+  property-sort-order:
+    - 1
+    -
+      order:
+        - display
+        - margin
+      ignore-custom-properties: true
   variable-for-property:
     - 2
     -

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -1,6 +1,11 @@
 'use strict';
 
-var helpers = require('../helpers');
+var helpers = require('../helpers'),
+    yaml = require('js-yaml'),
+    fs = require('fs'),
+    path = require('path');
+
+var propertyCheckList = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
 
 var orderPresets = {
   'recess': 'recess.yml',
@@ -102,7 +107,11 @@ module.exports = {
               name = prop.first('ident');
 
           if (name) {
-            properties[name.content] = prop;
+
+            if (propertyCheckList.indexOf(name.content) !== -1) {
+              properties[name.content] = prop;
+            }
+
           }
         });
 

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -89,7 +89,8 @@ var sortProperties = function (obj, order) {
 module.exports = {
   'name': 'property-sort-order',
   'defaults': {
-    'order': 'alphabetical'
+    'order': 'alphabetical',
+    'ignore-custom-properties': false
   },
   'detect': function (ast, parser) {
     var result = [],
@@ -107,11 +108,14 @@ module.exports = {
               name = prop.first('ident');
 
           if (name) {
-
-            if (propertyCheckList.indexOf(name.content) !== -1) {
+            if (parser.options['ignore-custom-properties']) {
+              if (propertyCheckList.indexOf(name.content) !== -1) {
+                properties[name.content] = prop;
+              }
+            }
+            else {
               properties[name.content] = prop;
             }
-
           }
         });
 

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -12,6 +12,20 @@ describe('property sort order - scss', function () {
     lint.test(file, {
       'property-sort-order': 1
     }, function (data) {
+      lint.assert.equal(15, data.warningCount);
+      done();
+    });
+  });
+
+  it('[order: alphabetical, ignore-custom-properties: true]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'ignore-custom-properties': true
+        }
+      ]
+    }, function (data) {
       lint.assert.equal(12, data.warningCount);
       done();
     });
@@ -36,6 +50,47 @@ describe('property sort order - scss', function () {
     });
   });
 
+  it('[order: custom + composes, ignore-custom-properties: false]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'height',
+            'composes',
+            'width',
+            'display',
+            'color'
+          ],
+          'ignore-custom-properties': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[order: custom + composes, ignore-custom-properties: true]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'height',
+            'width',
+            'display',
+            'color'
+          ],
+          'ignore-custom-properties': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
   it('[order: recess]', function (done) {
     lint.test(file, {
       'property-sort-order': [
@@ -45,7 +100,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -59,7 +114,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -73,7 +128,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -89,6 +144,20 @@ describe('property sort order - sass', function () {
     lint.test(file, {
       'property-sort-order': 1
     }, function (data) {
+      lint.assert.equal(15, data.warningCount);
+      done();
+    });
+  });
+
+  it('[order: alphabetical, ignore-custom-properties: true]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'ignore-custom-properties': true
+        }
+      ]
+    }, function (data) {
       lint.assert.equal(12, data.warningCount);
       done();
     });
@@ -113,6 +182,47 @@ describe('property sort order - sass', function () {
     });
   });
 
+  it('[order: custom + composes, ignore-custom-properties: false]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'height',
+            'composes',
+            'width',
+            'display',
+            'color'
+          ],
+          'ignore-custom-properties': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[order: custom + composes, ignore-custom-properties: true]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'height',
+            'width',
+            'display',
+            'color'
+          ],
+          'ignore-custom-properties': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
   it('[order: recess]', function (done) {
     lint.test(file, {
       'property-sort-order': [
@@ -122,7 +232,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -136,7 +246,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -150,7 +260,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -12,7 +12,7 @@ describe('property sort order - scss', function () {
     lint.test(file, {
       'property-sort-order': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -45,7 +45,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -59,7 +59,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -73,7 +73,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });
@@ -89,7 +89,7 @@ describe('property sort order - sass', function () {
     lint.test(file, {
       'property-sort-order': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -108,7 +108,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -122,7 +122,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -136,7 +136,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -150,7 +150,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });

--- a/tests/sass/property-sort-order.sass
+++ b/tests/sass/property-sort-order.sass
@@ -11,6 +11,19 @@
     height: 100vw
 
 
+.other-property
+  composes: heading
+  height: 100vh
+  display: block
+  width: 100vw
+  border: 1px
+
+.other-property-new
+  height: 100vh
+  display: block
+  width: 100vw
+  border: 1px
+  composes: heading
 
 @function test($foo)
   // The line below causes the problem
@@ -34,5 +47,5 @@
   @if not unitless($context)
     $context: strip-units($context)
 
-  @if $target == 0 @return 0 
+  @if $target == 0 @return 0
   @return $target / $context + 0em

--- a/tests/sass/property-sort-order.scss
+++ b/tests/sass/property-sort-order.scss
@@ -12,6 +12,22 @@
   }
 }
 
+.other-property {
+  composes: heading;
+  height: 100vh;
+  display: block;
+  width: 100vw;
+  border: 1px;
+}
+
+.other-property-new {
+  height: 100vh;
+  display: block;
+  width: 100vw;
+  border: 1px;
+  composes: heading;
+}
+
 @function test($foo) {
   // The line below causes the problem
   $bar: $foo;


### PR DESCRIPTION
Updates the `property-sort-order` rule to ignore non standard CSS properties to allow custom properties as described in #302 

Closes #302

Looking for possible feedback on this to see if we think this check should be enabled or disabled by an option flag or whether a whitelist would be preferable to this check.

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com