### PR TITLE
Set severity and options at the top of function

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -27,21 +27,30 @@ module.exports = function (config) {
   Object.keys(config.rules).forEach(function (rule) {
     var fullRule = config.rules[rule],
         loadRule,
+        severity,
         options,
         ruleSearch;
+
+    if (typeof fullRule === 'number') {
+      severity = fullRule;
+      options = {};
+    }
+    else {
+      severity = fullRule[0];
+      options = fullRule[1];
+    }
+
     // Only seek out rules that are enabled
-    if ((typeof fullRule === 'number' && fullRule !== 0) || (typeof fullRule === 'object' && fullRule[0] !== 0)) {
+    if (severity !== 0) {
       ruleSearch = searchArray(rules, rule);
       if (ruleSearch >= 0) {
         loadRule = require(rules[ruleSearch]);
-
-        options = typeof fullRule === 'object' ? fullRule[1] : {};
 
         options = merge.recursive(true, loadRule.defaults, options);
 
         handlers.push({
           'rule': loadRule,
-          'severity': typeof fullRule === 'number' ? fullRule : fullRule[0],
+          'severity': severity,
           'options': options
         });
       }


### PR DESCRIPTION
Checking `typeof fullRule` 1 time up front instead of 3-4 times throughout the function seems cleaner.

DCO 1.1 Signed-off-by: Benjamin Quorning <dco@quorning.net>