### PR TITLE
Gonzales 3.2 - Fix extends-before-mixins rule

### DIFF
--- a/lib/rules/extends-before-mixins.js
+++ b/lib/rules/extends-before-mixins.js
@@ -12,11 +12,13 @@ module.exports = {
       var lastMixin = null;
 
       block.forEach(function (item, j) {
-        if (item.type === 'include' || item.type === 'extend') {
-          if (item.first('atkeyword')) {
+        // TODO: Remove tempory fix - atrule type is work around for issue:
+        // https://github.com/tonyganch/gonzales-pe/issues/147
+        if (item.is('include') || item.is('extend') || item.is('atrule')) {
+          if (item.contains('atkeyword')) {
             var atkeyword = item.first('atkeyword');
 
-            if (atkeyword.first('ident')) {
+            if (atkeyword.contains('ident')) {
               var ident = atkeyword.first('ident');
 
               if (ident.content === 'extend') {
@@ -34,7 +36,7 @@ module.exports = {
           }
         }
 
-        if (item.type === 'include') {
+        if (item.is('include')) {
           lastMixin = j;
         }
       });


### PR DESCRIPTION
Fixes the `extends-before-mixies` rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `extends-before-mixins` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com