### PR TITLE
Gonzales 3.2 - Fix attribute nesting

### DIFF
--- a/lib/rules/force-attribute-nesting.js
+++ b/lib/rules/force-attribute-nesting.js
@@ -6,8 +6,8 @@ var helpers = require('../helpers'),
 
 // Our nestable selector types, separated by type for ease of use with rules
 // we replace ident with 'selector' for readability'
-var nestableElements = ['selector', 'class', 'id'],
-    nestableAttributes = ['attribute'],
+var nestableElements = ['selector', 'class', 'id', 'typeSelector'],
+    nestableAttributes = ['attributeSelector'],
     nestablePseudo = ['pseudoClass', 'pseudoElement', 'nth', 'nthSelector'];
 
 /**
@@ -27,61 +27,22 @@ module.exports = {
         elements = nestableElements.concat(nestableAttributes, nestablePseudo);
 
     ast.traverseByType('ruleset', function (ruleset) {
-      var delimOrder = [];
 
       ruleset.forEach('selector', function (selector) {
-        // Where we'll store the previous value
         var previousVal;
-
-        // Keep track of the order of elements & delimeters
-        selector.forEach(function (el) {
-          var curNode = helpers.mapDelims(el);
-
-          if (curNode !== false) {
-            delimOrder.push(curNode);
-          }
-        });
-
-        selector.forEach('simpleSelector', function (simpleSelector) {
-          // check if the next selector is proceeded by a delimiter
-          // if it is add it to the curSelector output
-          var nextType = delimOrder[0];
-
-          if (nextType === 'd') {
-            // Empty the previous value store
-            previousVal = null;
-
-            // remove the next delim and selector from our order as we are only
-            // looping over selectors
-            delimOrder.splice(0, 2);
-          }
-          else {
-            // if no delim then just remove the current selectors marker in the
-            // order array
-            delimOrder.splice(0, 1);
-          }
-
-          // Loop each selector while checking if it should be nested
-          simpleSelector.forEach(function (node) {
-            // Construct the selector and store the current selector value
-            var constructedSelector = helpers.constructSelector(node),
-                currentVal = constructedSelector.type;
-
-            if (helpers.isNestable(currentVal, previousVal, elements, nestableAttributes)) {
+        selector.forEach(function (item) {
+          if (previousVal) {
+            if (helpers.isNestable(item.type, previousVal.type, elements, nestableAttributes)) {
               helpers.addUnique(result, {
                 'ruleId': parser.rule.name,
-                'line': node.start.line,
-                'column': node.start.column,
-                'message': formatOutput(currentVal) + ' `' + constructedSelector.content + '` should be nested within its parent ' + previousVal,
+                'line': selector.start.line,
+                'column': selector.start.column,
+                'message': formatOutput(item.type) + 'should be nested within its parent ' + previousVal.type,
                 'severity': parser.severity
               });
             }
-
-            if (currentVal) {
-              // Store current value as previous and continue with the loop
-              previousVal = currentVal;
-            }
-          });
+          }
+          previousVal = item;
         });
       });
     });

--- a/lib/rules/force-attribute-nesting.js
+++ b/lib/rules/force-attribute-nesting.js
@@ -37,7 +37,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': selector.start.line,
                 'column': selector.start.column,
-                'message': formatOutput(item.type) + ' should be nested within its parent ' + previousVal.type,
+                'message': formatOutput(item.type) + ' should be nested within its parent ' + formatOutput(previousVal.type),
                 'severity': parser.severity
               });
             }

--- a/lib/rules/force-attribute-nesting.js
+++ b/lib/rules/force-attribute-nesting.js
@@ -6,7 +6,7 @@ var helpers = require('../helpers'),
 
 // Our nestable selector types, separated by type for ease of use with rules
 // we replace ident with 'selector' for readability'
-var nestableElements = ['selector', 'class', 'id', 'typeSelector'],
+var nestableElements = ['selector', 'class', 'id', 'typeSelector', 'parentSelectorExtension'],
     nestableAttributes = ['attributeSelector'],
     nestablePseudo = ['pseudoClass', 'pseudoElement', 'nth', 'nthSelector'];
 

--- a/lib/rules/force-attribute-nesting.js
+++ b/lib/rules/force-attribute-nesting.js
@@ -37,7 +37,7 @@ module.exports = {
                 'ruleId': parser.rule.name,
                 'line': selector.start.line,
                 'column': selector.start.column,
-                'message': formatOutput(item.type) + 'should be nested within its parent ' + previousVal.type,
+                'message': formatOutput(item.type) + ' should be nested within its parent ' + previousVal.type,
                 'severity': parser.severity
               });
             }


### PR DESCRIPTION
Fixes the `force-attribute-nesting` - rule to work with the latest version of gonzales.

Note: Travis will fail as there are broken tests on gonzales-3-develop branch. Verify by checking force-attribute-nesting rule test success.

`DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com`