### PR TITLE
Hotfix Develop - function-name-format, Ignore css transform functions

### DIFF
--- a/lib/rules/function-name-format.js
+++ b/lib/rules/function-name-format.js
@@ -2,6 +2,19 @@
 'use strict';
 
 var helpers = require('../helpers');
+var whitelist = [
+  'rotateX',
+  'rotateY',
+  'rotateZ',
+  'scaleX',
+  'scaleY',
+  'scaleZ',
+  'skewX',
+  'skewY',
+  'translateX',
+  'translateY',
+  'translateZ'
+];
 
 module.exports = {
   'name': 'function-name-format',
@@ -17,6 +30,11 @@ module.exports = {
       var name = node.first('ident').content,
           strippedName,
           violationMessage = false;
+
+      // ignore functions on whitelist - css3 transforms
+      if (whitelist.indexOf(name) !== -1) {
+        return;
+      }
 
       strippedName = name;
 

--- a/tests/sass/function-name-format.sass
+++ b/tests/sass/function-name-format.sass
@@ -28,3 +28,4 @@ $foo: SCREAMING_SNAKE_CASE()
   content: snake_case()
   color: _does_NOT-fitSTANDARD('bar')
   border-color: $foo
+  transform: translateX(1px) translateY(1px) translateZ(1px) scaleX(0.5) scaleY(0.5) scaleZ(0.5) skewX(1deg) skewY(1deg) rotateX(1deg) rotateY(1deg) rotateZ(1deg)

--- a/tests/sass/function-name-format.scss
+++ b/tests/sass/function-name-format.scss
@@ -36,4 +36,5 @@ $foo: SCREAMING_SNAKE_CASE();
   content: snake_case();
   color: _does_NOT-fitSTANDARD('bar');
   border-color: $foo;
+  transform: translateX(1px) translateY(1px) translateZ(1px) scaleX(0.5) scaleY(0.5) scaleZ(0.5) skewX(1deg) skewY(1deg) rotateX(1deg) rotateY(1deg) rotateZ(1deg);
 }


### PR DESCRIPTION
Closes #344 

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>