### PR TITLE
Gonzales 3.2 - Fix space-after-comma rule

### DIFF
--- a/lib/rules/space-after-comma.js
+++ b/lib/rules/space-after-comma.js
@@ -11,18 +11,25 @@ module.exports = {
     var result = [];
 
     ast.traverseByTypes(['operator', 'delimiter'], function (operator, i, parent) {
-      var next;
+      var next,
+          doubleNext;
 
       if (operator.content === ',') {
-        next = parent.content[i + 1];
+        next = parent.content[i + 1] || false;
+        doubleNext = parent.content[i + 2] || false;
 
         if (next) {
           if (operator.is('delimiter')) {
-            if (next.is('simpleSelector')) {
+            if (next.is('selector')) {
               next = next.content[0];
             }
           }
+
           if ((next.is('space') && !helpers.hasEOL(next.content)) && !parser.options.include) {
+            if (doubleNext && doubleNext.is('singlelineComment')) {
+              return false;
+            }
+
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,
               'line': next.start.line,
@@ -31,6 +38,7 @@ module.exports = {
               'severity': parser.severity
             });
           }
+
           if (!next.is('space') && parser.options.include) {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,


### PR DESCRIPTION
Fixes the `space-after-comma` rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `space-after-comma` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com