### PR TITLE
Gonzales 3.2 -  Fix rule indentation

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -82,13 +82,12 @@ module.exports = {
         }
 
         // if a block node is encountered we first check to see if it's within an include/function
-        // by checking if the node also contains argumentts, if it does we skip the block as we add a level
+        // by checking if the node also contains arguments, if it does we skip the block as we add a level
         // for arguments anyway. If not the the block is a usual ruleset block and should be treated accordingly
         // The other checks are kept from 1.0 and work for their respective types.
         if ((n.is('block') && !node.contains('arguments'))
-          || n.is('atrulers')
           || n.is('arguments')
-          || (n.is('parentheses') && !node.is('atruleb'))
+          || (n.is('parentheses') && !node.is('atrule'))
         ) {
           level++;
         }


### PR DESCRIPTION
This fixes the rule `indentation`.

`atruleb` has been merged into `atrule`
`atrulers` was reblaced by `block`.

DCO 1.1 Signed-off-by: Daniel Tschinder <code@tschinder.de>