### PR TITLE
sass syntax mixin include error "Cannot read property 'first' of undefined"

### DIFF
--- a/lib/rules/extends-before-declarations.js
+++ b/lib/rules/extends-before-declarations.js
@@ -13,9 +13,9 @@ module.exports = {
       var lastDeclaration = null;
 
       block.forEach(function (item, j) {
-        if ((item.type === 'include' || item.type === 'extend') &&
-            item.first('atkeyword')) {
-          if (item.first('atkeyword').first('ident').content === 'extend') {
+        if ((item.type === 'include' || item.type === 'extend')) {
+          if (item.first('atkeyword') &&
+            item.first('atkeyword').first('ident').content === 'extend') {
             if (j > lastDeclaration && lastDeclaration !== null) {
               item.forEach('simpleSelector', function () {
                 error = {

--- a/lib/rules/extends-before-declarations.js
+++ b/lib/rules/extends-before-declarations.js
@@ -13,7 +13,8 @@ module.exports = {
       var lastDeclaration = null;
 
       block.forEach(function (item, j) {
-        if (item.type === 'include' || item.type === 'extend') {
+        if ((item.type === 'include' || item.type === 'extend') &&
+            item.first('atkeyword')) {
           if (item.first('atkeyword').first('ident').content === 'extend') {
             if (j > lastDeclaration && lastDeclaration !== null) {
               item.forEach('simpleSelector', function () {

--- a/tests/sass/extends-before-declarations.sass
+++ b/tests/sass/extends-before-declarations.sass
@@ -27,3 +27,8 @@
   .bar
     @extend %waldo
     content: 'where'
+
+
+.foo-noextend
+  +foo
+  content: "bar"

--- a/tests/sass/extends-before-declarations.scss
+++ b/tests/sass/extends-before-declarations.scss
@@ -29,3 +29,7 @@
     content: 'where';
   }
 }
+
+.foo-noextend {
+  @include foo;
+}


### PR DESCRIPTION
When using Sass syntax mixin includes (+foobar), extends-before-declarations.js expects these to have an atkeyword node and then attempts access properties on an undefined object resulting in the following error. This provides test cases that were able to reproduce the error and a fix to resolve it.

```
/.../node_modules/sass-lint/lib/rules/extends-before-declarations.js:18
          if (item.first('atkeyword').first('ident').content === 'extend') {
                                     ^
TypeError: Cannot read property 'first' of undefined
```