### PR TITLE
Hotfix master - Fix issue where mixin-name-format incorrectly lints extends

### DIFF
--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -25,8 +25,10 @@ module.exports = {
       else {
         // We're not linting extends here
         if (node.contains('atkeyword')) {
-          if (node.first('atkeyword').content === 'extend') {
-            return false;
+          if (node.first('atkeyword').contains('ident')) {
+            if (node.first('atkeyword').first('ident').content === 'extend') {
+              return false;
+            }
           }
         }
 

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -49,30 +49,30 @@ module.exports = {
       }
 
       switch (parser.options.convention) {
-        case 'hyphenatedlowercase':
-          if (!helpers.isHyphenatedLowercase(strippedName)) {
-            violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
-          }
-          break;
-        case 'camelcase':
-          if (!helpers.isCamelCase(strippedName)) {
-            violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
-          }
-          break;
-        case 'snakecase':
-          if (!helpers.isSnakeCase(strippedName)) {
-            violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
-          }
-          break;
-        default:
-          if (!(new RegExp(parser.options.convention).test(strippedName))) {
-            violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
+      case 'hyphenatedlowercase':
+        if (!helpers.isHyphenatedLowercase(strippedName)) {
+          violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
+        }
+        break;
+      case 'camelcase':
+        if (!helpers.isCamelCase(strippedName)) {
+          violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
+        }
+        break;
+      case 'snakecase':
+        if (!helpers.isSnakeCase(strippedName)) {
+          violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
+        }
+        break;
+      default:
+        if (!(new RegExp(parser.options.convention).test(strippedName))) {
+          violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
 
-            // convention-message overrides violationMessage
-            if (parser.options['convention-explanation']) {
-              violationMessage = parser.options['convention-explanation'];
-            }
+          // convention-message overrides violationMessage
+          if (parser.options['convention-explanation']) {
+            violationMessage = parser.options['convention-explanation'];
           }
+        }
       }
 
       if (violationMessage) {

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -19,11 +19,9 @@ module.exports = {
           violationMessage = false;
 
       if (node.is('mixin')) {
-        if (!node.contains('ident')) {
-          return false;
+        if (node.contains('ident')) {
+          name = node.first('ident').content;
         }
-
-        name = node.first('ident').content;
       }
       else {
         // We're not linting extends here
@@ -34,55 +32,55 @@ module.exports = {
         }
 
         if (node.contains('simpleSelector')) {
-          if (!node.first('simpleSelector').contains('ident')) {
-            return false;
-          }
-
-          name = node.first('simpleSelector').first('ident').content;
-        }
-      }
-
-      strippedName = name;
-
-      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
-        strippedName = name.slice(1);
-      }
-
-      switch (parser.options.convention) {
-      case 'hyphenatedlowercase':
-        if (!helpers.isHyphenatedLowercase(strippedName)) {
-          violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
-        }
-        break;
-      case 'camelcase':
-        if (!helpers.isCamelCase(strippedName)) {
-          violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
-        }
-        break;
-      case 'snakecase':
-        if (!helpers.isSnakeCase(strippedName)) {
-          violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
-        }
-        break;
-      default:
-        if (!(new RegExp(parser.options.convention).test(strippedName))) {
-          violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
-
-          // convention-message overrides violationMessage
-          if (parser.options['convention-explanation']) {
-            violationMessage = parser.options['convention-explanation'];
+          if (node.first('simpleSelector').contains('ident')) {
+            name = node.first('simpleSelector').first('ident').content;
           }
         }
       }
 
-      if (violationMessage) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': node.start.line,
-          'column': node.start.column,
-          'message': violationMessage,
-          'severity': parser.severity
-        });
+      if (name) {
+        strippedName = name;
+
+        if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+          strippedName = name.slice(1);
+        }
+
+        switch (parser.options.convention) {
+        case 'hyphenatedlowercase':
+          if (!helpers.isHyphenatedLowercase(strippedName)) {
+            violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
+          }
+          break;
+        case 'camelcase':
+          if (!helpers.isCamelCase(strippedName)) {
+            violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
+          }
+          break;
+        case 'snakecase':
+          if (!helpers.isSnakeCase(strippedName)) {
+            violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
+          }
+          break;
+        default:
+          if (!(new RegExp(parser.options.convention).test(strippedName))) {
+            violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+            // convention-message overrides violationMessage
+            if (parser.options['convention-explanation']) {
+              violationMessage = parser.options['convention-explanation'];
+            }
+          }
+        }
+
+        if (violationMessage) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': violationMessage,
+            'severity': parser.severity
+          });
+        }
       }
     });
 

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -18,11 +18,28 @@ module.exports = {
           strippedName,
           violationMessage = false;
 
-      if (node.type === 'mixin') {
+      if (node.is('mixin')) {
+        if (!node.contains('ident')) {
+          return false;
+        }
+
         name = node.first('ident').content;
       }
       else {
-        name = node.first('simpleSelector').first('ident').content;
+        // We're not linting extends here
+        if (node.contains('atkeyword')) {
+          if (node.first('atkeyword').content === 'extend') {
+            return false;
+          }
+        }
+
+        if (node.contains('simpleSelector')) {
+          if (!node.first('simpleSelector').contains('ident')) {
+            return false;
+          }
+
+          name = node.first('simpleSelector').first('ident').content;
+        }
       }
 
       strippedName = name;
@@ -32,30 +49,30 @@ module.exports = {
       }
 
       switch (parser.options.convention) {
-      case 'hyphenatedlowercase':
-        if (!helpers.isHyphenatedLowercase(strippedName)) {
-          violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
-        }
-        break;
-      case 'camelcase':
-        if (!helpers.isCamelCase(strippedName)) {
-          violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
-        }
-        break;
-      case 'snakecase':
-        if (!helpers.isSnakeCase(strippedName)) {
-          violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
-        }
-        break;
-      default:
-        if (!(new RegExp(parser.options.convention).test(strippedName))) {
-          violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
-
-          // convention-message overrides violationMessage
-          if (parser.options['convention-explanation']) {
-            violationMessage = parser.options['convention-explanation'];
+        case 'hyphenatedlowercase':
+          if (!helpers.isHyphenatedLowercase(strippedName)) {
+            violationMessage = 'Mixin \'' + name + '\' should be written in lowercase with hyphens';
           }
-        }
+          break;
+        case 'camelcase':
+          if (!helpers.isCamelCase(strippedName)) {
+            violationMessage = 'Mixin \'' + name + '\' should be written in camelCase';
+          }
+          break;
+        case 'snakecase':
+          if (!helpers.isSnakeCase(strippedName)) {
+            violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
+          }
+          break;
+        default:
+          if (!(new RegExp(parser.options.convention).test(strippedName))) {
+            violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+            // convention-message overrides violationMessage
+            if (parser.options['convention-explanation']) {
+              violationMessage = parser.options['convention-explanation'];
+            }
+          }
       }
 
       if (violationMessage) {

--- a/tests/sass/mixin-name-format.sass
+++ b/tests/sass/mixin-name-format.sass
@@ -24,3 +24,6 @@
 
 .class
   +snake_case()
+
+.test
+  @extend .pure-u-1-6

--- a/tests/sass/mixin-name-format.scss
+++ b/tests/sass/mixin-name-format.scss
@@ -33,3 +33,7 @@
 .class {
   @include snake_case();
 }
+
+.test {
+  @extend .pure-u-1-6
+}


### PR DESCRIPTION
Fixes an issue where the mixin-name-format rule would incorrectly lint `@extends` aka class names when used with Sass syntax.

Closes #396

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com