### PR TITLE
Add extra checks to catch potential errors with CRLF

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -51,23 +51,27 @@ module.exports = {
             }
 
             if (spaceLength / parser.options.size !== level) {
-              if (count !== spaceLength) {
-                result = helpers.addUnique(result, {
-                  'ruleId': parser.rule.name,
-                  'line': node.content[i + 1].start.line,
-                  'column': node.content[i + 1].start.column,
-                  'message': 'Mixed tabs and spaces',
-                  'severity': parser.severity
-                });
-              }
-              if (i !== node.length - 1) {
-                result = helpers.addUnique(result, {
-                  'ruleId': parser.rule.name,
-                  'line': node.content[i + 1].start.line,
-                  'column': node.content[i + 1].start.column,
-                  'message': 'Indentation of ' + spaceLength + ', expected ' + level * parser.options.size,
-                  'severity': parser.severity
-                });
+              var next = node.content[i + 1] || false;
+
+              if (next) {
+                if (count !== spaceLength) {
+                  result = helpers.addUnique(result, {
+                    'ruleId': parser.rule.name,
+                    'line': next.start.line,
+                    'column': next.start.column,
+                    'message': 'Mixed tabs and spaces',
+                    'severity': parser.severity
+                  });
+                }
+                if (i !== node.length - 1) {
+                  result = helpers.addUnique(result, {
+                    'ruleId': parser.rule.name,
+                    'line': next.start.line,
+                    'column': next.start.column,
+                    'message': 'Indentation of ' + spaceLength + ', expected ' + level * parser.options.size,
+                    'severity': parser.severity
+                  });
+                }
               }
             }
           }


### PR DESCRIPTION
Improved the code of the indentation rule with extra checks to stop a TypeError.

While this doesn't fix the reason (Gonzales-pe's handling of CRLF), it will stop the error breaking out and allow the linter to continue.

Reported in #389, #382, #373... and lots of other reports by Windows users.

```
/Users/ben/workspace/github/sass-lint/lib/rules/indentation.js:57
                  'line': node.content[i + 1].start.line,
                    
TypeError: Cannot read property 'start' of undefined
```
DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com