### PR TITLE
Add BEM conventions for all naming rules

### DIFF
--- a/docs/rules/function-name-format.md
+++ b/docs/rules/function-name-format.md
@@ -5,7 +5,8 @@ Rule `function-name-format` will enforce a convention for function names.
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the function name must match (e.g. `^[_A-Z]+$`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
+[`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), or a Regular Expression that the function name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a function doesn't adhere to the convention
 
 ## Example 1
@@ -115,6 +116,72 @@ When enabled, the following are disallowed:
 ```
 
 ## Example 4
+
+Settings:
+- `convention: strictbem`
+
+When enabled, the following are allowed:
+
+```scss
+@function namespace__function {
+  @return "foo";
+}
+
+@function namespace__function_mod-name {
+  @return "foo";
+}
+
+@function namespace_mod-name__function {
+  @return "foo";
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@function HYPHENATED-UPPERCASE {
+  @return "foo";
+}
+
+.foo {
+  content: camelCase();
+}
+```
+
+## Example 5
+
+Settings:
+- `convention: hyphenatedbem`
+
+When enabled, the following are allowed:
+
+```scss
+@function namespace__function {
+  @return "foo";
+}
+
+@function namespace__function--mod-name {
+  @return "foo";
+}
+
+@function namespace--mod-name__function {
+  @return "foo";
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@function HYPHENATED-UPPERCASE {
+  @return "foo";
+}
+
+.foo {
+  content: camelCase();
+}
+```
+
+## Example 6
 
 Settings:
 - `allow-leading-underscore: true`

--- a/docs/rules/mixin-name-format.md
+++ b/docs/rules/mixin-name-format.md
@@ -5,7 +5,8 @@ Rule `mixin-name-format` will enforce a convention for mixin names.
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
+[`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a mixin doesn't adhere to the convention
 
 ## Example 1
@@ -116,6 +117,73 @@ When enabled, the following are disallowed:
 ```
 
 ## Example 4
+
+Settings:
+- `convention: strictbem`
+
+When enabled, the following are allowed:
+
+```scss
+@mixin block-name {
+  content: '';
+}
+
+@mixin block-name__mixin {
+  content: '';
+}
+
+@mixin block-name_mod-name {
+  content: '';
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@mixin HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @include camelCase();
+}
+```
+
+## Example 5
+
+Settings:
+- `convention: hyphenatedbem`
+
+When enabled, the following are allowed:
+
+```scss
+@mixin block-name {
+  content: '';
+}
+
+@mixin block-name__mixin {
+  content: '';
+}
+
+@mixin block-name--mod-name {
+  content: '';
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+@mixin HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @include camelCase();
+}
+```
+
+
+## Example 6
 
 Settings:
 - `allow-leading-underscore: true`

--- a/docs/rules/placeholder-name-format.md
+++ b/docs/rules/placeholder-name-format.md
@@ -5,7 +5,8 @@ Rule `placeholder-name-format` will enforce a convention for placeholder names.
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
+[`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a placeholder doesn't adhere to the convention
 
 ## Example 1
@@ -116,6 +117,72 @@ When enabled, the following are disallowed:
 ```
 
 ## Example 4
+
+Settings:
+- `convention: strictbem`
+
+When enabled, the following are allowed:
+
+```scss
+%block-name {
+  content: '';
+}
+
+%block-name__mixin {
+  content: '';
+}
+
+%block-name_mod-name {
+  content: '';
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+%HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @extend %camelCase;
+}
+```
+
+## Example 5
+
+Settings:
+- `convention: hyphenatedbem`
+
+When enabled, the following are allowed:
+
+```scss
+%block-name {
+  content: '';
+}
+
+%block-name__mixin {
+  content: '';
+}
+
+%block-name--mod-name {
+  content: '';
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+%HYPHENATED-UPPERCASE {
+  content: '';
+}
+
+.foo {
+  @extend %camelCase;
+}
+```
+
+## Example 6
 
 Settings:
 - `allow-leading-underscore: true`

--- a/docs/rules/variable-name-format.md
+++ b/docs/rules/variable-name-format.md
@@ -5,7 +5,8 @@ Rule `variable-name-format` will enforce a convention for variable names.
 ## Options
 
 * `allow-leading-underscore`: `true`/`false` (defaults to `true`)
-* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
+* `convention`: `'hyphenatedlowercase'` (default), `camelcase`, `snakecase`, [`strictbem`](https://en.bem.info/method/definitions/),
+[`hyphenatedbem`](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), or a Regular Expression that the variable name must match (e.g. `^[_A-Z]+$`)
 * `convention-explanation`: Custom explanation to display to the user if a variable doesn't adhere to the convention
 
 ## Example 1
@@ -92,6 +93,60 @@ $_snake_case_with_leading_underscore: 1px;
 ```
 
 ## Example 4
+
+Settings:
+- `convention: strictbem`
+
+When enabled, the following are allowed:
+
+```scss
+$block-name__variable: 1px;
+$block-name__variable_mod-name: 1px;
+$block-name_mod-name__variable: 1px;
+
+.foo {
+  width: $block-name__variable;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$HYPHENATED-UPPERCASE: 1px;
+
+.foo {
+  width: $camelCase;
+}
+```
+
+## Example 5
+
+Settings:
+- `convention: hyphenatedbem`
+
+When enabled, the following are allowed:
+
+```scss
+$block-name__variable: 1px;
+$block-name__variable--mod-name: 1px;
+$block-name--mod-name__variable: 1px;
+
+.foo {
+  width: $block-name__variable;
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+$HYPHENATED-UPPERCASE: 1px;
+
+.foo {
+  width: $camelCase;
+}
+```
+
+## Example 6
 
 Settings:
 - `allow-leading-underscore: true`

--- a/lib/rules/function-name-format.js
+++ b/lib/rules/function-name-format.js
@@ -50,6 +50,16 @@ module.exports = {
           violationMessage = 'Function \'' + name + '\' should be written in snake_case';
         }
         break;
+      case 'strictbem':
+        if (!helpers.isStrictBEM(strippedName)) {
+          violationMessage = 'Function \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+        }
+        break;
+      case 'hyphenatedbem':
+        if (!helpers.isHyphenatedBEM(strippedName)) {
+          violationMessage = 'Function \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+        }
+        break;
       default:
         if (!(new RegExp(parser.options.convention).test(strippedName))) {
           violationMessage = 'Function \'' + name + '\' should match regular expression /' + parser.options.convention + '/';

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -60,6 +60,16 @@ module.exports = {
             violationMessage = 'Mixin \'' + name + '\' should be written in snake_case';
           }
           break;
+        case 'strictbem':
+          if (!helpers.isStrictBEM(strippedName)) {
+            violationMessage = 'Mixin \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+          }
+          break;
+        case 'hyphenatedbem':
+          if (!helpers.isHyphenatedBEM(strippedName)) {
+            violationMessage = 'Mixin \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+          }
+          break;
         default:
           if (!(new RegExp(parser.options.convention).test(strippedName))) {
             violationMessage = 'Mixin \'' + name + '\' should match regular expression /' + parser.options.convention + '/';

--- a/lib/rules/placeholder-name-format.js
+++ b/lib/rules/placeholder-name-format.js
@@ -40,6 +40,16 @@ module.exports = {
           violationMessage = 'Placeholder \'%' + name + '\' should be written in snake_case';
         }
         break;
+      case 'strictbem':
+        if (!helpers.isStrictBEM(strippedName)) {
+          violationMessage = 'Placeholder \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+        }
+        break;
+      case 'hyphenatedbem':
+        if (!helpers.isHyphenatedBEM(strippedName)) {
+          violationMessage = 'Placeholder \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+        }
+        break;
       default:
         if (!(new RegExp(parser.options.convention).test(strippedName))) {
           violationMessage = 'Placeholder \'%' + name + '\' should match regular expression /' + parser.options.convention + '/';

--- a/lib/rules/variable-name-format.js
+++ b/lib/rules/variable-name-format.js
@@ -40,6 +40,16 @@ module.exports = {
           violationMessage = 'Variable \'' + name + '\' should be written in snake_case';
         }
         break;
+      case 'strictbem':
+        if (!helpers.isStrictBEM(strippedName)) {
+          violationMessage = 'Variable \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+        }
+        break;
+      case 'hyphenatedbem':
+        if (!helpers.isHyphenatedBEM(strippedName)) {
+          violationMessage = 'Variable \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+        }
+        break;
       default:
         if (!(new RegExp(parser.options.convention).test(strippedName))) {
           violationMessage = 'Variable \'' + name + '\' should match regular expression /' + parser.options.convention + '/';

--- a/tests/rules/function-name-format.js
+++ b/tests/rules/function-name-format.js
@@ -9,7 +9,7 @@ describe('function name format - scss', function () {
     lint.test(file, {
       'function-name-format': 1
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -37,7 +37,35 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -52,7 +80,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -66,7 +94,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -79,7 +107,7 @@ describe('function name format - sass', function () {
     lint.test(file, {
       'function-name-format': 1
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -93,7 +121,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -107,7 +135,35 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'function-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -122,7 +178,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -136,7 +192,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });

--- a/tests/rules/mixin-name-format.js
+++ b/tests/rules/mixin-name-format.js
@@ -9,7 +9,7 @@ describe('mixin name format - scss', function () {
     lint.test(file, {
       'mixin-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -37,7 +37,35 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -52,7 +80,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -66,7 +94,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -79,7 +107,7 @@ describe('mixin name format - sass', function () {
     lint.test(file, {
       'mixin-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -93,7 +121,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -107,7 +135,35 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'mixin-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -122,7 +178,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -136,7 +192,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });

--- a/tests/rules/placeholder-name-format.js
+++ b/tests/rules/placeholder-name-format.js
@@ -9,7 +9,7 @@ describe('placeholder name format - scss', function () {
     lint.test(file, {
       'placeholder-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('placeholder name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -37,7 +37,35 @@ describe('placeholder name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -52,7 +80,7 @@ describe('placeholder name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -66,7 +94,7 @@ describe('placeholder name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -79,7 +107,7 @@ describe('placeholder name format - sass', function () {
     lint.test(file, {
       'placeholder-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -93,7 +121,7 @@ describe('placeholder name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -107,7 +135,35 @@ describe('placeholder name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(13, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'placeholder-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -122,7 +178,7 @@ describe('placeholder name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -136,7 +192,7 @@ describe('placeholder name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -9,7 +9,7 @@ describe('variable name format - scss', function () {
     lint.test(file, {
       'variable-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -37,7 +37,35 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -52,7 +80,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -66,7 +94,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -79,7 +107,7 @@ describe('variable name format - sass', function () {
     lint.test(file, {
       'variable-name-format': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });
@@ -93,7 +121,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
       done();
     });
   });
@@ -107,7 +135,35 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: strictbem]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'strictbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(12, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: hyphenatedbem]', function (done) {
+    lint.test(file, {
+      'variable-name-format': [
+        1,
+        {
+          'convention': 'hyphenatedbem'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -122,7 +178,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -136,7 +192,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });

--- a/tests/sass/function-name-format.sass
+++ b/tests/sass/function-name-format.sass
@@ -19,6 +19,27 @@
 @function _with-leading-underscore()
   @return 'foo'
 
+@function strictbem()
+  @return 'foo'
+
+@function strictbem__function()
+  @return 'foo'
+
+@function strictbem__function_modifier()
+  @return 'foo'
+
+@function strictbem_modifier__function()
+  @return 'foo'
+
+@function hyphenatedbem__function()
+  @return 'foo'
+
+@function hyphenatedbem__function--modifier()
+  @return 'foo'
+
+@function hyphenatedbem--modifier__function()
+  @return 'foo'
+
 @function _does_NOT-fitSTANDARD($x)
   @return $x
 

--- a/tests/sass/function-name-format.scss
+++ b/tests/sass/function-name-format.scss
@@ -26,6 +26,34 @@
   @return 'foo';
 }
 
+@function strictbem() {
+  @return 'foo';
+}
+
+@function strictbem__function() {
+  @return 'foo';
+}
+
+@function strictbem__function_modifier() {
+  @return 'foo';
+}
+
+@function strictbem_modifier__function() {
+  @return 'foo';
+}
+
+@function hyphenatedbem__function() {
+  @return 'foo';
+}
+
+@function hyphenatedbem__function--modifier() {
+  @return 'foo';
+}
+
+@function hyphenatedbem--modifier__function() {
+  @return 'foo';
+}
+
 @function _does_NOT-fitSTANDARD($x) {
   @return $x;
 }

--- a/tests/sass/mixin-name-format.sass
+++ b/tests/sass/mixin-name-format.sass
@@ -19,6 +19,33 @@
 =_with-leading-underscore()
   content: ''
 
+=strictbem()
+  content: ''
+
+=strictbem_modifier()
+  content: ''
+
+=strictbem__mixin()
+  content: ''
+
+=strictbem__mixin_modifier()
+  content: ''
+
+=strictbem_modifier__mixin()
+  content: ''
+
+=hyphenatedbem--modifier()
+  content: ''
+
+=hyphenatedbem__mixin()
+  content: ''
+
+=hyphenatedbem__mixin--modifier()
+  content: ''
+
+=hyphenatedbem--modifier__mixin()
+  content: ''
+
 =_does_NOT-fitSTANDARD()
   content: ''
 

--- a/tests/sass/mixin-name-format.scss
+++ b/tests/sass/mixin-name-format.scss
@@ -26,6 +26,42 @@
   content: '';
 }
 
+@mixin strictbem() {
+  content: '';
+}
+
+@mixin strictbem_modifier() {
+  content: '';
+}
+
+@mixin strictbem__mixin() {
+  content: '';
+}
+
+@mixin strictbem__mixin_modifier() {
+  content: '';
+}
+
+@mixin strictbem_modifier__mixin() {
+  content: '';
+}
+
+@mixin hyphenatedbem--modifier() {
+  content: '';
+}
+
+@mixin hyphenatedbem__mixin() {
+  content: '';
+}
+
+@mixin hyphenatedbem__mixin--modifier() {
+  content: '';
+}
+
+@mixin hyphenatedbem--modifier__mixin() {
+  content: '';
+}
+
 @mixin _does_NOT-fitSTANDARD() {
   content: '';
 }

--- a/tests/sass/placeholder-name-format.sass
+++ b/tests/sass/placeholder-name-format.sass
@@ -19,6 +19,33 @@
 %_with-leading-underscore
   content: ''
 
+%strictbem
+  content: ''
+
+%strictbem_modifier
+  content: ''
+
+%strictbem__placeholder
+  content: ''
+
+%strictbem__placeholder_modifier
+  content: ''
+
+%strictbem_modifier__placeholder
+  content: ''
+
+%hyphenatedbem--modifier
+  content: ''
+
+%hyphenatedbem__placeholder
+  content: ''
+
+%hyphenatedbem__placeholder--modifier
+  content: ''
+
+%hyphenatedbem--modifier__placeholder
+  content: ''
+
 %_does_NOT-fitSTANDARD
   content: ''
 

--- a/tests/sass/placeholder-name-format.scss
+++ b/tests/sass/placeholder-name-format.scss
@@ -26,6 +26,42 @@
   content: '';
 }
 
+%strictbem {
+  content: '';
+}
+
+%strictbem_placeholder {
+  content: '';
+}
+
+%strictbem__mixin {
+  content: '';
+}
+
+%strictbem__mixin_placeholder {
+  content: '';
+}
+
+%strictbem_placeholder__mixin {
+  content: '';
+}
+
+%hyphenatedbem--placeholder {
+  content: '';
+}
+
+%hyphenatedbem__mixin {
+  content: '';
+}
+
+%hyphenatedbem__mixin--placeholder {
+  content: '';
+}
+
+%hyphenatedbem--placeholder__mixin {
+  content: '';
+}
+
 %_does_NOT-fitSTANDARD {
   content: '';
 }

--- a/tests/sass/variable-name-format.sass
+++ b/tests/sass/variable-name-format.sass
@@ -5,6 +5,16 @@ $PascalCase: 1
 $Camel_Snake_Case: 1
 $SCREAMING_SNAKE_CASE: 1
 $_with-leading-underscore: 1
+
+$strictbem: 1
+$strictbem__variable: 1
+$strictbem__variable_modifier: 1
+$strictbem_modifier__variable: 1
+$hyphenatedbem--modifier: 1
+$hyphenatedbem__variable: 1
+$hyphenatedbem__variable--modifier: 1
+$hyphenatedbem--modifier__variable: 1
+
 $_does_NOT-fitSTANDARD: 1
 
 .class

--- a/tests/sass/variable-name-format.scss
+++ b/tests/sass/variable-name-format.scss
@@ -5,6 +5,16 @@ $PascalCase: 1;
 $Camel_Snake_Case: 1;
 $SCREAMING_SNAKE_CASE: 1;
 $_with-leading-underscore: 1;
+
+$strictbem: 1;
+$strictbem__variable: 1;
+$strictbem__variable_modifier: 1;
+$strictbem_modifier__variable: 1;
+$hyphenatedbem--modifier: 1;
+$hyphenatedbem__variable: 1;
+$hyphenatedbem__variable--modifier: 1;
+$hyphenatedbem--modifier__variable: 1;
+
 $_does_NOT-fitSTANDARD: 1;
 
 .class {


### PR DESCRIPTION
*New PR after a git mistake in https://github.com/sasstools/sass-lint/pull/604*

**Fix**: sasstools#598
**Changes**:
Add `strictbem ` and `hyphenatedbem` conventions for all naming rules:
- `function-name-format`
- `mixin-name-format`
- `placeholder-name-format`
- `function-name-format`

Add tests and examples in documentation for these naming conventions.