### PR TITLE
Remove workarounds

### DIFF
--- a/lib/rules/extends-before-declarations.js
+++ b/lib/rules/extends-before-declarations.js
@@ -13,20 +13,25 @@ module.exports = {
       var lastDeclaration = null;
 
       block.forEach(function (item, j) {
-        // TODO: Remove tempory fix - atrule type is work around for issue:
-        // https://github.com/tonyganch/gonzales-pe/issues/147
-        if ((item.is('include') || item.is('extend') || item.is('atrule')) &&
-            item.first('atkeyword')) {
-          if (item.first('atkeyword').first('ident').content === 'extend') {
-            if (j > lastDeclaration && lastDeclaration !== null) {
-              error = {
-                'ruleId': parser.rule.name,
-                'line': item.start.line,
-                'column': item.start.column,
-                'message': 'Extends should come before declarations',
-                'severity': parser.severity
-              };
-              result = helpers.addUnique(result, error);
+        if (item.is('include') || item.is('extend')) {
+          if (item.contains('atkeyword')) {
+            var atkeyword = item.first('atkeyword');
+
+            if (atkeyword.contains('ident')) {
+              var ident = atkeyword.first('ident');
+
+              if (ident.content === 'extend') {
+                if (j > lastDeclaration && lastDeclaration !== null) {
+                  error = {
+                    'ruleId': parser.rule.name,
+                    'line': item.start.line,
+                    'column': item.start.column,
+                    'message': 'Extends should come before declarations',
+                    'severity': parser.severity
+                  };
+                  result = helpers.addUnique(result, error);
+                }
+              }
             }
           }
         }

--- a/lib/rules/extends-before-mixins.js
+++ b/lib/rules/extends-before-mixins.js
@@ -12,9 +12,7 @@ module.exports = {
       var lastMixin = null;
 
       block.forEach(function (item, j) {
-        // TODO: Remove tempory fix - atrule type is work around for issue:
-        // https://github.com/tonyganch/gonzales-pe/issues/147
-        if (item.is('include') || item.is('extend') || item.is('atrule')) {
+        if (item.is('include') || item.is('extend')) {
           if (item.contains('atkeyword')) {
             var atkeyword = item.first('atkeyword');
 


### PR DESCRIPTION
Removes workarounds that are now necessary due to fixes to gonzales.

Affects the following rules:
- `extends-before-declaration`
- `extends-before-mixins`

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com