### PR TITLE
Gonzales 3.2 - Fix empty-line-between-blocks rule

### DIFF
--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -163,14 +163,7 @@ module.exports = {
 
             // If it's a new line, lets go back up to the selector
             if (previous.is('space') && helpers.hasEOL(previous.content)) {
-
-              // If we have a node (most likely type of selector)
-              if (parent.content[i - 2]) {
-
-                if (typeof parent.content[i - 3] === 'undefined') {
-                  space = findNearestReturnSass(p, j);
-                }
-              }
+              space = findNearestReturnSass(p, j);
             }
           });
         }

--- a/tests/rules/empty-line-between-blocks.js
+++ b/tests/rules/empty-line-between-blocks.js
@@ -208,7 +208,7 @@ describe('empty line between blocks - sass', function () {
     lint.test(file, {
       'empty-line-between-blocks': 1
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -225,7 +225,7 @@ describe('empty line between blocks - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });


### PR DESCRIPTION
First of all two tests had wrong error counts. I counted the errors by hand and corrected the tests. (1st commit)

Now to the changes due to gonzales:

The content of ruleset nodes changed
```css
.foo + .bar,
h2
  content: 'foo'
```
For this sass-snipet the content of the ruleset looked like this in the old version of gonzales:
```js
[ selector, space, block ]
```
In the new version it looks like:
```js
[ selector, delimiter, selector, space, block ]
```

DCO 1.1 Signed-off-by: Daniel Tschinder <code@tschinder.de>