### PR TITLE
Gonzales 3.2 - Fix extends-before-declarations rule

### DIFF
--- a/lib/rules/extends-before-declarations.js
+++ b/lib/rules/extends-before-declarations.js
@@ -13,25 +13,25 @@ module.exports = {
       var lastDeclaration = null;
 
       block.forEach(function (item, j) {
-        if ((item.type === 'include' || item.type === 'extend') &&
+        // TODO: Remove tempory fix - atrule type is work around for issue:
+        // https://github.com/tonyganch/gonzales-pe/issues/147
+        if ((item.is('include') || item.is('extend') || item.is('atrule')) &&
             item.first('atkeyword')) {
           if (item.first('atkeyword').first('ident').content === 'extend') {
             if (j > lastDeclaration && lastDeclaration !== null) {
-              item.forEach('simpleSelector', function () {
-                error = {
-                  'ruleId': parser.rule.name,
-                  'line': item.start.line,
-                  'column': item.start.column,
-                  'message': 'Extends should come before declarations',
-                  'severity': parser.severity
-                };
-                result = helpers.addUnique(result, error);
-              });
+              error = {
+                'ruleId': parser.rule.name,
+                'line': item.start.line,
+                'column': item.start.column,
+                'message': 'Extends should come before declarations',
+                'severity': parser.severity
+              };
+              result = helpers.addUnique(result, error);
             }
           }
         }
 
-        if (item.type === 'declaration') {
+        if (item.is('declaration')) {
           lastDeclaration = j;
         }
       });


### PR DESCRIPTION
Fixes the extends-before-declarations rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking extends-before-declarations rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com