### PR TITLE
Gonzales 3.2 - Fix space-around-operator rule

### DIFF
--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -4,6 +4,12 @@ var helpers = require('../helpers');
 
 var operators = ['+', '-', '/', '*', '%', '<', '>', '==', '!=', '<=', '>='];
 
+/**
+ * Determine a relational operator based on the operator node
+ *
+ * @param {Object} node - The operator node
+ * @returns {string} Returns a relational operator
+ */
 var getRelationalOperator = function (node) {
   if (node.content === '<') {
     return '<=';
@@ -14,6 +20,16 @@ var getRelationalOperator = function (node) {
   }
 };
 
+/**
+ * Check the spacing around an operator
+ *
+ * @param {Object} node - The node to check the spacing around
+ * @param {int} i - The node's child index of it's parent
+ * @param {Object} parent - The parent node
+ * @param {Object} parser - The parser object
+ * @param {Object} result - The result object
+ * @returns {bool|null} false if exception
+ */
 var checkSpacing = function (node, i, parent, parser, result) {
   if (node.is('operator') || node.is('unaryOperator')) {
     var previous = parent.content[i - 1] || false,
@@ -131,8 +147,7 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    // FIXME: Gonzales v3 - No longer need atrulerq (for Sass)
-    ast.traverseByTypes(['condition', 'atruleb', 'value', 'atrulerq'], function (node) {
+    ast.traverseByTypes(['condition', 'atrule', 'value'], function (node) {
       node.forEach(function (item, i, parent) {
         // Perform another loop of the children if we come across a parenthesis
         // parent node

--- a/tests/rules/space-around-operator.js
+++ b/tests/rules/space-around-operator.js
@@ -12,7 +12,7 @@ describe('space around operator - scss', function () {
     lint.test(file, {
       'space-around-operator': 1
     }, function (data) {
-      lint.assert.equal(84, data.warningCount);
+      lint.assert.equal(91, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('space around operator - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(78, data.warningCount);
+      lint.assert.equal(90, data.warningCount);
       done();
     });
   });
@@ -42,7 +42,7 @@ describe('space around operator - sass', function () {
     lint.test(file, {
       'space-around-operator': 1
     }, function (data) {
-      lint.assert.equal(84, data.warningCount);
+      lint.assert.equal(87, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space around operator - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(78, data.warningCount);
+      lint.assert.equal(84, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -66,7 +66,7 @@ $qux: 2  +1
 $foo: (1+1)
 $bar: (2-1)
 $baz: (1/2)
-// $qux: (2*1) FIXME: Gonzales - FIXED IN BETA
+$qux: (2*1)
 // $norf: (5%2) Not valid SCSS.
 
 
@@ -75,7 +75,7 @@ $baz: (1/2)
 $foo: (1 +1)
 $bar: (2 -1)
 $baz: (1 /2)
-// $qux: (2 *1) FIXME: Gonzales - FIXED IN BETA
+$qux: (2 *1)
 // $norf: (5 %2) FIXME: Gonzales - FIXED IN BETA
 
 
@@ -84,7 +84,7 @@ $baz: (1 /2)
 $foo: (1+ 1)
 $bar: (2- 1)
 $baz: (1/ 2)
-// $qux: (2* 1) FIXME: Gonzales - FIXED IN BETA
+$qux: (2* 1)
 // $norf: (5% 2)  Not valid SCSS. Parses as 5 percent.
 
 
@@ -396,9 +396,7 @@ $qux: 2 * 1
 $foo: (1 + 1)
 $bar: (2 - 1)
 $baz: (1 / 2)
-// Include: false will ignore this, so count will be one down on what it should
-// be
-$qux: (2 * 1) // FIXME: Gonzales - FIXED IN BETA
+$qux: (2 * 1)
 // $norf: (5 % 2) FIXME: Gonzales - FIXED IN BETA
 
 // Space with no parens

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -48,7 +48,7 @@ $foo: 1 +1;
 $bar: 2 -1;
 $baz: 1 /2;
 $qux: 2 *1;
-// $norf: 5 %2; FIXME: Gonzales - FIXED IN BETA
+$norf: 5 %2;
 
 
 // No space before
@@ -66,14 +66,14 @@ $foo: 1     +    1;
 $bar: 2 +   1;
 $baz: 1     + 2;
 $qux: 2  +1;
-// $norf: 5  %    2; FIXME: Gonzales - FIXED IN BETA
+$norf: 5  %    2;
 
 // No space with parens
 
 $foo: (1+1);
 $bar: (2-1);
 $baz: (1/2);
-// $qux: (2*1); FIXME: Gonzales - FIXED IN BETA
+$qux: (2*1);
 // $norf: (5%2); Not valid SCSS.
 
 
@@ -82,8 +82,8 @@ $baz: (1/2);
 $foo: (1 +1);
 $bar: (2 -1);
 $baz: (1 /2);
-// $qux: (2 *1); FIXME: Gonzales - FIXED IN BETA
-// $norf: (5 %2); FIXME: Gonzales - FIXED IN BETA
+$qux: (2 *1);
+$norf: (5 %2);
 
 
 // No space before with parens
@@ -91,7 +91,7 @@ $baz: (1 /2);
 $foo: (1+ 1);
 $bar: (2- 1);
 $baz: (1/ 2);
-// $qux: (2* 1); FIXME: Gonzales - FIXED IN BETA
+$qux: (2* 1);
 // $norf: (5% 2);  Not valid SCSS. Parses as 5 percent.
 
 
@@ -101,7 +101,7 @@ $foo: (1     +    1);
 $bar: (2 +   1);
 $baz: (1     + 2);
 $qux: (2  +1);
-// $norf: (5   %   2); FIXME: Gonzales - FIXED IN BETA
+$norf: (5   %   2);
 
 
 
@@ -405,17 +405,15 @@ $foo: 1 + 1;
 $bar: 2 - 1;
 $baz: 1 / 2;
 $qux: 2 * 1;
-// $norf: 5 % 2; FIXME: Gonzales - FIXED IN BETA
+$norf: 5 % 2;
 
 // Values with parens
 
 $foo: (1 + 1);
 $bar: (2 - 1);
 $baz: (1 / 2);
-// Include: false will ignore this, so count will be one down on what it should
-// be
-$qux: (2 * 1); // FIXME: Gonzales - FIXED IN BETA
-// $norf: (5 % 2); FIXME: Gonzales - FIXED IN BETA
+$qux: (2 * 1);
+$norf: (5 % 2);
 
 // Space with no parens
 


### PR DESCRIPTION
Fixes the `space-around-operator` rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `space-around-operator` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com