### PR TITLE
Fix CRLF issues trailing whitespace and fix sass issues

### DIFF
--- a/lib/rules/no-trailing-whitespace.js
+++ b/lib/rules/no-trailing-whitespace.js
@@ -8,19 +8,20 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
     var trailing = (/( |\t)+\n/);
+    var trailingCRLF = (/( |\t)+\r\n/);
 
     ast.traverseByType('space', function (space, i, parent) {
       var content = space.content;
       var nextIndex = i + 1;
       var next = parent.content[nextIndex];
 
-      while (next && (next.is('space') || next.is('declarationDelimeter'))) {
+      while (next && (next.is('space') || next.is('declarationDelimiter'))) {
         content += next.content;
         nextIndex++;
         next = parent.content[nextIndex];
       }
 
-      if (trailing.test(content)) {
+      if (trailing.test(content) || trailingCRLF.test(content)) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'severity': parser.severity,

--- a/tests/sass/no-trailing-whitespace.sass
+++ b/tests/sass/no-trailing-whitespace.sass
@@ -1,24 +1,24 @@
 .foo
-  margin: 1.5rem;
+  margin: 1.5rem
 
 // Two trailing spaces after selector
 .bar  
-  margin: 1.5rem;
+  margin: 1.5rem
 
 // Two trailing spaces after property
 .baz
-  margin: 1.5rem;  
+  margin: 1.5rem  
 
 // Two trailing spaces between rules
 .qux
-  margin: 1.5rem;
+  margin: 1.5rem
   
 
 // Trailing tab after selector
 .cat	
-  margin: 1.5rem;
+  margin: 1.5rem
 
 // Trailing tab after property
 .dog
-  margin: 1.5rem;	
+  margin: 1.5rem	
 


### PR DESCRIPTION
Fixes an issue with the `no-trailing-whitespace` rule for CRLF line endings also makes up for the dodgy review i seemed to have done for the first iteration 😳 

Alongside the fixes I've done for CRLF in gonzales-pe this means all of our rules for both scss and sass pass for CRLF & LF line endings!!

`DCO 1.1 Signed-off-by: Dan Purdy <danjpurdy@gmail.com>`