### PR TITLE
Fix a small typo in the rule

### DIFF
--- a/docs/rules/indentation.md
+++ b/docs/rules/indentation.md
@@ -1,6 +1,6 @@
 # Indentation
 
-Rule `indentations` will enforce an indentation size (in spaces) and ensure that tabs and spaces are not mixed.
+Rule `indentation` will enforce an indentation size (in spaces) and ensure that tabs and spaces are not mixed.
 
 ## Options
 


### PR DESCRIPTION
There was a mistake on this file because it was using the name `indentations`  instead of `indentation` for this rule.