### PR TITLE
Fix assertion config error - Gonzales-3.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,6 @@ sassLint.lintFiles = function (files, options, configPath) {
   }
   else {
     files = this.getConfig(options, configPath).files;
-
     if (typeof files === 'string') {
       files = glob.sync(files);
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,29 +14,27 @@ var loadDefaults = function loadDefaults () {
 
 var findFile = function findFile (configPath, filename) {
   var HOME = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE,
-      dirname,
-      parentDirname;
+      dirname = null,
+      parentDirname = null;
 
   configPath = configPath || path.join(process.cwd(), filename);
 
-  if (fs.existsSync(configPath)) {
+  if (configPath && fs.existsSync(configPath)) {
+    dirname = path.dirname(configPath);
+    parentDirname = path.dirname(dirname);
     return fs.realpathSync(configPath);
   }
 
-  dirname = path.dirname(configPath);
-  parentDirname = path.dirname(dirname);
-
-  if (dirname === HOME || dirname === parentDirname) {
+  if (dirname === null || dirname === HOME || dirname === parentDirname) {
     return null;
   }
-
   configPath = path.join(parentDirname, filename);
 
   return findFile(configPath, filename);
 };
 
 module.exports = function (options, configPath) {
-  var meta,
+  var meta = null,
       metaPath,
       configMerge = false,
       configMergeExists = false,
@@ -70,10 +68,11 @@ module.exports = function (options, configPath) {
 
   if (!configPath) {
     metaPath = findFile(false, 'package.json');
-    meta = require(metaPath);
+    if (metaPath) {
+      meta = require(metaPath);
+    }
 
-    if (meta.sasslintConfig) {
-
+    if (meta && meta.sasslintConfig) {
       configPath = path.resolve(path.dirname(metaPath), meta.sasslintConfig);
     }
     else {
@@ -90,7 +89,6 @@ module.exports = function (options, configPath) {
       config.rules = config.rules ? config.rules : {};
     }
   }
-
   // check to see if user config contains an options property and whether property has a property called merge-default-rules
   configMergeExists = (config.options && typeof config.options['merge-default-rules'] !== 'undefined');
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -2,14 +2,14 @@ var assert = require('assert'),
     should = require('should'),
     fs = require('fs-extra'),
     path = require('path'),
-    childProcess = require('child_process');
+    exec = require('child_process').exec;
 
 
 describe('cli', function () {
   it('should return help instructions', function (done) {
     var command = 'sass-lint -h';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
       if (err) {
         return done(err);
       }
@@ -23,7 +23,7 @@ describe('cli', function () {
   it('should return a version', function (done) {
     var command = 'sass-lint -V';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
       if (err) {
         return done(err);
       }
@@ -37,7 +37,7 @@ describe('cli', function () {
   it('CLI format option should output JSON', function (done) {
     var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format json';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       if (err) {
         return done(err);
@@ -58,7 +58,7 @@ describe('cli', function () {
     var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format json --output tests/cli-output.json',
         outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
 
-    childProcess.exec(command, function (err) {
+    exec(command, function (err) {
 
       if (err) {
         return done(err);
@@ -81,7 +81,7 @@ describe('cli', function () {
     var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format json --output tests/cli-output.json',
         outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
 
-    childProcess.exec(command, function (err) {
+    exec(command, function (err) {
 
       if (err) {
         return done(err);
@@ -114,7 +114,7 @@ describe('cli', function () {
     var command = 'sass-lint -c tests/yml/.stylish-output.yml tests/sass/cli.scss --verbose --format JSON --output tests/cli-output.json',
         outputFile = path.resolve(process.cwd(), 'tests/cli-output.json');
 
-    childProcess.exec(command, function (err) {
+    exec(command, function (err) {
 
       if (err) {
         return done(err);
@@ -148,7 +148,7 @@ describe('cli', function () {
   it('should return JSON from a custom config', function (done) {
     var command = 'sass-lint -c tests/yml/.color-keyword-errors.yml tests/sass/cli.scss --verbose';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       if (err) {
         return done(err);
@@ -170,7 +170,7 @@ describe('cli', function () {
   it('output should return no errors/warnings', function (done) {
     var command = 'sass-lint -c tests/yml/.json-lint.yml tests/sass/cli.scss --verbose';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       var result = 0;
 
@@ -192,7 +192,7 @@ describe('cli', function () {
   it('should return a warning', function (done) {
     var command = 'sass-lint -c tests/yml/.color-keyword-errors.yml tests/sass/cli.scss --verbose';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       var result = '';
 
@@ -222,7 +222,7 @@ describe('cli', function () {
     var command = 'sass-lint -c tests/yml/.stylish-errors.yml tests/sass/cli.scss --verbose',
         expectedOutputLength = 155;
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       if (err) {
         return done(err);
@@ -244,7 +244,7 @@ describe('cli', function () {
 
     var command = 'sass-lint -i \'**/*.s+(a|c)ss\'';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       if (err) {
         return done(err);
@@ -267,7 +267,7 @@ describe('cli', function () {
 
     var command = 'sass-lint -i \'**/*.scss, **/*.sass \'';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       if (err) {
         return done(err);
@@ -290,7 +290,7 @@ describe('cli', function () {
 
     var command = 'sass-lint --syntax scss tests/sass/cli.txt --verbose';
 
-    childProcess.exec(command, function (err, stdout) {
+    exec(command, function (err, stdout) {
 
       var result = 0;
 
@@ -311,12 +311,24 @@ describe('cli', function () {
   it('should exit with exit code 1 when quiet', function (done) {
     var command = 'sass-lint -c tests/yml/.error-output.yml tests/sass/cli-error.scss --verbose --no-exit';
 
-    childProcess.exec(command, function (err) {
+    exec(command, function (err) {
       if (err.code === 1) {
         return done();
       }
 
       return done(new Error('Error code not 1'));
+    });
+  });
+
+  it('should not exit with an error if no config is specified', function (done) {
+    var command = 'sass-lint tests/sass/cli-clean.scss --verbose --no-exit';
+
+    exec(command, function (err) {
+      if (!err) {
+        return done();
+      }
+
+      return done(new Error('Exited with error code 1'));
     });
   });
 
@@ -326,7 +338,7 @@ describe('cli', function () {
   it('parse errors should report as a lint error', function (done) {
     var command = 'sass-lint --config tests/yml/.stylish-output.yml tests/sass/parse.scss --verbose --no-exit --format json';
 
-    childProcess.exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
+    exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0];
 
       assert.equal(1, result.errorCount);
@@ -337,7 +349,7 @@ describe('cli', function () {
   it('parse errors should report as severity 2', function (done) {
     var command = 'sass-lint --config tests/yml/.stylish-output.yml tests/sass/parse.scss --verbose --no-exit --format json';
 
-    childProcess.exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
+    exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0],
           messages = result.messages[0],
           severity = 2;
@@ -350,7 +362,7 @@ describe('cli', function () {
   it('parse errors should report the correct message', function (done) {
     var command = 'sass-lint --config tests/yml/.stylish-output.yml tests/sass/parse.scss --verbose --no-exit --format json';
 
-    childProcess.exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
+    exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0],
           message = result.messages[0].message,
           expected = 'Please check validity of the block starting from line #5';
@@ -363,7 +375,7 @@ describe('cli', function () {
   it('parse errors rule Id should be \'Fatal\'', function (done) {
     var command = 'sass-lint --config tests/yml/.stylish-output.yml tests/sass/parse.scss --verbose --no-exit --format json';
 
-    childProcess.exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
+    exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0],
           messages = result.messages[0],
           ruleId = 'Fatal';

--- a/tests/sass/cli-clean.scss
+++ b/tests/sass/cli-clean.scss
@@ -1,0 +1,5 @@
+$red: #f00;
+
+.cli {
+  color: $red;
+}


### PR DESCRIPTION
Fixes #563 

This is one I've sort of known about for a long time but finally got round to investigating it a bit.

Currently if you're using the CLI and you don't supply a path a config file or have a config file in the root of your project then the config loader throws an error to say it can't find a path. This was mainly down to the way the config loader would fall back to your package.json if it couldn't find a `.sass-lint.yml` file, the logic wasn't taking into account a scenario where that path wasn't specified in your package file.

This resolves it and adds a test to ensure this error doesn't reoccur.

I've pointed it towards the gonzales 3.2 update branch as I don't want to have to keep updating that one with new develop work, we may as well just load it all together in preparation for 1.6.

`<DCO 1.1 Signed-off-by: Dan Purdy danjpurdy@gmail.com>`