### PR TITLE
Ignore unicode syntax

### DIFF
--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -44,7 +44,6 @@ var checkSpacing = function (node, i, parent, parser, result) {
     //////////////////////////
 
     if (parent && operator && next) {
-
       // The parent ofthe exceptions are always going to be of type value
       if (parent.is('value')) {
         // 1. We should allow valid CSS use of leading - operator when
@@ -53,9 +52,10 @@ var checkSpacing = function (node, i, parent, parser, result) {
           return false;
         }
 
-        // 2. We should allow valid CSS use of / operators when defining
-        // font size/line-height
         if (previous) {
+          // 2. We should allow valid CSS use of / operators when defining
+          // font size/line-height
+
           // The first value is the font-size and must have a unit, therefore
           // a node of type dimension
           if (operator === '/' && previous.is('dimension')
@@ -64,9 +64,14 @@ var checkSpacing = function (node, i, parent, parser, result) {
           ) {
             return false;
           }
+
+          // 3. Ignore if Unicode
+          if (previous.is('ident') && previous.content === 'U' && operator === '+') {
+            return false;
+          }
         }
 
-        // 3. If there is nothing leading the minus, it's a negative value so we
+        // 4. If there is nothing leading the minus, it's a negative value so we
         // shouldn't have a following space
         if (!previous && operator === '-' && !next.is('space')) {
           return false;

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -466,3 +466,7 @@ h1
 // Should flag this if rule is false
 .foo
   $val: 1 - ($foo * 2)
+
+@font-face
+  font-family: 'Proxima Nova'
+  unicode-range: U+1F00-1FFF

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -469,4 +469,9 @@ h1
 
 @font-face
   font-family: 'Proxima Nova'
-  unicode-range: U+1F00-1FFF
+    unicode-range: U+26
+    unicode-range: U+0-7F
+    unicode-range: U+0025-00FF
+    // Wildcard currently causes gonzales to fail
+    // unicode-range: U+4??;
+    // unicode-range: U+0025-00FF, U+4??;

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -480,3 +480,8 @@ $qux: (2 * 1); // FIXME: Gonzales - FIXED IN BETA
 // .foo {
 //   $val: - ($foo * 2);
 // }
+
+@font-face {
+  font-family: 'Proxima Nova';
+  unicode-range: U+1F00-1FFF;
+}

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -483,5 +483,10 @@ $qux: (2 * 1); // FIXME: Gonzales - FIXED IN BETA
 
 @font-face {
   font-family: 'Proxima Nova';
-  unicode-range: U+1F00-1FFF;
+  unicode-range: U+26;
+  unicode-range: U+0-7F;
+  unicode-range: U+0025-00FF;
+  // Wildcard currently causes gonzales to fail
+  // unicode-range: U+4??;
+  // unicode-range: U+0025-00FF, U+4??;
 }


### PR DESCRIPTION
Fixes #619 by making sure that the `space-around-operator` rule will ignore unicode.