### PR TITLE
Hotfix master - Add missing background-clip property to SMACSS config file

### DIFF
--- a/lib/config/property-sort-orders/smacss.yml
+++ b/lib/config/property-sort-orders/smacss.yml
@@ -101,6 +101,7 @@ order:
   # Background
 
   - 'background'
+  - 'background-clip'
   - 'background-color'
   - 'background-image'
   - 'background-repeat'


### PR DESCRIPTION
Closes #366 by adding background-clip property to SMACSS property order config file.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com