### PR TITLE
Add CRLF line endings for Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+# CRLF Line Endings
+init:
+  - git config --global core.autocrlf true
+
 # Test against this version of Node.js
 environment:
   matrix:


### PR DESCRIPTION
Appveyor isn't testing CRLF line endings. Let's see if this git config will switch that, and how much 'splodes when we do.