### PR TITLE
Gonzales 3.2 - Fix single-line-per-selector rule

### DIFF
--- a/lib/rules/single-line-per-selector.js
+++ b/lib/rules/single-line-per-selector.js
@@ -8,12 +8,12 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('selector', function (selector) {
-      selector.forEach('delimiter', function (delimiter, i) {
-        var next = selector.content[i + 1];
+    ast.traverseByType('ruleset', function (ruleset) {
+      ruleset.forEach('delimiter', function (delimiter, j) {
+        var next = ruleset.content[j + 1] || false;
 
         if (next) {
-          if (next.is('simpleSelector')) {
+          if (next.is('selector')) {
             next = next.content[0];
           }
 


### PR DESCRIPTION
Fixes the `single-line-per-selector - scss` rule to work with the latest version of gonzales.

This only fixes the SCSS syntax as unfortunately the sass code is blocked by a gonzales-pe issue https://github.com/tonyganch/gonzales-pe/issues/119 and currently causes a parse error :sob:

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `single-line-per-selector - scss` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com