### PR TITLE
Hotfix master - Correct no-url-protocols rule name

### DIFF
--- a/lib/rules/no-url-protocols.js
+++ b/lib/rules/no-url-protocols.js
@@ -9,7 +9,7 @@ var stripQuotes = function (str) {
 };
 
 module.exports = {
-  'name': 'url-format',
+  'name': 'no-url-protocols',
   'defaults': {},
   'detect': function (ast, parser) {
     var result = [];


### PR DESCRIPTION
Corrects an issue where `no-url-protocols` rule was using an incorrect and now deprecated name.

Fixes #335 
DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com