### PR TITLE
Fix no-color-literals raising warning on variables named as a color

### DIFF
--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -118,8 +118,9 @@ module.exports = {
 
         // if a map / list check to see if it's property names are the same as color literals - this is bad
         else if (valElem.type === 'parentheses') {
-          valElem.traverse( function (mapVals) {
-            if (mapVals.type === 'ident' && cssColors.indexOf(mapVals.content) !== -1 ) {
+          valElem.traverse( function (mapVals, idx, mapValsParent) {
+            // check if the parent is a variable to allow variables named after CSS colors, e.g. `$black`
+            if (mapVals.type === 'ident' && mapValsParent.type !== 'variable' && cssColors.indexOf(mapVals.content) !== -1) {
               result = helpers.addUnique(result, {
                 'ruleId': parser.rule.name,
                 'line': mapVals.start.line,

--- a/tests/sass/no-color-literals.scss
+++ b/tests/sass/no-color-literals.scss
@@ -60,6 +60,7 @@ $colors: (
 );
 
 // allowed
+$black: #000;
 $literal: mediumslateblue;
 $hexVar: #fff;
 $rgb: rgb(255, 255, 255);
@@ -118,3 +119,8 @@ $hsla: hsla(40, 50%, 50%, .3);
 .rgba-enabled {
   color: rgba($hexVar, .3);
 }
+
+// allowed - using variables named after colors as map values
+$colors: (
+  font-color: $black,
+);


### PR DESCRIPTION
Addresses a fix for the issue outlined in #538.

DCO 1.1 Signed-off-by: Brett Langdon <me@brett.is>