### PR TITLE
Fix issue with negative z-index and space-around-operator

### DIFF
--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -65,6 +65,11 @@ var checkSpacing = function (node, i, parent, parser, result) {
             return false;
           }
         }
+        // If we have a negative value without a preceeding value then we should
+        // return false
+        else {
+          return false;
+        }
       }
     }
 

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -447,3 +447,6 @@ $qux: (2 * 1) // FIXME: Gonzales - FIXED IN BETA
 
 h1
   +large-text
+
+.foo
+  z-index: -1

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -452,3 +452,7 @@ $qux: (2 * 1); // FIXME: Gonzales - FIXED IN BETA
 @if ($foo <= $bar) {
   $baz: 1;
 }
+
+.foo {
+  z-index: -1;
+}


### PR DESCRIPTION
Fixes an issue where negative value for z-index was incorrectly flagged up. Rule should now ignore all negative values that do not have proceeding value.

Closes #454 