### PR TITLE
Gonzales 3.2 - Fix space-after-bang rule

### DIFF
--- a/lib/rules/space-after-bang.js
+++ b/lib/rules/space-after-bang.js
@@ -11,7 +11,7 @@ module.exports = {
     var result = [],
         regex = /!\s/;
 
-    ast.traverseByTypes(['important', 'default', 'global'], function (block) {
+    ast.traverseByTypes(['important', 'default', 'global', 'optional'], function (block) {
       if (block.content.match(regex) !== null) {
         if (parser.options.include) {
           result = helpers.addUnique(result, {

--- a/lib/rules/space-after-bang.js
+++ b/lib/rules/space-after-bang.js
@@ -11,7 +11,7 @@ module.exports = {
     var result = [],
         regex = /!\s/;
 
-    ast.traverseByTypes(['important', 'default'], function (block) {
+    ast.traverseByTypes(['important', 'default', 'global'], function (block) {
       if (block.content.match(regex) !== null) {
         if (parser.options.include) {
           result = helpers.addUnique(result, {

--- a/lib/rules/space-after-bang.js
+++ b/lib/rules/space-after-bang.js
@@ -8,31 +8,30 @@ module.exports = {
     'include': false
   },
   'detect': function (ast, parser) {
-    var result = [];
+    var result = [],
+        regex = /!\s/;
 
     ast.traverseByTypes(['important', 'default'], function (block) {
-      block.traverse(function (item) {
-        if (item.type === 'space') {
-          if (parser.options.include) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': block.start.line,
-              'column': block.start.column + 1,
-              'message': 'Bangs (!) should be followed by a space',
-              'severity': parser.severity
-            });
-          }
-          else {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': block.start.line,
-              'column': block.start.column,
-              'message': 'Bangs (!) should not be followed by a space',
-              'severity': parser.severity
-            });
-          }
+      if (block.content.match(regex) !== null) {
+        if (parser.options.include) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': block.start.line,
+            'column': block.start.column + 1,
+            'message': 'Bangs (!) should be followed by a space',
+            'severity': parser.severity
+          });
         }
-      });
+        else {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': block.start.line,
+            'column': block.start.column,
+            'message': 'Bangs (!) should not be followed by a space',
+            'severity': parser.severity
+          });
+        }
+      }
     });
 
     return result;

--- a/tests/rules/space-after-bang.js
+++ b/tests/rules/space-after-bang.js
@@ -12,7 +12,7 @@ describe('space after bang - scss', function () {
     lint.test(file, {
       'space-after-bang': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('space after bang - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -42,7 +42,7 @@ describe('space after bang - sass', function () {
     lint.test(file, {
       'space-after-bang': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space after bang - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });

--- a/tests/rules/space-after-bang.js
+++ b/tests/rules/space-after-bang.js
@@ -12,7 +12,7 @@ describe('space after bang - scss', function () {
     lint.test(file, {
       'space-after-bang': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('space after bang - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -42,7 +42,7 @@ describe('space after bang - sass', function () {
     lint.test(file, {
       'space-after-bang': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space after bang - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-after-bang.sass
+++ b/tests/sass/space-after-bang.sass
@@ -35,3 +35,18 @@ $bar: orange !global
 $baz: blue! global
 
 $qux: green ! global
+
+// Optional
+
+.foo
+  @extend .notice !optional
+
+.bar
+  @extend .notice ! optional
+
+// Both the following are invalid
+// .baz
+//   @extend .notice!optional
+//
+// .qux
+//   @extend .notice! optional

--- a/tests/sass/space-after-bang.sass
+++ b/tests/sass/space-after-bang.sass
@@ -20,9 +20,18 @@
 
 $foo: red!default
 
-$foo: orange !default
+$bar: orange !default
 
-$foo: blue! default
+$baz: blue! default
 
-$foo: green ! default
-  
+$qux: green ! default
+
+// Global
+
+$foo: red!global
+
+$bar: orange !global
+
+$baz: blue! global
+
+$qux: green ! global

--- a/tests/sass/space-after-bang.scss
+++ b/tests/sass/space-after-bang.scss
@@ -35,3 +35,22 @@ $bar: red !global;
 $baz: red! global;
 
 $qux: red ! global;
+
+// Optional
+
+.foo {
+  @extend .notice !optional;
+}
+
+.bar {
+  @extend .notice ! optional;
+}
+
+// Both the following are invalid
+// .baz {
+//   @extend .notice!optional;
+// }
+//
+// .qux {
+//   @extend .notice! optional;
+// }

--- a/tests/sass/space-after-bang.scss
+++ b/tests/sass/space-after-bang.scss
@@ -20,8 +20,18 @@
 
 $foo: red!default;
 
-$foo: red !default;
+$bar: red !default;
 
-$foo: red! default;
+$baz: red! default;
 
-$foo: red ! default;
+$qux: red ! default;
+
+// Global
+
+$foo: red!global;
+
+$bar: red !global;
+
+$baz: red! global;
+
+$qux: red ! global;


### PR DESCRIPTION
Fixes the `space-after-bang` rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking space-after-bang rule test success.

Fix was necessary as gonzales now doesn't break up `! default` into separate nodes and instead considers it just one string node of `! default`.

Also adds support global and optional.

Closes #305
Closes #56 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com