### PR TITLE
Adjust no-trailing-zero to fail on first decimal

### DIFF
--- a/docs/rules/no-trailing-zero.md
+++ b/docs/rules/no-trailing-zero.md
@@ -18,4 +18,8 @@ When enabled, the following are disallowed:
 .foo {
   margin: 0.2500rem;
 }
+
+.foo {
+  margin: 4.0rem;
+}
 ```

--- a/lib/rules/no-trailing-zero.js
+++ b/lib/rules/no-trailing-zero.js
@@ -2,7 +2,7 @@
 
 var helpers = require('../helpers');
 
-var trailingZeroRegex = /^(\d+\.|\.)+(\d*?[1-9])0+$/;
+var trailingZeroRegex = /^(\d+\.|\.)+(\d*?)0+$/;
 
 module.exports = {
   'name': 'no-trailing-zero',

--- a/tests/rules/no-trailing-zero.js
+++ b/tests/rules/no-trailing-zero.js
@@ -12,7 +12,7 @@ describe('no trailing zero - scss', function () {
     lint.test(file, {
       'trailing-zero': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no trailing zero - sass', function () {
     lint.test(file, {
       'trailing-zero': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });

--- a/tests/rules/no-trailing-zero.js
+++ b/tests/rules/no-trailing-zero.js
@@ -12,7 +12,7 @@ describe('no trailing zero - scss', function () {
     lint.test(file, {
       'trailing-zero': 1
     }, function (data) {
-      lint.assert.equal(3, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no trailing zero - sass', function () {
     lint.test(file, {
       'trailing-zero': 1
     }, function (data) {
-      lint.assert.equal(3, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-trailing-zero.sass
+++ b/tests/sass/no-trailing-zero.sass
@@ -23,4 +23,19 @@
 
 
 .foo
+  margin: 5.0rem
+
+.foo
+  margin: 5.00rem
+
+.foo
+  margin: .000rem
+
+.foo
+  margin: 0.0rem
+
+.foo
+  margin: .0rem
+
+.foo
   margin: 0

--- a/tests/sass/no-trailing-zero.scss
+++ b/tests/sass/no-trailing-zero.scss
@@ -23,5 +23,25 @@
 }
 
 .foo {
+  margin: 5.0rem;
+}
+
+.foo {
+  margin: 5.00rem;
+}
+
+.foo {
+  margin: .000rem;
+}
+
+.foo {
+  margin: 0.0rem;
+}
+
+.foo {
+  margin: .0rem;
+}
+
+.foo {
   margin: 0;
 }


### PR DESCRIPTION
The `no-trailing-zero` rule was not failing on numbers like `1.0`, as the regular expression required there to be a non-zero number in the decimal for the check to work.  

This change removes that constraint and adds test cases to make sure that the result works as expected.  The change fixes #438 and fixes #439.

DCO 1.1 Signed-off-by: Drew Hays <drewshays@gmail.com>