### PR TITLE
Fix 'indentation' setting

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -54,8 +54,8 @@ module.exports = {
               if (count !== spaceLength) {
                 result = helpers.addUnique(result, {
                   'ruleId': parser.rule.name,
-                  'line': node.content[i + 1].start.line,
-                  'column': node.content[i + 1].start.column,
+                  'line': node.start.line,
+                  'column': node.start.column,
                   'message': 'Mixed tabs and spaces',
                   'severity': parser.severity
                 });
@@ -63,8 +63,8 @@ module.exports = {
               if (i !== node.length - 1) {
                 result = helpers.addUnique(result, {
                   'ruleId': parser.rule.name,
-                  'line': node.content[i + 1].start.line,
-                  'column': node.content[i + 1].start.column,
+                  'line': node.start.line,
+                  'column': node.start.column,
                   'message': 'Indentation of ' + spaceLength + ', expected ' + level * parser.options.size,
                   'severity': parser.severity
                 });


### PR DESCRIPTION
When I try to run sass-lint with webpack, the indentation validation seems to fail when it creates the props of the warning message. By removing content[i+1], the messages are well generated.

This is the indentation prop in .sass-lint.yml to replicate the error and the output.

```
  indentation:
    - 1
    - size: 2
```

> Output:
> Module build failed: ModuleBuildError: Module build failed: TypeError: Cannot read property 'start' of undefined
> at processNode (node_modules\sass-lint\lib\rules\indentation.js:57:46)