### PR TITLE
Hotfix master: Fix space before brace rule for nested properties

### DIFF
--- a/lib/rules/space-before-brace.js
+++ b/lib/rules/space-before-brace.js
@@ -3,6 +3,10 @@
 var helpers = require('../helpers');
 
 var getLastWhitespace = function (node) {
+  if (node === false) {
+    return null;
+  }
+
   if (typeof node !== 'object') {
     return false;
   }
@@ -20,35 +24,55 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
+    if (ast.syntax === 'scss') {
+      ast.traverseByTypes(['block', 'atrulers', 'declaration'], function (block, i, parent) {
+        var previous = false,
+            whitespace,
+            warn = {};
 
-    ast.traverseByTypes(['block', 'atrulers'], function (block, i, parent) {
-      var previous = parent.get(i - 1),
-          whitespace = getLastWhitespace(previous);
-
-      if (whitespace === false) {
-        if (parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': block.start.line,
-            'column': block.start.column - 1,
-            'message': 'Whitespace required before {',
-            'severity': parser.severity
-          });
+        if ((block.is('block') || block.is('atrulers')) && !parent.is('value')) {
+          previous = parent.get(i - 1);
         }
-      }
-      else {
-        if (!parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': whitespace.start.line,
-            'column': whitespace.start.column,
-            'message': 'Whitespace not allowed before {',
-            'severity': parser.severity
-          });
+        else if (block.is('declaration')) {
+          if (block.contains('value')) {
+            for (var j = 0; j < block.content.length; j++) {
+              if (block.content[j].is('value') && block.content[j].content[0].is('block')) {
+                previous = block.content[j - 1];
+                warn.line = block.content[j].content[0].start.line;
+                warn.col = block.content[j].content[0].start.column;
+              }
+            }
+          }
         }
-      }
-    });
-
+        whitespace = getLastWhitespace(previous);
+        if (whitespace === false) {
+          if (parser.options.include) {
+            if (!warn.hasOwnProperty('line')) {
+              warn.line = block.start.line;
+              warn.col = block.start.column;
+            }
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': warn.line,
+              'column': warn.col - 1,
+              'message': 'Whitespace required before {',
+              'severity': parser.severity
+            });
+          }
+        }
+        else {
+          if (!parser.options.include && whitespace !== null) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': whitespace.start.line,
+              'column': whitespace.start.column,
+              'message': 'Whitespace not allowed before {',
+              'severity': parser.severity
+            });
+          }
+        }
+      });
+    }
     return result;
   }
 };

--- a/tests/rules/space-before-brace.js
+++ b/tests/rules/space-before-brace.js
@@ -12,7 +12,7 @@ describe('space before brace - scss', function () {
     lint.test(file, {
       'space-before-brace': 1
     }, function (data) {
-      lint.assert.equal(3, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('space before brace - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-before-brace.scss
+++ b/tests/sass/space-before-brace.scss
@@ -39,7 +39,7 @@
   }
   @include breakpoint {
     content: bar;
-    font{
+    font:{
       family: fantasy;
     }
   }

--- a/tests/sass/space-before-brace.scss
+++ b/tests/sass/space-before-brace.scss
@@ -20,7 +20,37 @@
 
 .qux {
   content: 'bar';
+  font:{
+    family: fantasy;
+  }
   @include breakpoint{
     content: bar;
+    font: {
+      family: fantasy;
+    }
+  }
+}
+
+
+.other {
+  content: 'bar';
+  font: {
+    family: fantasy;
+  }
+  @include breakpoint {
+    content: bar;
+    font{
+      family: fantasy;
+    }
+  }
+}
+
+.selector {
+  content: '';
+
+  .mergeable {
+    font: {
+      family: fantasy;
+    }
   }
 }


### PR DESCRIPTION
Fixes an issue with the space before brace rule when encountering nested values as brought up in #352 

DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com