### PR TITLE
Fix dot in filename issue with clean-import-paths rule

### DIFF
--- a/lib/rules/clean-import-paths.js
+++ b/lib/rules/clean-import-paths.js
@@ -71,7 +71,7 @@ module.exports = {
               var filename = path.basename(importPath),
                   fileExtension = path.extname(filename);
 
-              if (fileExtension !== '.css') {
+              if (fileExtension === '.sass' || fileExtension === '.scss' || fileExtension === '') {
                 if (filename.charAt(0) === '_') {
                   if (!parser.options['leading-underscore']) {
                     result = helpers.addUnique(result, {

--- a/tests/sass/clean-import-paths.scss
+++ b/tests/sass/clean-import-paths.scss
@@ -25,3 +25,6 @@
 @if variable-exists(google-fonts-url) {
   @import url($google-fonts-url);
 }
+
+// Test dot in filename
+@import '../../node_modules/inuit-normalize/generic.normalize';


### PR DESCRIPTION
Fix an issue with dots in filenames.

Closes #536
 
DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com