### PR TITLE
Gonzales 3.2 - Fix gonzales-pe version to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^1.1.0",
     "fs-extra": "^0.26.0",
     "glob": "^6.0.0",
-    "gonzales-pe": "^3.2.1",
+    "gonzales-pe": "3.2.2",
     "js-yaml": "^3.2.6",
     "lodash.capitalize": "^3.0.0",
     "lodash.kebabcase": "^3.0.1",


### PR DESCRIPTION
see tonyganch/gonzales-pe#149

Currently I'm not able to install versions > 3.2.2

DCO 1.1 Signed-off-by: Daniel Tschinder <code@tschinder.de>