### PR TITLE
Update dependencies & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sass Lint [![npm version](https://badge.fury.io/js/sass-lint.svg)](http://badge.fury.io/js/sass-lint) [![Build Status](https://travis-ci.org/sasstools/sass-lint.svg)](https://travis-ci.org/sasstools/sass-lint) [![Coverage Status](https://coveralls.io/repos/sasstools/sass-lint/badge.svg?branch=develop&service=github)](https://coveralls.io/github/sasstools/sass-lint?branch=develop)
+# Sass Lint [![npm version](https://badge.fury.io/js/sass-lint.svg)](http://badge.fury.io/js/sass-lint) [![Build Status](https://travis-ci.org/sasstools/sass-lint.svg)](https://travis-ci.org/sasstools/sass-lint) [![Coverage Status](https://coveralls.io/repos/sasstools/sass-lint/badge.svg?branch=develop&service=github)](https://coveralls.io/github/sasstools/sass-lint?branch=develop) [![Dependency Status](https://david-dm.org/sasstools/sass-lint.svg)](https://david-dm.org/sasstools/sass-lint#info=dependencies&view=list) [![Dev Dependency Status](https://david-dm.org/sasstools/sass-lint/dev-status.svg)](https://david-dm.org/sasstools/sass-lint#info=devDependencies&view=list)
 
 A Node-only Sass linter for both `sass` and `scss` syntax!
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "commander": "^2.8.1",
     "eslint": "^1.1.0",
-    "fs-extra": "^0.24.0",
-    "glob": "^5.0.15",
+    "fs-extra": "^0.26.0",
+    "glob": "^6.0.0",
     "gonzales-pe": "3.0.0-31",
     "js-yaml": "^3.2.6",
     "lodash.capitalize": "^3.0.0",


### PR DESCRIPTION
No issue for this one as it's more a housekeeping task, but it was suggested in the Atom.io slack that sass-lint includes a badge to highlight its dependency status.

This PR updates the 2 out of date dependencies we had (excluding gonzales) and then includes badges for the Readme to make these dependency updates easier to spot in the future.

`DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com`