### PR TITLE
Feature/property count

### DIFF
--- a/docs/rules/property-count.md
+++ b/docs/rules/property-count.md
@@ -1,0 +1,122 @@
+# Property Count
+
+Rule `property-count` will enforce the maximum number of properties allowed within a ruleset. This can include or exclude a cumulative count of nested properties also.
+
+## Options
+
+* `max-properties`: number (defaults to `0`)
+* `include-nested`: `true`/`false` (defaults to `false`)
+
+## Examples
+
+When `max-properties: '2'`, the following are allowed.
+
+```scss
+.foo {
+  content: '';
+  display: block;
+}
+
+.nest {
+  content: '';
+  display: block;
+
+  .nest-child {
+    content: '';
+    display: block;
+  }
+}
+```
+When `max-properties: '2'`, the following are disallowed.
+
+```scss
+.foo { // lint reported
+  content: '';
+  display: block;
+  color: red;
+}
+
+.nest { // lint reported
+  content: '';
+  display: block;
+  color: red;
+
+  .nest-child { // lint reported
+    content: '';
+    display: block;
+    color: red;
+  }
+}
+```
+
+When `max-properties: 2` and `include-nested: true`, the following are allowed.
+
+```scss
+.foo {
+  content: '';
+  display: block;
+}
+
+.nest { // nested property count of 2
+  content: '';
+
+  .nest-child {
+    content: '';
+  }
+}
+```
+
+When `max-properties: 2` and `include-nested: true`, the following are disallowed.
+
+```scss
+.foo { // lint reported
+  content: '';
+  display: block;
+  color: red;
+}
+
+.nest { // lint reported - nested property count of 3
+  content: '';
+
+  .nest-child {
+    content: '';
+    color: red
+  }
+}
+
+.nest-other { // lint reported - nested property count of 3
+  content: '';
+
+  .nest-other-child {
+    content: '';
+  }
+
+  .nest-other-child-sibling {
+    display: block;
+  }
+}
+```
+
+#### Special Case - `max-properties: 0`
+
+As there is no perceived best practice for a maximum number of properties per ruleset the default for `max-properties` is 0. This effectively leaves the rule disabled and should therefore always be customised by the end user.
+
+
+When `max-properties: '0'`, the following are allowed.
+
+```scss
+.foo {
+  content: '';
+  display: block;
+}
+
+.nest {
+  content: '';
+  display: block;
+
+  .nest-child {
+    content: '';
+    display: block;
+  }
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -58,6 +58,7 @@ rules:
   leading-zero: 1
   nesting-depth: 1
   property-sort-order: 1
+  property-count: 0
   quotes: 1
   shorthand-values: 1
   url-quotes: 1

--- a/lib/rules/property-count.js
+++ b/lib/rules/property-count.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+/**
+ * Traverses a ruleset node for declarations and rulesets.
+ * Counts the properties per nest depth and handles the parser options
+ * for excluding nested values. Also used to skip over rulesets in the main rule
+ * if they've already been parsed here.
+ * @param {object} node - the current ruleset node
+ * @param {bool} includeNested - user defined option on whether to parse nested blocks
+ * @returns {array} the property count and the number of child rulesets parsed
+ */
+var countProps = function (node, includeNested) {
+  var propertyCount = 0,
+      nestCount = 1;
+
+  if (node.contains('block')) {
+    node.forEach('block', function (block) {
+      block.forEach('declaration', function (declaration) {
+        if (declaration.contains('property')) {
+          propertyCount++;
+        }
+      });
+      if (includeNested && block.contains('ruleset')) {
+        block.forEach('ruleset', function (childRule) {
+          var outcome = countProps(childRule, true);
+          propertyCount += outcome[0];
+          nestCount += outcome[1];
+        });
+      }
+    });
+  }
+
+  return [propertyCount, nestCount];
+};
+
+module.exports = {
+  'name': 'property-count',
+  'defaults': {
+    'max-properties': 0,
+    'include-nested': false
+  },
+  'detect': function (ast, parser) {
+    var result = [],
+        propCount = 0,
+        nestedRules = 1,
+        outcome,
+        errProps,
+        propSuffix;
+
+    ast.traverseByType('ruleset', function (ruleset) {
+      var errMessage = 'Rule set contains ';
+
+      if (nestedRules > 1) {
+        nestedRules--;
+
+        return false;
+      }
+
+      outcome = countProps(ruleset, parser.options['include-nested']);
+      propCount = outcome[0];
+      nestedRules = outcome[1];
+
+      if (parser.options['max-properties'] >= 1 && propCount > parser.options['max-properties']) {
+        errProps = parseInt(propCount - parser.options['max-properties'], 10);
+        propSuffix = errProps === 1 ? 'property' : 'properties';
+        errMessage += errProps + ' ' + propSuffix;
+        errMessage += ' more than the specified maximum of ' + parser.options['max-properties'];
+        errMessage += parser.options['include-nested'] ? '(includes properties in nested rules)' : '';
+
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': ruleset.start.line,
+          'column': ruleset.start.column,
+          'message': errMessage,
+          'severity': parser.severity
+        });
+      }
+    });
+    return result;
+  }
+};

--- a/tests/rules/property-count.js
+++ b/tests/rules/property-count.js
@@ -1,0 +1,181 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('property count - scss', function () {
+  var file = lint.file('property-count.scss');
+
+  it('[default]', function (done) {
+    lint.test(file, {
+      'property-count': 1
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 2]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 2
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 2, include-nested: true]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 2,
+          'include-nested': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 0, include-nested: true]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 0,
+          'include-nested': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 4]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 4
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 4, include-nested: true]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 4,
+          'include-nested': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('property count - sass', function () {
+  var file = lint.file('property-count.sass');
+
+  it('[default]', function (done) {
+    lint.test(file, {
+      'property-count': 1
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 2]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 2
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 2, include-nested: true]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 2,
+          'include-nested': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 0, include-nested: true]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 0,
+          'include-nested': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 4]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 4
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(2, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-properties: 4, include-nested: true]', function (done) {
+    lint.test(file, {
+      'property-count': [
+        1,
+        {
+          'max-properties': 4,
+          'include-nested': true
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/property-count.sass
+++ b/tests/sass/property-count.sass
@@ -1,0 +1,86 @@
+.test
+  content: ''
+
+.test-class
+  content: ''
+  display: block
+
+.test-again
+  content: ''
+  display: block
+  color: red
+
+.test-large
+  content: ''
+  display: block
+  color: red
+  border-top: 1px solid red
+  border-right: 1px solid red
+  border-bottom: 1px solid red
+  border-left: 1px solid red
+
+.nest-parent
+  color: red
+  .nest-child
+    display: block
+    .nest-grand-child
+      content: ''
+      display: block
+      color: red
+
+.nest-test
+  color: red
+  .nest-other-child
+    display: block
+  .nest-second-child
+    content: ''
+    display: block
+    color: red
+
+.foo
+  display: block
+  content: 0
+  color: red
+  .bar
+    display: block
+    content: 0
+    color: red
+    .baz
+      display: block
+      content: 0
+      color: red
+  .small
+    display: block
+
+=test
+  .test
+    content: ''
+  .test-class
+    content: ''
+    display: block
+  .test-again
+    content: ''
+    display: block
+    color: red
+  .test-large
+    content: ''
+    display: block
+    color: red
+    border-top: 1px solid red
+    border-right: 1px solid red
+    border-bottom: 1px solid red
+    border-left: 1px solid red
+  .foo
+    display: block
+    content: 0
+    color: red
+    .bar
+      display: block
+      content: 0
+      color: red
+      .baz
+        display: block
+        content: 0
+        color: red
+    .small
+      display: block

--- a/tests/sass/property-count.scss
+++ b/tests/sass/property-count.scss
@@ -1,0 +1,123 @@
+.test {
+  content: '';
+}
+
+.test-class {
+  content: '';
+  display: block;
+}
+
+.test-again {
+  content: '';
+  display: block;
+  color: red;
+}
+
+.test-large {
+  content: '';
+  display: block;
+  color: red;
+  border-top: 1px solid red;
+  border-right: 1px solid red;
+  border-bottom: 1px solid red;
+  border-left: 1px solid red;
+}
+
+.nest-parent {
+  color: red;
+
+  .nest-child {
+    display:block;
+
+    .nest-grand-child {
+      content: '';
+      display: block;
+      color: red;
+    }
+  }
+}
+
+.nest-test {
+  color: red;
+
+  .nest-other-child {
+    display: block;
+  }
+
+  .nest-second-child {
+    content: '';
+    display: block;
+    color: red;
+  }
+}
+
+.foo {
+  display: block;
+  content: 0;
+  color: red;
+
+  .bar {
+    display: block;
+    content: 0;
+    color: red;
+
+    .baz {
+      display: block;
+      content: 0;
+      color: red;
+    }
+  }
+
+  .small {
+    display: block;
+  }
+}
+
+@mixin test {
+  .test {
+    content: '';
+  }
+
+  .test-class {
+    content: '';
+    display: block;
+  }
+
+  .test-again {
+    content: '';
+    display: block;
+    color: red;
+  }
+
+  .test-large {
+    content: '';
+    display: block;
+    color: red;
+    border-top: 1px solid red;
+    border-right: 1px solid red;
+    border-bottom: 1px solid red;
+    border-left: 1px solid red;
+  }
+
+  .foo {
+    display: block;
+    content: 0;
+    color: red;
+
+    .bar {
+      display: block;
+      content: 0;
+      color: red;
+
+      .baz {
+        display: block;
+        content: 0;
+        color: red;
+      }
+    }
+
+    .small {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
Adds the rule `property-count` which enforces the maximum number of properties per ruleset. This can be configured to be per ruleset or inclusive of nested rulesets.

Warning Message:
> Rule set contains {number} {property/properties} more than the specified maximum of {number} {(includes properties in nested rules)}

Includes the options:
* `max-properties`
* `include-nested`

Closes #406

`DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com`