### PR TITLE
Gonzales 3.2 - Fix rule nesting-depth

### DIFF
--- a/lib/rules/nesting-depth.js
+++ b/lib/rules/nesting-depth.js
@@ -16,30 +16,29 @@ module.exports = {
       if (node.contains('block')) {
         node.forEach('block', function (block) {
           if (block.contains('ruleset')) {
+            depth++;
             block.forEach('ruleset', function (ruleset) {
-              ruleset.forEach('selector', function (selector) {
-                depth++;
+              var selector = ruleset.first('selector');
 
-                if (depth > parser.options['max-depth']) {
-                  selector.forEach('simpleSelector', function (simpleSelector) {
-                    var nodeLineColumn = simpleSelector.start.line + ':' + simpleSelector.start.column;
+              if (depth > parser.options['max-depth']) {
+                var nodeLineColumn = selector.start.line + ':' + selector.start.column;
 
-                    if (nodes[nodeLineColumn]) {
-                      if (depth > nodes[nodeLineColumn].depth) {
-                        nodes[nodeLineColumn].depth = depth;
-                      }
-                    }
-                    else {
-                      nodes[nodeLineColumn] = {
-                        'line': simpleSelector.start.line,
-                        'column': simpleSelector.start.column,
-                        'depth': depth
-                      };
-                    }
-                  });
+                if (nodes[nodeLineColumn]) {
+                  if (depth > nodes[nodeLineColumn].depth) {
+                    nodes[nodeLineColumn].depth = depth;
+                  }
                 }
-              });
-              recursiveSearch(ruleset);
+                else {
+                  nodes[nodeLineColumn] = {
+                    'line': selector.start.line,
+                    'column': selector.start.column,
+                    'depth': depth
+                  };
+                }
+              }
+              else {
+                recursiveSearch(ruleset);
+              }
             });
           }
         });

--- a/tests/rules/nesting-depth.js
+++ b/tests/rules/nesting-depth.js
@@ -12,7 +12,21 @@ describe('nesting depth - scss', function () {
     lint.test(file, {
       'nesting-depth': 1
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-depth: 3]', function (done) {
+    lint.test(file, {
+      'nesting-depth': [
+        1,
+        {
+          'max-depth': 3
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
       done();
     });
   });
@@ -28,7 +42,21 @@ describe('nesting depth - sass', function () {
     lint.test(file, {
       'nesting-depth': 1
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+
+  it('[max-depth: 3]', function (done) {
+    lint.test(file, {
+      'nesting-depth': [
+        1,
+        {
+          'max-depth': 3
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
       done();
     });
   });

--- a/tests/sass/nesting-depth.sass
+++ b/tests/sass/nesting-depth.sass
@@ -8,15 +8,15 @@
     .fail
       content: 'bob'
 
-      &:hover
+      &:hover,
+      &:active
         content: 'fail'
+
+        .bar
+          content: 'fail'
 
       .bar
         content: 'fail'
-
-
-
-
 
 .block
   content: 'bar'
@@ -27,7 +27,3 @@
 
     &--modifier
       content: 'bar'
-
-
-
-

--- a/tests/sass/nesting-depth.scss
+++ b/tests/sass/nesting-depth.scss
@@ -8,8 +8,13 @@
     .fail {
       content: 'bob';
 
-      &:hover {
+      &:hover,
+      &:active {
         content: 'fail';
+
+        .bar {
+          content: 'fail';
+        }
       }
 
       .bar {


### PR DESCRIPTION
This fixes the rule `nesting-depth`.

Node type `simpleSelector` has been removed.

Currently only the scss part is fixed, sass throws Fatal.

DCO 1.1 Signed-off-by: Daniel Tschinder <code@tschinder.de>