### PR TITLE
Add node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
-  - '4.2.x'
+  - '4.2'
   - node
   - iojs
 before_script: npm link

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - '4.2.x'
   - node
   - iojs
 before_script: npm link


### PR DESCRIPTION
Checking the node versions, we aren't testing against node v4 anymore..

https://github.com/nodejs/LTS#example has the dates of when LTS support will end. So in October we should remove support/testing for node 0.10.x and in December remove support for 0.12.x

`DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com`