### PR TITLE
Update eslint 2.x - Gonzales 3.2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,7 +54,7 @@ rules:
   no-caller: 2
   no-console: 0
   no-delete-var: 2
-  no-empty-label: 2
+  no-labels: 2
   no-eval: 2
   no-extend-native: 2
   no-extra-bind: 2
@@ -64,7 +64,6 @@ rules:
   no-invalid-this: 2
   no-iterator: 2
   no-label-var: 2
-  no-labels: 2
   no-lone-blocks: 2
   no-loop-func: 2
   no-mixed-spaces-and-tabs:
@@ -110,15 +109,16 @@ rules:
     - 2
     - before: false
       after: true
-  space-after-keywords:
-    - 2
-    - always
+  keyword-spacing:
+      - 2
+      -
+        before: true
+        after: true
   space-before-blocks: 2
   space-before-function-paren:
     - 2
     - always
   space-infix-ops: 2
-  space-return-throw-case: 2
   space-unary-ops:
     - 2
     - words: true
@@ -144,11 +144,9 @@ rules:
 
   # Previously on by default in node environment
   no-catch-shadow: 0
-  no-console: 0
   no-mixed-requires: 2
   no-new-require: 2
   no-path-concat: 2
-  no-process-exit: 2
   handle-callback-err:
     - 2
     - err

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -34,6 +34,8 @@ var getPreviousNode = function (node) {
   if (node.is('atrule') || node.is('mixin') || node.is('loop')) {
     return node.contains('atkeyword') ? node.last('atkeyword') : false;
   }
+
+  return false;
 };
 
 /**
@@ -256,6 +258,8 @@ module.exports = {
           }
         }
       }
+
+      return true;
     });
 
     return result;

--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -46,6 +46,7 @@ var findNearestReturnSCSS = function (parent, i) {
       }
     }
   }
+  return false;
 };
 
 var findNearestReturnSass = function (parent, i) {
@@ -191,6 +192,7 @@ module.exports = {
           }
         }
       }
+      return true;
     });
 
     return result;

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -81,6 +81,7 @@ module.exports = {
           });
         }
       }
+      return true;
     });
 
     return result;

--- a/lib/rules/space-after-comma.js
+++ b/lib/rules/space-after-comma.js
@@ -50,6 +50,7 @@ module.exports = {
           }
         }
       }
+      return true;
     });
 
     return result;

--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -18,6 +18,7 @@ var getRelationalOperator = function (node) {
   if (node.content === '>') {
     return '>=';
   }
+  return false;
 };
 
 /**
@@ -137,6 +138,7 @@ var checkSpacing = function (node, i, parent, parser, result) {
       }
     }
   }
+  return true;
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/sasstools/sass-lint",
   "dependencies": {
     "commander": "^2.8.1",
-    "eslint": "^2.5.1",
+    "eslint": "^2.5.3",
     "fs-extra": "^0.26.0",
     "glob": "^7.0.0",
     "gonzales-pe": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/sasstools/sass-lint",
   "dependencies": {
     "commander": "^2.8.1",
-    "eslint": "^1.1.0",
+    "eslint": "^2.5.1",
     "fs-extra": "^0.26.0",
     "glob": "^7.0.0",
     "gonzales-pe": "^3.2.6",

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -16,7 +16,7 @@ describe('cli', function () {
 
       assert(stdout.indexOf('Usage') > 0);
 
-      done(null);
+      return done(null);
     });
   });
 
@@ -30,7 +30,7 @@ describe('cli', function () {
 
       should(stdout).match(/^[0-9]+.[0-9]+(.[0-9]+)?/);
 
-      done(null);
+      return done(null);
     });
   });
 
@@ -230,7 +230,7 @@ describe('cli', function () {
 
       else {
         assert.equal(expectedOutputLength, stdout.length);
-        done();
+        return done();
       }
     });
   });
@@ -254,7 +254,7 @@ describe('cli', function () {
         assert(stdout.indexOf(file) === -1);
       });
 
-      done();
+      return done();
     });
   });
 
@@ -277,7 +277,7 @@ describe('cli', function () {
         assert(stdout.indexOf(file) === -1);
       });
 
-      done();
+      return done();
     });
   });
 

--- a/tests/config.js
+++ b/tests/config.js
@@ -24,9 +24,9 @@ var custOptions = function () {
       'no-duplicate-properties': 0,
       'indentation': [
         2,
-          {
-            'size': 4
-          }
+        {
+          'size': 4
+        }
       ]
     }
   };

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,30 +5,30 @@ var assert = require('assert'),
     gonzales = require('gonzales-pe');
 
 var haystack = [
-    {
-      prop: 'a',
-      propb: 'b'
-    },
-    {
-      prop: 'c',
-      propb: 'd'
-    }
+  {
+    prop: 'a',
+    propb: 'b'
+  },
+  {
+    prop: 'c',
+    propb: 'd'
+  }
 ];
 
 var classBlock =
     {
       type: 'class',
       content:
-          [
-              {
-                type: 'ident',
-                content: 'foo',
-                syntax: 'scss',
-                start: { line: 5, column: 2 },
-                end: { line: 5, column: 4 },
-                indexHasChanged: [ 0 ]
-              }
-          ],
+      [
+        {
+          type: 'ident',
+          content: 'foo',
+          syntax: 'scss',
+          start: { line: 5, column: 2 },
+          end: { line: 5, column: 4 },
+          indexHasChanged: [ 0 ]
+        }
+      ],
       syntax: 'scss',
       start: { line: 5, column: 1 },
       end: { line: 5, column: 4 },
@@ -39,16 +39,16 @@ var classBlock =
     {
       type: 'class',
       content:
-          [
-              {
-                type: 'ident',
-                content: 'test',
-                syntax: 'scss',
-                start: { line: 9, column: 2 },
-                end: { line: 9, column: 5 },
-                indexHasChanged: [ 0 ]
-              }
-          ],
+      [
+        {
+          type: 'ident',
+          content: 'test',
+          syntax: 'scss',
+          start: { line: 9, column: 2 },
+          end: { line: 9, column: 5 },
+          indexHasChanged: [ 0 ]
+        }
+      ],
       syntax: 'scss',
       start: { line: 9, column: 1 },
       end: { line: 9, column: 5 },
@@ -129,16 +129,16 @@ describe('helpers', function () {
         {
           type: 'class',
           content:
-              [
-                  {
-                    type: 'ident',
-                    content: 'foo',
-                    syntax: 'scss',
-                    start: { line: 5, column: 2 },
-                    end: { line: 5, column: 4 },
-                    indexHasChanged: [ 0 ]
-                  }
-              ],
+          [
+            {
+              type: 'ident',
+              content: 'foo',
+              syntax: 'scss',
+              start: { line: 5, column: 2 },
+              end: { line: 5, column: 4 },
+              indexHasChanged: [ 0 ]
+            }
+          ],
           syntax: 'scss',
           start: { line: 5, column: 1 },
           end: { line: 5, column: 4 },

--- a/tests/output.js
+++ b/tests/output.js
@@ -12,20 +12,20 @@ var results = [{
   warningCount: 2,
   errorCount: 0,
   messages: [
-      {
-        ruleId: 'empty-line-between-blocks',
-        line: 14,
-        column: 2,
-        message: 'Space expected between blocks',
-        severity: 1
-      },
-      {
-        ruleId: 'empty-line-between-blocks',
-        line: 17,
-        column: 2,
-        message: 'Space expected between blocks',
-        severity: 1
-      }
+    {
+      ruleId: 'empty-line-between-blocks',
+      line: 14,
+      column: 2,
+      message: 'Space expected between blocks',
+      severity: 1
+    },
+    {
+      ruleId: 'empty-line-between-blocks',
+      line: 17,
+      column: 2,
+      message: 'Space expected between blocks',
+      severity: 1
+    }
   ]
 }];
 


### PR DESCRIPTION
Seen as we are waiting for gonzales to allow us to release 1.6 I thought I'd jump ahead and just get these eslint updates done too.

Updates our config with the latest format of the rules for eslint as some of the rules have merged/changed names in version 2.x, It also fixes all of the issues that eslint now flags up on our shiny 1.6 branch so it should all be ready to be released once we go ahead with it.

closes #577 
closes #525 

`<DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com>`