### PR TITLE
Fix 'ignore' setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,14 +32,16 @@ sassLint.resultCount = function (results) {
 };
 
 sassLint.lintText = function (file, options, configPath) {
-  var rules = slRules(this.getConfig(options, configPath)),
+  var config = this.getConfig(options, configPath),
+      rules = slRules(config),
       ast = groot(file.text, file.format, file.filename),
       detects,
       results = [],
       errors = 0,
-      warnings = 0;
+      warnings = 0,
+      ignores = config.files.ignore || '';
 
-  if (ast.content.length > 0) {
+  if (ignores.indexOf(file.filename) === -1 && ast.content.length > 0) {
     rules.forEach(function (rule) {
       detects = rule.rule.detect(ast, rule);
       results = results.concat(detects);

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ var slConfig = require('./lib/config'),
     glob = require('glob'),
     path = require('path'),
     jsonFormatter = require('eslint/lib/formatters/json'),
-    fs = require('fs-extra'),
-    minimatch = require('minimatch');
+    fs = require('fs-extra');
 
 
 var sassLint = function (config) {
@@ -41,20 +40,8 @@ sassLint.lintText = function (file, options, configPath) {
       errors = 0,
       warnings = 0,
       ignoredFiles = config.files.ignore || '',
-      ignore = false;
+      ignore = helpers.checkIfIgnored(file, ignoredFiles);
 
-  if (ignoredFiles instanceof Array && ignoredFiles.length > 0) {
-    ignoredFiles.forEach(function (ignorePath) {
-      if (minimatch(file.filename, ignorePath)) {
-        ignore = true;
-      }
-    });
-  }
-  else if (typeof ignoredFiles === 'string') {
-    if (minimatch(file.filename, ignoredFiles)) {
-      ignore = true;
-    }
-  }
 
   if (!ignore && ast.content.length > 0) {
     rules.forEach(function (rule) {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ sassLint.lintText = function (file, options, configPath) {
     }
   });
 
-  if (ast.content.length > 0) {
+  if (!ignore && ast.content.length > 0) {
     rules.forEach(function (rule) {
       detects = rule.rule.detect(ast, rule);
       results = results.concat(detects);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var slConfig = require('./lib/config'),
     glob = require('glob'),
     path = require('path'),
     jsonFormatter = require('eslint/lib/formatters/json'),
-    fs = require('fs-extra');
+    fs = require('fs-extra'),
+    minimatch = require('minimatch');
 
 
 var sassLint = function (config) {
@@ -39,9 +40,16 @@ sassLint.lintText = function (file, options, configPath) {
       results = [],
       errors = 0,
       warnings = 0,
-      ignores = config.files.ignore || '';
+      ignoreList = config.files.ignore || '',
+      ignore = false;
 
-  if (ignores.indexOf(file.filename) === -1 && ast.content.length > 0) {
+  ignoreList.forEach(function (ignorePath) {
+    if (minimatch(file.filename, ignorePath)) {
+      ignore = true;
+    }
+  });
+
+  if (ast.content.length > 0) {
     rules.forEach(function (rule) {
       detects = rule.rule.detect(ast, rule);
       results = results.concat(detects);

--- a/index.js
+++ b/index.js
@@ -40,14 +40,21 @@ sassLint.lintText = function (file, options, configPath) {
       results = [],
       errors = 0,
       warnings = 0,
-      ignoreList = config.files.ignore || '',
+      ignoredFiles = config.files.ignore || '',
       ignore = false;
 
-  ignoreList.forEach(function (ignorePath) {
-    if (minimatch(file.filename, ignorePath)) {
+  if (ignoredFiles instanceof Array && ignoredFiles.length > 0) {
+    ignoredFiles.forEach(function (ignorePath) {
+      if (minimatch(file.filename, ignorePath)) {
+        ignore = true;
+      }
+    });
+  }
+  else if (typeof ignoredFiles === 'string') {
+    if (minimatch(file.filename, ignoredFiles)) {
       ignore = true;
     }
-  });
+  }
 
   if (!ignore && ast.content.length > 0) {
     rules.forEach(function (rule) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,8 @@ var util = require('util'),
     fs = require('fs'),
     path = require('path'),
     yaml = require('js-yaml'),
-    merge = require('merge');
+    merge = require('merge'),
+    minimatch = require('minimatch');
 
 /**
  * Easy access to the 'merge' library's cloning functionality
@@ -452,6 +453,34 @@ helpers.collectSuffixExtensions = function (ruleset, selectorType) {
   });
 
   return parentSelectors.concat(selectorList);
+};
+
+/**
+ * Checks if given file matches any of given patterns or filenames.
+ * If yes return true - so it will be ignored in linting process.
+ *
+ * @param  {object} file                object with 'filename' property
+ * @param  {string|array} ignoredFiles  ignoredFiles filename(s) or path(s)
+ *                                      eg. 'sass/variables.scss' | ['scss/vendor/*.scss']
+ * @returns {bool}                       true/false value if file should be ignored or not
+ */
+helpers.checkIfIgnored = function (file, ignoredFiles) {
+  var ignored = false;
+
+  if (ignoredFiles instanceof Array && ignoredFiles.length > 0) {
+    ignoredFiles.forEach(function (ignorePath) {
+      if (minimatch(file.filename, ignorePath)) {
+        ignored = true;
+      }
+    });
+  }
+  else if (typeof ignoredFiles === 'string') {
+    if (minimatch(file.filename, ignoredFiles)) {
+      ignored = true;
+    }
+  }
+
+  return ignored;
 };
 
 module.exports = helpers;

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "lodash.capitalize": "^3.0.0",
     "lodash.kebabcase": "^3.0.1",
     "merge": "^1.2.0",
-    "util": "^0.10.3",
-    "minimatch": "^3.0.0"
+    "minimatch": "^3.0.0",
+    "util": "^0.10.3"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lodash.capitalize": "^3.0.0",
     "lodash.kebabcase": "^3.0.1",
     "merge": "^1.2.0",
-    "util": "^0.10.3"
+    "util": "^0.10.3",
+    "minimatch": "^3.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -383,6 +383,10 @@ var detectTestA = {
       column: 2
     };
 
+var exampleFile = {
+  filename: 'sass/main/styles.scss'
+};
+
 
 describe('helpers', function () {
 
@@ -1672,5 +1676,45 @@ describe('helpers', function () {
       }),
       ['a', 'b', 'ac', 'bc', 'ad', 'bd', 'ace', 'bce', 'ade', 'bde', 'acf', 'bcf', 'adf', 'bdf']
     );
+  });
+
+  //////////////////////////////
+  // checkIfIgnored
+  //////////////////////////////
+  it('checkIfIgnored - string with filename', function () {
+    var ignoredFiles = 'sass/main/styles.scss';
+    var ignored = helpers.checkIfIgnored(exampleFile, ignoredFiles);
+
+    assert.equal(ignored, true);
+  });
+
+  it('checkIfIgnored - string with path', function (done) {
+    var ignoredFiles = 'sass/**/*.scss';
+    var ignored = helpers.checkIfIgnored(exampleFile, ignoredFiles);
+
+    assert.equal(ignored, true);
+    done();
+  });
+
+  it('checkIfIgnored - array with filenames/paths - false', function (done) {
+    var ignoredFiles = [
+      'sass/vendor/**/*.scss',
+      'sass/variables.scss'
+    ];
+    var ignored = helpers.checkIfIgnored(exampleFile, ignoredFiles);
+
+    assert.equal(ignored, false);
+    done();
+  });
+
+  it('checkIfIgnored - array with filenames/paths - true', function (done) {
+    var ignoredFiles = [
+      'sass/vendor/**/*.scss',
+      'sass/main/**/*.scss'
+    ];
+    var ignored = helpers.checkIfIgnored(exampleFile, ignoredFiles);
+
+    assert.equal(ignored, true);
+    done();
   });
 });


### PR DESCRIPTION
When trying to set 'ignore' some files from linting, current version of sass-lint doesn't get it, and lint them anyway. I'm checking if current file in 'lintText()' is in configs ignore list, and prevent from linting it.

DCO 1.1 Signed-off-by: Michał Sajnóg <michal.sajnog@hotmail.com>