### PR TITLE
Fix issue with percentages in values

### DIFF
--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -48,7 +48,7 @@ var checkSpacing = function (node, i, parent, parser, result) {
       if (parent.is('value')) {
         // 1. We should allow valid CSS use of leading - operator when
         // defining negative values (margin, top, etc)
-        if (parent.is('value') && operator === '-' && next.is('dimension')) {
+        if (parent.is('value') && operator === '-' && (next.is('dimension') || next.is('percentage'))) {
           return false;
         }
 
@@ -72,7 +72,10 @@ var checkSpacing = function (node, i, parent, parser, result) {
     if (operators.indexOf(operator) !== -1) {
 
       if (parser.options.include) {
-        if (!previous.is('space') || !next.is('space')) {
+        if (
+          (previous && !previous.is('space'))
+          || (next && !next.is('space'))
+        ) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': node.start.line,
@@ -97,7 +100,10 @@ var checkSpacing = function (node, i, parent, parser, result) {
         }
       }
       else {
-        if (previous.is('space') || next.is('space')) {
+        if (
+          (previous && previous.is('space'))
+          || (next && next.is('space'))
+        ) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': node.start.line,

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -319,7 +319,10 @@ $qux: (2  +1)
 // Should be ok
 //====================
 
-// Valid CSS
+$foo: scale-color($foo, $lightness: -14%)
+
+.foo
+  top: -10px
 
 .foo
   margin: 5px -15px
@@ -328,7 +331,28 @@ $qux: (2  +1)
   margin: -10px -15px
 
 .foo
-  top: -10px
+  margin: -10px 10px -15px
+
+.foo
+  margin: -10px -15px -15px
+
+.foo
+  margin: -10px -15px -15px -15px
+
+.foo
+  margin: -10rem -15em -15px 15px
+
+.foo
+  margin-bottom: -20px
+
+.foo
+  width: 100%
+
+.foo
+  width: calc(100% - 20px)
+
+.foo
+  width: calc(100% / 2)
 
 .foo
   margin-bottom: -20px

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -13,6 +13,10 @@
 }
 
 .foo {
+  margin: 5px -15px;
+}
+
+.foo {
   margin: 5px+ 15px;
 }
 
@@ -322,7 +326,13 @@ $qux: (2  +1);
 // Should be ok
 //====================
 
+$foo: scale-color($foo, $lightness: -14%);
+
 // Valid CSS
+
+.foo {
+  top: -10px;
+}
 
 .foo {
   margin: 5px -15px;
@@ -333,7 +343,19 @@ $qux: (2  +1);
 }
 
 .foo {
-  top: -10px;
+  margin: -10px 10px -15px;
+}
+
+.foo {
+  margin: -10px -15px -15px;
+}
+
+.foo {
+  margin: -10px -15px -15px -15px;
+}
+
+.foo {
+  margin: -10rem -15em -15px 15px;
 }
 
 .foo {
@@ -341,10 +363,19 @@ $qux: (2  +1);
 }
 
 .foo {
-  font: italic small-caps bolder 16px/3 cursive;
+  width: 100%;
 }
 
 .foo {
+  width: calc(100% - 20px);
+}
+
+.foo {
+  width: calc(100% / 2);
+}
+
+.foo {
+  font: italic small-caps bolder 16px/3 cursive;
   font: italic small-caps bolder 16px/8px cursive;
 }
 
@@ -358,9 +389,6 @@ ul {
 
 .foo {
   font: italic small-caps bolder 16px / 3 cursive;
-}
-
-.foo {
   font: italic small-caps bolder 16px / 8px cursive;
 }
 

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -326,9 +326,9 @@ $qux: (2  +1);
 // Should be ok
 //====================
 
-$foo: scale-color($foo, $lightness: -14%);
-
 // Valid CSS
+
+$foo: scale-color($foo, $lightness: -14%);
 
 .foo {
   top: -10px;


### PR DESCRIPTION
Fixes #425. 

Rule had an issue with percentages as values like the example below:

`scale-color($a-font-color, $lightness: -14%);`

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com