### PR TITLE
Gonzales 3.2 - Fix mixin-name-format

### DIFF
--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -32,10 +32,8 @@ module.exports = {
           }
         }
 
-        if (node.contains('simpleSelector')) {
-          if (node.first('simpleSelector').contains('ident')) {
-            name = node.first('simpleSelector').first('ident').content;
-          }
+        if (node.contains('ident')) {
+          name = node.first('ident').content;
         }
       }
 


### PR DESCRIPTION
Just had to remove the simpleSelector node.

DCO 1.1 Signed-off-by: Ben Rothman <bensrothman@gmail.com>