### PR TITLE
Add maxWarnings CLI option

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -10,6 +10,12 @@ var configPath,
     configOptions = {},
     exitCode = 0;
 
+var tooManyWarnings = function (detects) {
+  var warningCount = lint.warningCount(detects).count;
+
+  return warningCount > 0 && warningCount > program.maxWarnings;
+};
+
 var detectPattern = function (pattern) {
   var detects;
 
@@ -19,7 +25,7 @@ var detectPattern = function (pattern) {
     lint.outputResults(detects, configOptions, configPath);
   }
 
-  if (lint.errorCount(detects).count) {
+  if (lint.errorCount(detects).count || tooManyWarnings(detects)) {
     exitCode = 1;
   }
 
@@ -38,6 +44,7 @@ program
   .option('-f, --format [format]', 'pass one of the available eslint formats')
   .option('-o, --output [output]', 'the path and filename where you would like output to be written')
   .option('-s, --syntax [syntax]', 'syntax to evaluate the file(s) with (either sass or scss)')
+  .option('--max-warnings [integer]', 'Number of warnings to trigger nonzero exit code')
   .parse(process.argv);
 
 

--- a/docs/cli/readme.md
+++ b/docs/cli/readme.md
@@ -16,6 +16,7 @@ Command Line Flag        | Description
 `-f`,`--format [format]`  | Pass one of the available [Eslint formats](https://github.com/eslint/eslint/tree/master/lib/formatters) to format the output of sass-lint results.
 `-h`,`--help`             | Outputs usage information for the CLI
 `-i`,`--ignore [pattern]` | A pattern that should be ignored from linting. Multiple patterns can be used by separating each pattern by `, `. Patterns should be wrapped in quotes (will be merged with other ignore options)
+`--max-warnings [integer]`| Normally, if SassLint runs and finds no errors (only warnings), it will exit with a success exit status. However, if this option is specified and the total warning count is greater than the specified threshold, SassLint will exit with an error status.
 `-o`,`--output [output]`  | The path plus file name relative to where Sass Lint is being run from where the output should be written to.
 `-q`,`--no-exit`          | Prevents the CLI from throwing an error if there is one (useful for development work)
 `-s`,`--syntax`           | Syntax to evaluate the given file(s) with, either sass or scss. Use with care: overrides filename extension-based syntax detection.

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -320,6 +320,18 @@ describe('cli', function () {
     });
   });
 
+  it('should exit with exit code 1 when more warnings than --max-warnings', function (done) {
+    var command = 'sass-lint -c tests/yml/.color-keyword-errors.yml tests/sass/cli.scss --max-warnings 0';
+
+    childProcess.exec(command, function (err) {
+      if (err && err.code === 1) {
+        return done();
+      }
+
+      return done(new Error('Error code not 1'));
+    });
+  });
+
   /**
    * We disabled eslints handle callback err rule here as we are deliberately throwing errors that we don't care about
    */


### PR DESCRIPTION
Exit with non-zero value when the number of warnings is greater than the maxWarning option.

see #567 

DCO 1.1 Signed-off-by: Jesse House <jesse.house@codingzeal.com>