### PR TITLE
Gonzales 3.2 - Fix spaceBeforeBrace

### DIFF
--- a/lib/rules/space-before-brace.js
+++ b/lib/rules/space-before-brace.js
@@ -7,7 +7,7 @@ var getLastWhitespace = function (node) {
     return null;
   }
 
-  if (typeof node !== 'object') {
+  if (!node) {
     return false;
   }
   if (node.is('space')) {


### PR DESCRIPTION
Fixes the `space-before-brace` rule to work with the latest version of gonzales.

node.last() changed from returning undefined to null. As ```typeof null === object``` the check was failing.
The new check is now accounting for all falsy values, and as false is captured in a separate check the logic is still the same.

DCO 1.1 Signed-off-by: Daniel Tschinder <code@tschinder.de>