### PR TITLE
Fix valid default properties - Gonzales 3.2

### DIFF
--- a/docs/rules/variable-for-property.md
+++ b/docs/rules/variable-for-property.md
@@ -1,6 +1,12 @@
 # Variable For Property
 
-Rule `variable-for-property` will enforce the use of variables for the values of specified properties. There are no properties by default.
+Rule `variable-for-property` will enforce the use of variables for the values of specified properties.
+There are no properties by default, except for reserved words listed below which are always whitelisted:
+* inherit
+* initial
+* transparent
+* none
+* currentColor
 
 ## Options
 

--- a/lib/rules/variable-for-property.js
+++ b/lib/rules/variable-for-property.js
@@ -2,6 +2,27 @@
 
 var helpers = require('../helpers');
 
+// The whitelisted ident values
+var whitelistedValues = ['inherit', 'initial', 'transparent', 'none', 'currentColor'];
+
+/**
+ * Checks If the property is of a valid type, either its a variable or it's a whitelisted ident value
+ *
+ * @param {Object} propertyElem - The property element
+ * @returns {boolean} Whether the property is valid or not
+ */
+var isValidProperty = function (propertyElem) {
+  if (propertyElem) {
+    if (propertyElem.type === 'variable') {
+      return true;
+    }
+    else if (propertyElem.type === 'ident' && whitelistedValues.indexOf(propertyElem.content) !== -1) {
+      return true;
+    }
+  }
+  return false;
+};
+
 module.exports = {
   'name': 'variable-for-property',
   'defaults': {
@@ -19,7 +40,7 @@ module.exports = {
         if (declarationType === 'ident') {
           if (parser.options.properties.indexOf(declarationIdent) !== -1) {
             node.forEach(function (valElem) {
-              if (valElem.type !== 'variable') {
+              if (!isValidProperty(valElem)) {
                 result = helpers.addUnique(result, {
                   'ruleId': parser.rule.name,
                   'line': declaration.start.line,

--- a/tests/rules/variable-for-property.js
+++ b/tests/rules/variable-for-property.js
@@ -24,7 +24,8 @@ describe('variable for property - scss', function () {
         {
           'properties': [
             'margin',
-            'content'
+            'content',
+            'background'
           ]
         }
       ]
@@ -57,7 +58,8 @@ describe('variable for property - sass', function () {
         {
           'properties': [
             'margin',
-            'content'
+            'content',
+            'background'
           ]
         }
       ]

--- a/tests/sass/variable-for-property.sass
+++ b/tests/sass/variable-for-property.sass
@@ -4,7 +4,7 @@
 
   &__element
     margin: $margin
-  
+
 
 
 =blue()
@@ -17,8 +17,14 @@
 
   &__element
     margin: 0
-  
+
 
 
 =red()
   margin: 0
+
+.test
+  background: inherit
+  background: initial
+  background: transparent
+  background: none

--- a/tests/sass/variable-for-property.scss
+++ b/tests/sass/variable-for-property.scss
@@ -23,3 +23,10 @@
 @mixin red() {
   margin: 0;
 }
+
+.test {
+  background: inherit;
+  background: initial;
+  background: transparent;
+  background: none;
+}


### PR DESCRIPTION
Fixes #571 

The variable for property rule wasn't taking into account reserved words usage.

This fix implements a function to check the property in question against a list of whitelisted ident values as well as it's type as is currently happening.

`<DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com>`