### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install sass-lint --save-dev
 
 ## Configuring
 
-Sass-lint can be configured from a `.sass-lint.yml` file in your project. If you don't have one in the root of your project or you would like all your projects to follow a standard config file then you can specify the path to one in your projects `pacakge.json` file.
+Sass-lint can be configured from a `.sass-lint.yml` file in your project. If you don't have one in the root of your project or you would like all your projects to follow a standard config file then you can specify the path to one in your projects `package.json` file.
 
 For example:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -123,9 +123,19 @@ For further information you can visit our CLI documentation linked below.
 
 ---
 
+## Contributions
+
+We welcome all contributions to this project but please do read our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/master/CONTRIBUTING.md) first, especially before opening a pull request. It would also be good to read our [code of conduct](https://github.com/sasstools/sass-lint/blob/master/CODE_OF_CONDUCT.md).
+
+Please don't feel hurt or embarrassed if you find your issues/PR's that don't follow these guidelines closed as it can be a very time consuming process managing the quantity of issues and PR's we receive. If you have any questions just ask!
+
+---
+
 ## Creating Rules
 
 Our AST is [Gonzales-PE](https://github.com/tonyganch/gonzales-pe/tree/dev). Each rule will be passed the full AST which they can traverse as they please. There are many different [node types](https://github.com/tonyganch/gonzales-pe/blob/dev/docs/node-types.md) that may be traversed, and an extensive [API for working with nodes](https://github.com/tonyganch/gonzales-pe/tree/dev#api). The file of the rule must have the same name as the name of the rule. All of the available rules are in our [rules directory](https://github.com/sasstools/sass-lint/tree/develop/lib/rules). Default options will be merged in with user config.
+
+---
 
 ## Task Runner Integration
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,33 @@
 
 A Node-only Sass linter for both `sass` and `scss` syntax!
 
+---
+
 ## Install
+You can get `sass-lint` from [NPM](https://www.npmjs.com/package/sass-lint)
 
 ```
 npm install sass-lint --save-dev
 ```
 
+---
+
 ## Configuring
 
-Use the [Sample Config](docs/sass-lint.yml) as a guide to create your `.sass-lint.yml` in the root of where you are running Sass Lint from. The default configuration can be found [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml).
+Sass-lint can be configured from a `.sass-lint.yml` file in your project. If you don't have one in the root of your project or you would like all your projects to follow a standard config file then you can specify the path to one in your projects `pacakge.json` file.
+
+For example:
+```javascript
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "sasslintConfig": "PATH/TO/YOUR/CONFIG/FILE"
+}
+```
+
+Use the [Sample Config](https://github.com/sasstools/sass-lint/tree/master/docs/sass-lint.yml) as a guide to create your own `.sass-lint.yml` config file. The default configuration can be found [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml).
+
+### [Configuration Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/options)
 
 *Migrating from SCSS-Lint*: If you already have a config for SCSS-Lint, you can instantly convert it to the equivalent Sass Lint config at [sasstools.github.io/make-sass-lint-config](http://sasstools.github.io/make-sass-lint-config/).
 
@@ -18,13 +36,27 @@ Use the [Sample Config](docs/sass-lint.yml) as a guide to create your `.sass-lin
 
 The following are options that you can use to config the Sass Linter.
 
+* [cache-config](https://github.com/sasstools/sass-lint/tree/master/docs/options/cache-config.md) - Allows you to cache your config for a small speed boost when not changing the contents of your config file
+* [config-file](https://github.com/sasstools/sass-lint/tree/master/docs/options/config-file.md) - Specify another config file to load
+* [formatter](https://github.com/sasstools/sass-lint/tree/master/docs/options/formatter.md) - Choose the format for any warnings/errors to be displayed
+* [merge-default-rules](https://github.com/sasstools/sass-lint/tree/master/docs/options/merge-default-rules.md) - Allows you to merge your rules with the default config file included with sass-lint
+* [output-file](https://github.com/sasstools/sass-lint/tree/master/docs/options/output-file.md) - Choose to write the linters output to a file
+
+
 #### Files
 
 The `files` option can either be set to a [glob](https://github.com/isaacs/node-glob) or it can be set to an object, where the key `include` is set to the glob you want to include, and `ignore` set to either a glob string or an array of glob strings that you would like to ignore.
 
+```yml
+files:
+  include: 'sass/**/*.s+(a|c)ss'
+  ignore:
+    - 'sass/vendor/**/*.*'
+```
+
 #### Rules
 
-For all [rules](docs/rules), setting their severity to `0` turns it off, setting to `1` sets it as a warning (something that should not be committed in), and setting to `2` set it to an error (something that should not be written). If a rule is set to just a severity, it will use the default configuration (where available).
+For all [rules](https://github.com/sasstools/sass-lint/tree/master/docs/rules), setting their severity to `0` turns it off, setting to `1` sets it as a warning (something that should not be committed in), and setting to `2` sets it to an error (something that should not be written). If a rule is set to just a severity, it will use the default configuration (where available).
 
 If you want to configure options, set the rule to an array, where the first item in the array is the severity, and the second item in the array is an object including the options you would like to set.
 
@@ -37,9 +69,28 @@ indentation:
     size: 2
 ```
 
+### [Rules Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/rules)
+
+---
+
 ## CLI
 
-Sass Lint [`v1.1.0`](https://github.com/sasstools/sass-lint/releases/tag/v1.1.0) introduced the ability to run Sass Lint through a command line interface. See the [CLI Docs](docs/cli) for full documentation on how to use the CLI.
+Sass Lint [`v1.1.0`](https://github.com/sasstools/sass-lint/releases/tag/v1.1.0) introduced the ability to run Sass Lint through a command line interface. See the [CLI Docs](https://github.com/sasstools/sass-lint/tree/master/docs/cli) for full documentation on how to use the CLI.
+
+There are small differences which are useful to understand over other CLI tools you may have encountered with other linters.
+
+By default any rule set to severity: `2` in your config will throw an error which will stop the CLI on the first error it encounters. If you wish to see a list of errors and not have the CLI  then you'll need to use the `-q` or `--no-exit` flag.
+
+Warnings or any rule set to severity: `1` in your config by default will not be reported by the CLI tool unless you use verbose flag `-v` or `--verbose`.
+
+With this in mind if you would like to have the CLI show both warnings and errors then at the very least you should start with the following command.
+`sass-lint -v -q`
+
+This will be revisited and updated in `sass-lint` v2.0.0
+
+### [CLI Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/cli)
+
+---
 
 ## Creating Rules
 

--- a/README.md
+++ b/README.md
@@ -88,18 +88,30 @@ With this in mind if you would like to have the CLI show both warnings and error
 
 Below is an example of the command being used to load a config `-c app/config/.sass-lint.yml` file show errors and warnings on the command line and target a glob pattern `**/*.scss` being used.
 
-`sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q`
+```
+sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q
+```
+
 or with long form flags
-`sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit`
+
+```
+sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit
+```
 
 To add a list of files to ignore `tests/**/*.scss, dist/other.scss` into the mix you could do the following:
-`sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q -i 'tests/**/*.scss'`
+```
+sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q -i 'tests/**/*.scss'
+```
 or with long form flags
-`sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit --ignore 'tests/**/*.scss, dist/other.scss'`
+```
+sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit --ignore 'tests/**/*.scss, dist/other.scss'
+```
 
 Notice that glob patterns need to be wrapped in quotation or single quote marks in order to be passed to sass-lint correctly and if you want to ignore multiple paths you also need to wrap it in quotation marks and seperate each pattern/fil with a comma and a space `, `.
 
 This will be revisited and updated in `sass-lint` v2.0.0
+
+For further information you can visit our CLI documentation linked below.
 
 ### [CLI Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/cli)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Warnings or any rule set to severity: `1` in your config by default will not be 
 With this in mind if you would like to have the CLI show both warnings and errors then at the very least your starting point to use the cli should be the following command.
 `sass-lint -v -q`
 
+### CLI Examples
+
+#### Specify a config
+
 Below is an example of the command being used to load a config `-c app/config/.sass-lint.yml` file show errors and warnings on the command line and target a glob pattern `**/*.scss` being used.
 
 ```
@@ -98,6 +102,7 @@ or with long form flags
 sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit
 ```
 
+#### Ignore files/patterns
 To add a list of files to ignore `tests/**/*.scss, dist/other.scss` into the mix you could do the following:
 ```
 sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q -i 'tests/**/*.scss'
@@ -107,7 +112,8 @@ or with long form flags
 sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit --ignore 'tests/**/*.scss, dist/other.scss'
 ```
 
-Notice that glob patterns need to be wrapped in quotation or single quote marks in order to be passed to sass-lint correctly and if you want to ignore multiple paths you also need to wrap it in quotation marks and seperate each pattern/fil with a comma and a space `, `.
+
+> Notice that glob patterns need to be wrapped in quotation or single quote marks in order to be passed to sass-lint correctly and if you want to ignore multiple paths you also need to wrap it in quotation marks and seperate each pattern/fil with a comma and a space `, `.
 
 This will be revisited and updated in `sass-lint` v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,25 @@ Sass Lint [`v1.1.0`](https://github.com/sasstools/sass-lint/releases/tag/v1.1.0)
 
 There are small differences which are useful to understand over other CLI tools you may have encountered with other linters.
 
-By default any rule set to severity: `2` in your config will throw an error which will stop the CLI on the first error it encounters. If you wish to see a list of errors and not have the CLI  then you'll need to use the `-q` or `--no-exit` flag.
+By default any rule set to severity: `2` in your config will throw an error which will stop the CLI on the first error it encounters. If you wish to see a list of errors and not have the CLI exit then you'll need to use the `-q` or `--no-exit` flag.
 
 Warnings or any rule set to severity: `1` in your config by default will not be reported by the CLI tool unless you use verbose flag `-v` or `--verbose`.
 
-With this in mind if you would like to have the CLI show both warnings and errors then at the very least you should start with the following command.
+With this in mind if you would like to have the CLI show both warnings and errors then at the very least your starting point to use the cli should be the following command.
 `sass-lint -v -q`
+
+Below is an example of the command being used to load a config `-c app/config/.sass-lint.yml` file show errors and warnings on the command line and target a glob pattern `**/*.scss` being used.
+
+`sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q`
+or with long form flags
+`sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit`
+
+To add a list of files to ignore `tests/**/*.scss, dist/other.scss` into the mix you could do the following:
+`sass-lint -c app/config/.sass-lint.yml '**/*.scss' -v -q -i 'tests/**/*.scss'`
+or with long form flags
+`sass-lint --config app/config/.sass-lint.yml '**/*.scss' --verbose --no-exit --ignore 'tests/**/*.scss, dist/other.scss'`
+
+Notice that glob patterns need to be wrapped in quotation or single quote marks in order to be passed to sass-lint correctly and if you want to ignore multiple paths you also need to wrap it in quotation marks and seperate each pattern/fil with a comma and a space `, `.
 
 This will be revisited and updated in `sass-lint` v2.0.0
 


### PR DESCRIPTION
This updates the current main project README.md with a little more description and information relating to `sass-lint` and its current status/functionality. It also provides more of a quick start guide to some of the most frequent questions we receive regarding the CLI and also provides clear links to all parts of our documentation in an effort to reduce the number of configuration style issues we get.

Related to many issues but most recently #563 

`<DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com>`
