### PR TITLE
Correct indentation checks when using CRLFs

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -16,7 +16,8 @@ module.exports = {
           prevNode,
           space,
           spaceLength,
-          count;
+          count,
+          newlineLength;
 
       level = level || 0;
 
@@ -35,16 +36,18 @@ module.exports = {
         if (n.type === 'space') {
           // Test for CRLF first, since it includes LF
           space = n.content.lastIndexOf('\r\n');
+          newlineLength = 2;
 
           if (space === -1) {
             space = n.content.lastIndexOf('\n');
+            newlineLength = 1;
           }
 
           if (space >= 0) {
-            spaceLength = n.content.slice(space + 1).length;
+            spaceLength = n.content.slice(space + newlineLength).length;
 
             try {
-              count = n.content.slice(space + 1).match(/ /g).length;
+              count = n.content.slice(space + newlineLength).match(/ /g).length;
             }
             catch (e) {
               count = 0;


### PR DESCRIPTION
Otherwise we think there's an extra indent and mixed tabs.

This resolves #389 and #382 for me.  All rules are still showing doubled line numbers, but at least it doesn't die outright and is usable.