### PR TITLE
Gonzales 3.2 - Fix placeholder-in-extend rule

### DIFF
--- a/lib/rules/placeholder-in-extend.js
+++ b/lib/rules/placeholder-in-extend.js
@@ -12,7 +12,7 @@ module.exports = {
       keyword.forEach(function (item) {
         if (item.content === 'extend') {
 
-          parent.forEach('simpleSelector', function (selector) {
+          parent.forEach('selector', function (selector) {
             var placeholder = false;
 
             selector.content.forEach(function (selectorPiece) {


### PR DESCRIPTION
Fixes the `placeholder-in-extend` rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `placeholder-in-extend` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com