### PR TITLE
Temporary gonzales

### DIFF
--- a/lib/groot.js
+++ b/lib/groot.js
@@ -3,7 +3,7 @@
 //////////////////////////////
 'use strict';
 
-var gonzales = require('gonzales-pe');
+var gonzales = require('gonzales-pe-sl');
 
 module.exports = function (text, syntax, filename) {
   var tree;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,7 @@ var util = require('util'),
     fs = require('fs'),
     path = require('path'),
     yaml = require('js-yaml'),
-    gonzales = require('gonzales-pe');
+    gonzales = require('gonzales-pe-sl');
 
 var helpers = {};
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^2.5.3",
     "fs-extra": "^0.26.0",
     "glob": "^7.0.0",
-    "gonzales-pe": "^3.2.6",
+    "gonzales-pe-sl": "3.2.6",
     "js-yaml": "^3.5.4",
     "lodash.capitalize": "^4.1.0",
     "lodash.kebabcase": "^4.0.0",

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert'),
     helpers = require('../lib/helpers'),
-    gonzales = require('gonzales-pe');
+    gonzales = require('gonzales-pe-sl');
 
 var haystack = [
   {


### PR DESCRIPTION
Due to the issue here https://github.com/tonyganch/gonzales-pe/issues/149 gonzales-pe can no longer be installed on windows. As a temporary stop gap I've removed the post install script and just updated a few things and republished to npm as gonzales-pe-sl.

This PR replaces it in sass-lint and runs all our tests fine. If we could test this on a windows machine now that would be great.. I dont have access or time to one tonight!

