### PR TITLE
Gonzales 3.2 - Fix mixins-before-declaration rule

### DIFF
--- a/lib/rules/mixins-before-declarations.js
+++ b/lib/rules/mixins-before-declarations.js
@@ -18,26 +18,23 @@ module.exports = {
       var depth = 0,
           declarationCount = [depth];
 
-      parent.forEach( function (item) {
-        if (item.type === 'ruleset') {
+      parent.forEach(function (item) {
+        if (item.is('ruleset')) {
           depth++;
           declarationCount[depth] = 0;
         }
-        else if (item.type === 'declaration') {
+        else if (item.is('declaration')) {
           if (item.first().is('property')) {
-
             var prop = item.first();
 
             if (prop.first().is('ident')) {
-
               declarationCount[depth]++;
-
             }
           }
         }
-        else if (item.type === 'include') {
-          item.forEach('simpleSelector', function (name) {
-            if (parser.options.exclude.indexOf(name.content[0].content) === -1 && declarationCount[depth] > 0) {
+        else if (item.is('include')) {
+          item.forEach('ident', function (name) {
+            if (parser.options.exclude.indexOf(name.content) === -1 && declarationCount[depth] > 0) {
               error = {
                 'ruleId': parser.rule.name,
                 'line': item.start.line,


### PR DESCRIPTION
Fixes the `mixins-before-declaration` - scss rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking `mixins-before-declaration` rule test success.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com