### PR TITLE
New Rule: id-name-format

### DIFF
--- a/docs/rules/id-name-format.md
+++ b/docs/rules/id-name-format.md
@@ -1,0 +1,183 @@
+# ID Name Format
+
+Rule `id-name-format` will enforce a convention for ids.
+
+## Options
+
+* `allow-leading-underscore`: `true`/`false` (defaults to `true`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`,
+or a Regular Expression that the id name must match (e.g. `^[_A-Z]+$`)
+* `convention-explanation`: Custom explanation to display to the user if an id doesn't adhere to the convention
+* `ignore`: Array of names to ignore
+
+## Example 1
+
+Settings:
+- `allow-leading-underscore: true`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+#hyphenated-lowercase {
+  content: '';
+
+  &#_with-leading-underscore {
+    content: '';
+  }
+}
+
+#foo {
+  @extend #hyphenated-lowercase;
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+#HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+#camelCase {
+  content: '';
+
+  @extend #snake_case;
+}
+```
+
+## Example 2
+
+Settings:
+- `allow-leading-underscore: false`
+- `convention: hyphenatedlowercase`
+
+When enabled, the following are allowed:
+
+```scss
+#hyphenated-lowercase {
+  content: '';
+
+  &#another-hyphenated-lowercase {
+    content: '';
+  }
+}
+
+#foo {
+  @extend #hyphenated-lowercase;
+}
+
+```
+
+When enabled, the following are disallowed:
+
+```scss
+#_with-leading-underscore {
+  content: '';
+}
+
+#HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+#camelCase {
+  content: '';
+
+  @extend #snake_case;
+}
+```
+
+## Example 3
+
+Settings:
+- `convention: camelcase`
+
+When enabled, the following are allowed:
+
+```scss
+#camelCase {
+  content: '';
+}
+
+#foo {
+  @extend #anotherCamelCase;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+#HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+#foo {
+  @extend #snake_case;
+}
+```
+
+## Example 4
+
+Settings:
+- `convention: snakecase`
+
+When enabled, the following are allowed:
+
+```scss
+#snake_case {
+  content: '';
+}
+
+#foo {
+  @extend #another_snake_case;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+#HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+#foo {
+  @extend #camelCase;
+}
+```
+
+## Example 5
+
+Settings:
+- `convention: ^[_A-Z]+$`
+- `convention-explanation: 'IDs must contain only uppercase letters and underscores'`
+
+When enabled, the following are allowed:
+
+```scss
+#SCREAMING_SNAKE_CASE {
+  content: '';
+}
+
+#FOO {
+  @extend #SCREAMING_SNAKE_CASE;
+}
+```
+
+When enabled, the following are disallowed:
+
+(Each line with an id will report `IDs must contain only uppercase letters and underscores` when linted.)
+
+```scss
+#HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+#snake_case {
+  content: '';
+}
+
+#foo {
+  @extend #camelCase;
+}
+```

--- a/docs/rules/id-name-format.md
+++ b/docs/rules/id-name-format.md
@@ -15,6 +15,7 @@ or a Regular Expression that the id name must match (e.g. `^[_A-Z]+$`)
 Settings:
 - `allow-leading-underscore: true`
 - `convention: hyphenatedlowercase`
+- `ignore: ['IGNORED_SELECTOR']`
 
 When enabled, the following are allowed:
 
@@ -29,6 +30,10 @@ When enabled, the following are allowed:
 
 #foo {
   @extend #hyphenated-lowercase;
+}
+
+#IGNORED_SELECTOR {
+  content: '';
 }
 
 ```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -45,6 +45,7 @@ rules:
   # Name Formats
   class-name-format: 1
   function-name-format: 1
+  id-name-format: 0
   mixin-name-format: 1
   placeholder-name-format: 1
   variable-name-format: 1

--- a/lib/rules/id-name-format.js
+++ b/lib/rules/id-name-format.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'id-name-format',
+  'defaults': {
+    'allow-leading-underscore': true,
+    'convention': 'hyphenatedlowercase',
+    'convention-explanation': false,
+    'ignore': []
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('ruleset', function (ruleset) {
+      var selectorAndExtensions = helpers.collectSuffixExtensions(ruleset, 'id');
+
+      selectorAndExtensions.forEach(function (node) {
+        var name = node.content,
+            strippedName,
+            violationMessage = false;
+
+        if (parser.options.ignore.indexOf(name) !== -1) {
+          return;
+        }
+
+        strippedName = name;
+
+        if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+          strippedName = name.slice(1);
+        }
+
+        switch (parser.options.convention) {
+        case 'hyphenatedlowercase':
+          if (!helpers.isHyphenatedLowercase(strippedName)) {
+            violationMessage = 'ID \'#' + name + '\' should be written in lowercase with hyphens';
+          }
+          break;
+        case 'camelcase':
+          if (!helpers.isCamelCase(strippedName)) {
+            violationMessage = 'ID \'#' + name + '\' should be written in camelCase';
+          }
+          break;
+        case 'snakecase':
+          if (!helpers.isSnakeCase(strippedName)) {
+            violationMessage = 'ID \'#' + name + '\' should be written in snake_case';
+          }
+          break;
+        default:
+          if (!(new RegExp(parser.options.convention).test(strippedName))) {
+            violationMessage = 'ID \'#' + name + '\' should match regular expression /' + parser.options.convention + '/';
+
+            // convention-message overrides violationMessage
+            if (parser.options['convention-explanation']) {
+              violationMessage = parser.options['convention-explanation'];
+            }
+          }
+        }
+
+        if (violationMessage) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': violationMessage,
+            'severity': parser.severity
+          });
+        }
+      });
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/id-name-format.js
+++ b/tests/rules/id-name-format.js
@@ -1,0 +1,181 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('id name format - scss', function () {
+  var file = lint.file('id-name-format.scss');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'id-name-format': 1
+    }, function (data) {
+      lint.assert.equal(14, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedlowercase with ignore]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'ignore': ['one_parent_valid_child']
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(16, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$], with convention-explanation', function (done) {
+    var message = 'Its bad and you should feel bad.';
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': message
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(data.messages[0].message, message);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('id name format - sass', function () {
+  var file = lint.file('id-name-format.sass');
+
+  it('[convention: hyphenatedlowercase]', function (done) {
+    lint.test(file, {
+      'id-name-format': 1
+    }, function (data) {
+      lint.assert.equal(14, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedlowercase with ignore]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'ignore': ['one_parent_valid_child']
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: camelcase]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': 'camelcase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: snakecase]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': 'snakecase'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(16, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$]', function (done) {
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: RegExp ^[_A-Z]+$], with convention-explanation', function (done) {
+    var message = 'Its bad and you should feel bad.';
+    lint.test(file, {
+      'id-name-format': [
+        1,
+        {
+          'convention': '^[_A-Z]+$',
+          'convention-explanation': message
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(data.messages[0].message, message);
+      done();
+    });
+  });
+});

--- a/tests/sass/id-name-format.sass
+++ b/tests/sass/id-name-format.sass
@@ -1,0 +1,44 @@
+#hyphenated-lowercase
+  content: ''
+
+#snake_case
+  content: ''
+
+#camelCase
+  content: ''
+
+#PascalCase
+  content: ''
+
+  #Camel_Snake_Case
+    content: ''
+
+    #SCREAMING_SNAKE_CASE
+      content: ''
+
+#_with-leading-underscore
+  content: ''
+
+#_does_NOT-fitSTANDARD
+  @extend #snake_case
+
+#hyphentated-lowercase
+  color: blue
+
+  &-with-suffix-extension
+    color: green
+
+    &-and-another
+      color: red
+
+  &-INVALID
+    color: pink
+
+#one_parent,
+#two_parents,
+#third-invalid-parent
+  width: 10px
+
+  &_valid_child,
+  &-invalid-child
+    height: 10px

--- a/tests/sass/id-name-format.scss
+++ b/tests/sass/id-name-format.scss
@@ -1,0 +1,58 @@
+#hyphenated-lowercase {
+  content: '';
+}
+
+#snake_case {
+  content: '';
+}
+
+#camelCase {
+  content: '';
+}
+
+#PascalCase {
+  content: '';
+
+  #Camel_Snake_Case {
+    content: '';
+
+    #SCREAMING_SNAKE_CASE {
+      content: '';
+    }
+  }
+}
+
+#_with-leading-underscore {
+  content: '';
+}
+
+#_does_NOT-fitSTANDARD {
+  @extend #snake_case;
+}
+
+#hyphentated-lowercase {
+  color: blue;
+
+  &-with-suffix-extension {
+    color: green;
+
+    &-and-another {
+      color: red;
+    }
+  }
+
+  &-INVALID {
+    color: pink;
+  }
+}
+
+#one_parent,
+#two_parents,
+#third-invalid-parent {
+  width: 10px;
+
+  &_valid_child,
+  &-invalid-child {
+    height: 10px;
+  }
+}


### PR DESCRIPTION
Clone of `class-name-format`, although I can't imagine why a person would want to use suffix extensions on an ID.

Will close #325 

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>