### PR TITLE
Support config extends

### DIFF
--- a/docs/options/extends.md
+++ b/docs/options/extends.md
@@ -1,0 +1,80 @@
+# Extends
+
+Option `extends` will tell `sass-lint` to `require` additional defaults configs to load before loading your rules.
+
+`extends` is expected to be an array of strings with either the module name to import or an absolute path to the file to load by default.
+
+When using `extends`, the configs are loaded in the same order they are defined in and they each override the default config before finally loading your config/rules on top.
+
+Example:
+
+```yml
+options:
+  extends:
+    # Load in company wide default config to start with
+    - 'sass-lint-config-company'
+rules:
+  # Project specific rules
+  extends-before-mixins: 0
+```
+
+In the above example, `sass-lint` will start with the default config file, then load and override that with `sass-lint-config-company`, and finally override everything with the defined `rules`.
+
+## Writing a config module
+
+When writing a config module to import, you should either export a JavaScript object representation of the config or use a JSON file.
+
+### Exporting JavaScript object
+
+package.json:
+
+```json
+{
+  "name": "sass-lint-config-company",
+  "version": "0.1.0",
+  "main": "config.js"
+}
+```
+
+config.js:
+
+```js
+// Define config inline
+module.exports = {
+  options: {},
+  rules: {
+    'extends-before-mixins': 0
+  }
+};
+
+
+// Or, load config from local yml file
+var fs = require('fs');
+var path = require('path');
+var yml = require('yml');
+
+module.exports = yml.safeLoad(fs.readFileSync(path.join(__dirname, '.sass-lint.yml'), 'utf-8'));
+```
+
+### Using JSON config file
+
+package.json:
+
+```json
+{
+  "name": "sass-lint-config-company",
+  "version": "0.1.0",
+  "main": "config.json"
+}
+```
+
+config.json:
+
+```json
+{
+  "options": {},
+  "rules": {
+    "extends-before-mixins": 0
+  }
+}
+```

--- a/lib/config.js
+++ b/lib/config.js
@@ -106,6 +106,13 @@ module.exports = function (options, configPath) {
   // merge-default-rules defaults to true so each step above should merge with the previous. If at any step merge-default-rules is set to
   // false it should skip that steps merge.
   defaults = loadDefaults();
+
+  // Override the default config with any user provided `extends`
+  if (config.options && Array.isArray(config.options.extends)) {
+    config.options.extends.forEach(function (moduleName) {
+      defaults = merge.recursive(defaults, require(moduleName), options);
+    });
+  }
   finalConfig = merge.recursive(defaults, config, options);
 
   // if merge-default-rules is set to false in user config file then we essentially skip the merging with default rules by overwriting our

--- a/tests/config.js
+++ b/tests/config.js
@@ -191,4 +191,19 @@ describe('config', function () {
 
     done();
   });
+
+  it('should load and override an extended config', function (done) {
+    var tempOptions = {
+          'options': {}
+        },
+        conf;
+
+    tempOptions.options['cache-config'] = false;
+    conf = config(tempOptions, path.join(__dirname, 'yml', '.extend-config.yml'));
+
+    assert(equal(conf.rules['extends-before-mixins'], 0));
+    assert(equal(conf.rules['test-rule-name'], 1));
+
+    done();
+  });
 });

--- a/tests/json/extend.json
+++ b/tests/json/extend.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "extends-before-mixins": 1,
+    "test-rule-name": 1
+  }
+}

--- a/tests/yml/.extend-config.yml
+++ b/tests/yml/.extend-config.yml
@@ -1,0 +1,7 @@
+options:
+  extends:
+    # We call `require` for this config from the context of `lib/config.js`
+    - '../tests/json/extend'
+rules:
+  # Override rule set in `extend.json`
+  extends-before-mixins: 0


### PR DESCRIPTION
I was looking to create a common `.sass-lint.yml` config that I could use across different projects easily, similar to ESLint.

I noticed in #400 that there was mention of supporting plugins similar to ESLint. This isn't really support for plugins, more specific for defining common styles in a separate package, but there is potentially some overlap between the two goals.

I am content if this isn't the approach that we want to take here, I just figured I'd take an initial stab at it.

DCO 1.1 Signed-off-by: Brett Langdon me@brett.is
