### PR TITLE
Bem Depth remove stray console.logs

### DIFF
--- a/tests/rules/bem-depth.js
+++ b/tests/rules/bem-depth.js
@@ -57,7 +57,6 @@ describe('bem depth - sass', function () {
     lint.test(file, {
       'bem-depth': [1, { 'max-depth': 0 }]
     }, function (data) {
-      console.log(data);
       lint.assert.equal(12, data.warningCount);
       done();
     });
@@ -67,7 +66,6 @@ describe('bem depth - sass', function () {
     lint.test(file, {
       'bem-depth': 1
     }, function (data) {
-      console.log(data);
       lint.assert.equal(6, data.warningCount);
       done();
     });


### PR DESCRIPTION
Dont know how but some console logs managed to slip through with the recent bem-depth rule, my bad!

Anyway this just removes them...

`DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com`