### PR TITLE
Updated sorting logic and error reporting. Added (group separator).

### DIFF
--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -5,16 +5,23 @@ var helpers,
     fs,
     path,
     sortBy,
+    clone,
     propertyCheckList,
     orderPresets,
     getOrderConfig,
-    sortProperties;
+    sortProperties,
+    trimGroupSeparator,
+    validateSeparation,
+    GROUP_SEPARATOR;
+
+GROUP_SEPARATOR = '(group separator)';
 
 helpers = require('../helpers');
 yaml = require('js-yaml');
 fs = require('fs');
 path = require('path');
 sortBy = require('lodash.sortby');
+clone = require('lodash.clone');
 
 propertyCheckList = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
 
@@ -71,6 +78,95 @@ sortProperties = function (properties, order) {
   }
 };
 
+trimGroupSeparator = function (subject) {
+  if (!subject.length) {
+    return subject;
+  }
+
+  if (subject[0] === GROUP_SEPARATOR) {
+    subject.shift();
+
+    return trimGroupSeparator(subject);
+  }
+
+  if (subject[subject.length - 1] === GROUP_SEPARATOR) {
+    subject.pop();
+
+    return trimGroupSeparator(subject);
+  }
+
+  return subject;
+};
+
+validateSeparation = function (parser, block, expectedPropertyOrder) {
+  var blockProperties;
+
+  blockProperties = [];
+
+  block.forEach(function (dec) {
+    var prop,
+        name;
+
+    if (dec.type === 'declaration') {
+      prop = dec.first('property');
+      name = prop.first('ident');
+
+      if (!name) {
+        return;
+      }
+
+      if (parser.options['ignore-custom-properties'] && propertyCheckList.indexOf(name.content) === -1) {
+        return;
+      }
+
+      blockProperties.push(name.content);
+    }
+
+    if (dec.type === 'space' && dec.content.indexOf('\n\n') === 0) {
+      blockProperties.push(GROUP_SEPARATOR);
+    }
+  });
+
+  expectedPropertyOrder = clone(expectedPropertyOrder);
+
+  // First remove expectedPropertyOrder properties that do not appear in blockProperties.
+  expectedPropertyOrder = expectedPropertyOrder.filter((propertyName) => {
+    if (propertyName === GROUP_SEPARATOR) {
+      return true;
+    }
+
+    return blockProperties.indexOf(propertyName) !== -1;
+  });
+
+  expectedPropertyOrder = trimGroupSeparator(expectedPropertyOrder);
+
+  // Then do the inverse with blockProperties.
+  blockProperties = blockProperties.filter((propertyName) => {
+    if (propertyName === GROUP_SEPARATOR) {
+      return true;
+    }
+
+    return expectedPropertyOrder.indexOf(propertyName) !== -1;
+  });
+
+  blockProperties = trimGroupSeparator(blockProperties);
+
+  blockProperties = blockProperties.join(', ');
+  expectedPropertyOrder = expectedPropertyOrder.join(', ');
+
+  if (blockProperties !== expectedPropertyOrder) {
+    return {
+      'ruleId': parser.rule.name,
+      'line': block.start.line,
+      'column': block.start.column,
+      'message': 'Expected "' + expectedPropertyOrder + '", found "' + blockProperties + '"',
+      'severity': parser.severity
+    };
+  }
+
+  return null;
+};
+
 module.exports = {
   'name': 'property-sort-order',
   'defaults': {
@@ -79,6 +175,7 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [],
+        validateSeparationResult,
         order = getOrderConfig(parser.options.order) || parser.options.order;
 
     ast.traverseByType('block', function (block) {
@@ -128,6 +225,14 @@ module.exports = {
           'message': 'Expected "' + expectedOrder + '", found "' + currentOrder + '"',
           'severity': parser.severity
         });
+      } else {
+        if (typeof order === 'object') {
+          validateSeparationResult = validateSeparation(parser, block, order);
+
+          if (validateSeparationResult) {
+            result = helpers.addUnique(result, validateSeparationResult);
+          }
+        }
       }
     });
 

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -225,7 +225,8 @@ module.exports = {
           'message': 'Expected "' + expectedOrder + '", found "' + currentOrder + '"',
           'severity': parser.severity
         });
-      } else {
+      }
+      else {
         if (typeof order === 'object') {
           validateSeparationResult = validateSeparation(parser, block, order);
 

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -1,15 +1,20 @@
 'use strict';
 
-var helpers = require('../helpers'),
-    yaml = require('js-yaml'),
-    fs = require('fs'),
-    path = require('path'),
-    sortBy = require('lodash.sortby'),
+var helpers,
+    yaml,
+    fs,
+    path,
+    sortBy,
     propertyCheckList,
     orderPresets,
     getOrderConfig,
     sortProperties;
 
+helpers = require('../helpers');
+yaml = require('js-yaml');
+fs = require('fs');
+path = require('path');
+sortBy = require('lodash.sortby');
 
 propertyCheckList = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
 
@@ -24,7 +29,7 @@ getOrderConfig = function (order) {
       orderConfig;
 
   if (typeof order === 'string' && orderPresets.hasOwnProperty(order)) {
-    filename = orderPresets[order],
+    filename = orderPresets[order];
     orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
 
     return orderConfig.order;
@@ -36,14 +41,12 @@ getOrderConfig = function (order) {
 /**
  * Sorts properties using alphabetical order or based on order array properties.
  *
- * @param {Object[]} properties
- * @param {string|string[]} order
- * @returns {Object[]}
+ * @param {Object[]} properties List of CSS properties.
+ * @param {string|string[]} order List of CSS property names.
+ * @returns {Object[]} A copy of the properties that is sorted based on the order.
  */
 sortProperties = function (properties, order) {
-  var sorted,
-      i,
-      orderedKeys;
+  var sorted;
 
   if (typeof order === 'string') {
     if (order === 'alphabetical') {
@@ -51,7 +54,8 @@ sortProperties = function (properties, order) {
     }
 
     throw new Error('Unexpected sorting order.');
-  } else {
+  }
+  else {
     sorted = sortBy(properties, 'name');
 
     // @see http://jsfiddle.net/vsn32xp3/
@@ -80,8 +84,6 @@ module.exports = {
     ast.traverseByType('block', function (block) {
       var properties = [],
           sorted,
-          pKeys,
-          sKeys,
           expectedOrder,
           currentOrder;
 

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -4,6 +4,7 @@ var helpers = require('../helpers'),
     yaml = require('js-yaml'),
     fs = require('fs'),
     path = require('path'),
+    sortBy = require('lodash.sortby'),
     propertyCheckList,
     orderPresets,
     getOrderConfig,
@@ -21,77 +22,49 @@ orderPresets = {
 getOrderConfig = function (order) {
   var filename,
       orderConfig;
-  if (typeof order === 'string') {
-    if (orderPresets.hasOwnProperty(order)) {
-      filename = orderPresets[order],
-      orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
 
-      return orderConfig.order;
-    }
+  if (typeof order === 'string' && orderPresets.hasOwnProperty(order)) {
+    filename = orderPresets[order],
+    orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
+
+    return orderConfig.order;
   }
 
   return false;
 };
 
-sortProperties = function (obj, order) {
-  var keys = Object.keys(obj),
-      unknown = [],
-      sorted = {},
+/**
+ * Sorts properties using alphabetical order or based on order array properties.
+ *
+ * @param {Object[]} properties
+ * @param {string|string[]} order
+ * @returns {Object[]}
+ */
+sortProperties = function (properties, order) {
+  var sorted,
       i,
       orderedKeys;
 
   if (typeof order === 'string') {
     if (order === 'alphabetical') {
-      keys = keys.sort();
-    }
-  }
-  else if (typeof order === 'object') {
-    orderedKeys = [];
-
-    for (i = 0; i < order.length; i++) {
-      if (keys.indexOf(order[i]) !== -1) {
-        orderedKeys.push(order[i]);
-      }
+      return sortBy(properties, 'name');
     }
 
-    keys = orderedKeys;
-  }
-  else {
-    keys = keys.sort(function (a, b) {
-      if (order.indexOf(a) === -1) {
-        if (unknown.indexOf(a) === -1) {
-          unknown.push(a);
-        }
-      }
-      if (order.indexOf(b) === -1) {
-        if (unknown.indexOf(b) === -1) {
-          unknown.push(b);
-        }
-      }
+    throw new Error('Unexpected sorting order.');
+  } else {
+    sorted = sortBy(properties, 'name');
 
-      if (order.indexOf(a) > order.indexOf(b)) {
-        return 1;
-      }
-      if (order.indexOf(a) < order.indexOf(b)) {
-        return -1;
-      }
-      return 0;
+    // @see http://jsfiddle.net/vsn32xp3/
+    sorted = sortBy(sorted, function (property) {
+      var matchIndex;
+
+      matchIndex = order.indexOf(property.name);
+
+      return matchIndex === -1 ? properties.length : matchIndex;
     });
+
+    return sorted;
   }
-
-  for (i = 0; i < unknown.length; i++) {
-    if (keys.indexOf(unknown[i]) !== -1) {
-      keys.splice(keys.indexOf(unknown[i]), 1);
-    }
-  }
-
-  keys = keys.concat(unknown.sort());
-
-  for (i = 0; i < keys.length; i++) {
-    sorted[keys[i]] = obj[keys[i]];
-  }
-
-  return sorted;
 };
 
 module.exports = {
@@ -105,10 +78,12 @@ module.exports = {
         order = getOrderConfig(parser.options.order) || parser.options.order;
 
     ast.traverseByType('block', function (block) {
-      var properties = {},
+      var properties = [],
           sorted,
           pKeys,
-          sKeys;
+          sKeys,
+          expectedOrder,
+          currentOrder;
 
       if (block) {
         block.forEach('declaration', function (dec) {
@@ -118,35 +93,51 @@ module.exports = {
           if (name) {
             if (parser.options['ignore-custom-properties']) {
               if (propertyCheckList.indexOf(name.content) !== -1) {
-                properties[name.content] = prop;
+                properties.push({
+                  name: name.content,
+                  line: prop.start.line,
+                  column: prop.start.column
+                });
               }
             }
             else {
-              properties[name.content] = prop;
+              properties.push({
+                name: name.content,
+                line: prop.start.line,
+                column: prop.start.column
+              });
             }
           }
+
+
         });
+
+        // console.log('properties', properties);
+
+        // console.log('order', order);
 
         sorted = sortProperties(properties, order);
 
-        pKeys = Object.keys(properties);
-        sKeys = Object.keys(sorted);
+        expectedOrder = sorted.map(function (prop) {
+          return prop.name;
+        }).join(', ');
 
-        sKeys.every(function (e, i) {
-          var pKey = pKeys[i],
-              prop = properties[pKey];
+        currentOrder = properties.map(function (prop) {
+          return prop.name;
+        }).join(', ');
 
-          if (e !== pKey) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': prop.start.line,
-              'column': prop.start.column,
-              'message': 'Expected `' + e + '`, found `' + pKey + '`',
-              'severity': parser.severity
-            });
-          }
-          return true;
-        });
+        // console.log('expectedOrder', expectedOrder);
+        // console.log('currentOrder', currentOrder);
+
+        if (expectedOrder !== currentOrder) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': block.start.line,
+            'column': block.start.column,
+            'message': 'Expected "' + expectedOrder + '", found "' + currentOrder + '"',
+            'severity': parser.severity
+          });
+        }
       }
     });
 

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -87,59 +87,47 @@ module.exports = {
           expectedOrder,
           currentOrder;
 
-      if (block) {
-        block.forEach('declaration', function (dec) {
-          var prop = dec.first('property'),
-              name = prop.first('ident');
+      if (!block) {
+        return;
+      }
 
-          if (name) {
-            if (parser.options['ignore-custom-properties']) {
-              if (propertyCheckList.indexOf(name.content) !== -1) {
-                properties.push({
-                  name: name.content,
-                  line: prop.start.line,
-                  column: prop.start.column
-                });
-              }
-            }
-            else {
-              properties.push({
-                name: name.content,
-                line: prop.start.line,
-                column: prop.start.column
-              });
-            }
-          }
+      block.forEach('declaration', function (dec) {
+        var prop = dec.first('property'),
+            name = prop.first('ident');
 
-
-        });
-
-        // console.log('properties', properties);
-
-        // console.log('order', order);
-
-        sorted = sortProperties(properties, order);
-
-        expectedOrder = sorted.map(function (prop) {
-          return prop.name;
-        }).join(', ');
-
-        currentOrder = properties.map(function (prop) {
-          return prop.name;
-        }).join(', ');
-
-        // console.log('expectedOrder', expectedOrder);
-        // console.log('currentOrder', currentOrder);
-
-        if (expectedOrder !== currentOrder) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': block.start.line,
-            'column': block.start.column,
-            'message': 'Expected "' + expectedOrder + '", found "' + currentOrder + '"',
-            'severity': parser.severity
-          });
+        if (!name) {
+          return;
         }
+
+        if (parser.options['ignore-custom-properties'] && propertyCheckList.indexOf(name.content) === -1) {
+          return;
+        }
+
+        properties.push({
+          name: name.content,
+          line: prop.start.line,
+          column: prop.start.column
+        });
+      });
+
+      sorted = sortProperties(properties, order);
+
+      expectedOrder = sorted.map(function (prop) {
+        return prop.name;
+      }).join(', ');
+
+      currentOrder = properties.map(function (prop) {
+        return prop.name;
+      }).join(', ');
+
+      if (expectedOrder !== currentOrder) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': block.start.line,
+          'column': block.start.column,
+          'message': 'Expected "' + expectedOrder + '", found "' + currentOrder + '"',
+          'severity': parser.severity
+        });
       }
     });
 

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -130,7 +130,7 @@ validateSeparation = function (parser, block, expectedPropertyOrder) {
   expectedPropertyOrder = clone(expectedPropertyOrder);
 
   // First remove expectedPropertyOrder properties that do not appear in blockProperties.
-  expectedPropertyOrder = expectedPropertyOrder.filter((propertyName) => {
+  expectedPropertyOrder = expectedPropertyOrder.filter(function (propertyName) {
     if (propertyName === GROUP_SEPARATOR) {
       return true;
     }
@@ -141,7 +141,7 @@ validateSeparation = function (parser, block, expectedPropertyOrder) {
   expectedPropertyOrder = trimGroupSeparator(expectedPropertyOrder);
 
   // Then do the inverse with blockProperties.
-  blockProperties = blockProperties.filter((propertyName) => {
+  blockProperties = blockProperties.filter(function (propertyName) {
     if (propertyName === GROUP_SEPARATOR) {
       return true;
     }

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -3,21 +3,28 @@
 var helpers = require('../helpers'),
     yaml = require('js-yaml'),
     fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    propertyCheckList,
+    orderPresets,
+    getOrderConfig,
+    sortProperties;
 
-var propertyCheckList = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
 
-var orderPresets = {
+propertyCheckList = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
+
+orderPresets = {
   'recess': 'recess.yml',
   'smacss': 'smacss.yml',
   'concentric': 'concentric.yml'
 };
 
-var getOrderConfig = function (order) {
+getOrderConfig = function (order) {
+  var filename,
+      orderConfig;
   if (typeof order === 'string') {
     if (orderPresets.hasOwnProperty(order)) {
-      var filename = orderPresets[order],
-          orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
+      filename = orderPresets[order],
+      orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
 
       return orderConfig.order;
     }
@@ -26,11 +33,12 @@ var getOrderConfig = function (order) {
   return false;
 };
 
-var sortProperties = function (obj, order) {
+sortProperties = function (obj, order) {
   var keys = Object.keys(obj),
       unknown = [],
       sorted = {},
-      i;
+      i,
+      orderedKeys;
 
   if (typeof order === 'string') {
     if (order === 'alphabetical') {
@@ -38,7 +46,7 @@ var sortProperties = function (obj, order) {
     }
   }
   else if (typeof order === 'object') {
-    var orderedKeys = [];
+    orderedKeys = [];
 
     for (i = 0; i < order.length; i++) {
       if (keys.indexOf(order[i]) !== -1) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gonzales-pe": "3.0.0-31",
     "js-yaml": "^3.2.6",
     "lodash.capitalize": "^3.0.0",
+    "lodash.clone": "^3.0.3",
     "lodash.kebabcase": "^3.0.1",
     "lodash.sortby": "^3.1.5",
     "merge": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "js-yaml": "^3.2.6",
     "lodash.capitalize": "^3.0.0",
     "lodash.kebabcase": "^3.0.1",
+    "lodash.sortby": "^3.1.5",
     "merge": "^1.2.0",
     "util": "^0.10.3"
   },

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -5,7 +5,7 @@ var lint = require('./_lint');
 //////////////////////////////
 // SCSS syntax tests
 //////////////////////////////
-describe('property sort order - scss', function () {
+describe.only('property sort order - scss', function () {
   var file = lint.file('property-sort-order.scss');
 
   it('[order: alphabetical]', function (done) {

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -12,7 +12,12 @@ describe('property sort order - scss', function () {
     lint.test(file, {
       'property-sort-order': 1
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "border, content, height, width", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "border, composes, display, height, width", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "border, composes, display, height, width", found "height, display, width, border, composes"', data.messages[3].message);
+
       done();
     });
   });
@@ -26,7 +31,11 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "border, content, height, width", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[3].message);
       done();
     });
   });
@@ -45,7 +54,12 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "height, width, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "height, width, display, border, composes", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "height, width, display, border, composes", found "height, display, width, border, composes"', data.messages[3].message);
+
       done();
     });
   });
@@ -66,7 +80,12 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "height, width, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "height, composes, width, display, border", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "height, composes, width, display, border", found "height, display, width, border, composes"', data.messages[3].message);
+
       done();
     });
   });
@@ -86,7 +105,12 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "height, width, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[3].message);
+
       done();
     });
   });
@@ -100,35 +124,12 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
-    });
-  });
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "display, width, height, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "width, height, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "composes, display, width, height, border", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "composes, display, width, height, border", found "height, display, width, border, composes"', data.messages[3].message);
 
-  it('[order: smacss]', function (done) {
-    lint.test(file, {
-      'property-sort-order': [
-        1,
-        {
-          'order': 'smacss'
-        }
-      ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
-    });
-  });
-
-  it('[order: concentric]', function (done) {
-    lint.test(file, {
-      'property-sort-order': [
-        1,
-        {
-          'order': 'concentric'
-        }
-      ]
-    }, function (data) {
-      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -144,7 +145,12 @@ describe('property sort order - sass', function () {
     lint.test(file, {
       'property-sort-order': 1
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "border, content, height, width", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "border, composes, display, height, width", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "border, composes, display, height, width", found "height, display, width, border, composes"', data.messages[3].message);
+
       done();
     });
   });
@@ -158,7 +164,14 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      // console.log(data.messages.map(function (m, i) { return 'lint.assert.equal(\'' + m.message + '\', data.messages[' + i + '].message);'; }).join('\n'));
+
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "border, content, height, width", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "border, display, height, width", found "height, display, width, border"', data.messages[3].message);
+
       done();
     });
   });
@@ -177,7 +190,12 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "height, width, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "height, width, display, border, composes", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "height, width, display, border, composes", found "height, display, width, border, composes"', data.messages[3].message);
+
       done();
     });
   });
@@ -198,7 +216,12 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "height, width, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "height, composes, width, display, border", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "height, composes, width, display, border", found "height, display, width, border, composes"', data.messages[3].message);
+
       done();
     });
   });
@@ -218,7 +241,12 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "height, width, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "height, width, display, border", found "height, display, width, border"', data.messages[3].message);
+
       done();
     });
   });
@@ -232,35 +260,14 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
-    });
-  });
+      // console.log(data.messages.map(function (m, i) { return 'lint.assert.equal(\'' + m.message + '\', data.messages[' + i + '].message);'; }).join('\n'));
 
-  it('[order: smacss]', function (done) {
-    lint.test(file, {
-      'property-sort-order': [
-        1,
-        {
-          'order': 'smacss'
-        }
-      ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
-    });
-  });
+      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal('Expected "display, width, height, border", found "height, display, width, border"', data.messages[0].message);
+      lint.assert.equal('Expected "width, height, border, content", found "width, content, border, height"', data.messages[1].message);
+      lint.assert.equal('Expected "composes, display, width, height, border", found "composes, height, display, width, border"', data.messages[2].message);
+      lint.assert.equal('Expected "composes, display, width, height, border", found "height, display, width, border, composes"', data.messages[3].message);
 
-  it('[order: concentric]', function (done) {
-    lint.test(file, {
-      'property-sort-order': [
-        1,
-        {
-          'order': 'concentric'
-        }
-      ]
-    }, function (data) {
-      lint.assert.equal(14, data.warningCount);
       done();
     });
   });

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -5,7 +5,7 @@ var lint = require('./_lint');
 //////////////////////////////
 // SCSS syntax tests
 //////////////////////////////
-describe.only('property sort order - scss', function () {
+describe('property sort order - scss', function () {
   var file = lint.file('property-sort-order.scss');
 
   it('[order: alphabetical]', function (done) {
@@ -129,6 +129,34 @@ describe.only('property sort order - scss', function () {
       lint.assert.equal('Expected "width, height, border, content", found "width, content, border, height"', data.messages[1].message);
       lint.assert.equal('Expected "composes, display, width, height, border", found "composes, height, display, width, border"', data.messages[2].message);
       lint.assert.equal('Expected "composes, display, width, height, border", found "height, display, width, border, composes"', data.messages[3].message);
+
+      done();
+    });
+  });
+
+  it('[order: custom + group separator]', function (done) {
+    file = lint.file('property-sort-order-group-separator.scss');
+
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'width',
+            'height',
+            '(group separator)',
+            'display',
+            '(group separator)',
+            'border',
+            'foo',
+            '(group separator)',
+            'bar'
+          ]
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      lint.assert.equal('Expected "width, height, (group separator), display, (group separator), border", found "width, height, (group separator), display, border"', data.messages[0].message);
 
       done();
     });

--- a/tests/sass/property-sort-order-group-separator.scss
+++ b/tests/sass/property-sort-order-group-separator.scss
@@ -1,0 +1,9 @@
+.foo {
+  width: 100vw;
+  height: 100vh;
+
+  display: block;
+  border: 1px;
+
+  content: '';
+}


### PR DESCRIPTION
This step is required to implement https://github.com/sasstools/sass-lint/issues/414.

The most notable, user affecting change is the error formatting for `property-sort-order` rule.

The new format is:

```js
result = helpers.addUnique(result, {
  'ruleId': parser.rule.name,
  'line': block.start.line,
  'column': block.start.column,
  'message': 'Expected "' + expectedOrder + '", found "' + currentOrder + '"',
  'severity': parser.severity
});
```

and it is reported per block, as opposed to per property.