### PR TITLE
Add missing contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The long overdue update!
 * [Dan Purdy](https://github.com/DanPurdy)
 * [Ben Rothman](https://github.com/benthemonkey)
 * [Don Abrams](https://github.com/donabrams)
+* [Andrew Hays](https://github.com/Dru89)
 * [Kaelig](https://github.com/kaelig)
 
 **A big thankyou to everyone who reported issues or contributed to the discussion around issues**


### PR DESCRIPTION
Massive apologies to @Dru89 I added him to the changelog and then replaced him with someone else!

A big thankyou for your contributions your name will be added with our next update!

`DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com`