### PR TITLE
Gonzales 3.2 - Fix no-qualifying-elements rule

### DIFF
--- a/lib/rules/no-qualifying-elements.js
+++ b/lib/rules/no-qualifying-elements.js
@@ -12,21 +12,36 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('simpleSelector', function (selectors) {
+    ast.traverseByType('selector', function (selector) {
+      selector.forEach(function (item, i) {
+        if (item.is('attributeSelector') || item.is('class') || item.is('id')) {
+          var previous = selector.content[i - 1] || false;
 
-      selectors.content.forEach(function (item, i) {
-        if (item.is('class') || item.is('attribute') || item.is('id')) {
-          var previous = selectors.content[i - 1] || false;
+          if (previous && previous.is('typeSelector')) {
+            if (previous.contains('ident')) {
+              var type = null;
 
-          if (previous && previous.is('ident')) {
-            if (!parser.options['allow-element-with-' + item.type]) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': item.start.line,
-                'column': item.start.column,
-                'message': 'Qualifying elements are not allowed for ' + item.type + ' selectors',
-                'severity': parser.severity
-              });
+              if (item.is('attributeSelector')) {
+                type = 'attribute';
+              }
+
+              if (item.is('class')) {
+                type = 'class';
+              }
+
+              if (item.is('id')) {
+                type = 'id';
+              }
+
+              if (type && !parser.options['allow-element-with-' + type]) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': item.start.line,
+                  'column': item.start.column,
+                  'message': 'Qualifying elements are not allowed for ' + type + ' selectors',
+                  'severity': parser.severity
+                });
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes the `no-qualifying-elements` - scss rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `no-qualifying-elements` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com