### PR TITLE
Check for osx vendor prefix

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -207,10 +207,20 @@ helpers.stripQuotes = function (str) {
   return str.substring(1, str.length - 1);
 };
 
+/**
+ * Strips vendor prefixes from a string
+ *
+ * @param {string} str - The string we wish to remove vendor prefixes from
+ * @returns {string} The string without vendor prefixes
+ */
 helpers.stripPrefix = function (str) {
   var modProperty = str.slice(1),
       prefixLength = modProperty.indexOf('-');
 
+  // check for the -osx- vendor prefix too as well as the original -moz- etc
+  if (modProperty.slice(prefixLength + 1).slice(0, 3) === 'osx') {
+    return modProperty.slice(prefixLength + 5);
+  }
   return modProperty.slice(prefixLength + 1);
 };
 

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -21,7 +21,6 @@ module.exports = {
 
         if (curProperty.charAt(0) === '-') {
           curProperty = helpers.stripPrefix(curProperty);
-
         }
 
         if (properties.indexOf(curProperty) === -1 && parser.options['extra-properties'].indexOf(curProperty) === -1) {
@@ -32,7 +31,6 @@ module.exports = {
             'message': 'Property `' + curProperty + '` appears to be spelled incorrectly',
             'severity': parser.severity
           });
-
         }
       }
     });

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -23,7 +23,7 @@ module.exports = {
           curProperty = helpers.stripPrefix(curProperty);
         }
 
-        if (properties.indexOf(curProperty) === -1 && parser.options['extra-properties'].indexOf(curProperty) === -1) {
+        if (curProperty.length > 0 && properties.indexOf(curProperty) === -1 && parser.options['extra-properties'].indexOf(curProperty) === -1) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': node.start.line,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -995,6 +995,14 @@ describe('helpers', function () {
     done();
   });
 
+  it('stripPrefix - [-moz-osx-font-smoothing - font-smoothing]', function (done) {
+
+    var result = helpers.stripPrefix('-moz-osx-font-smoothing');
+
+    assert.equal('font-smoothing', result);
+    done();
+  });
+
   //////////////////////////////
   // stripLastSpace
   //////////////////////////////

--- a/tests/sass/no-misspelled-properties.sass
+++ b/tests/sass/no-misspelled-properties.sass
@@ -14,7 +14,9 @@ $red: #ff0000
   color: $red
   transition: width 2s
 
-// FIXME Currently a parse error within gonzales-pe
-// .test-interp
-//-webkit-#{$property}: $value
-//
+.test-interp
+  -webkit-#{$property}: $value
+
+// https://github.com/sasstools/sass-lint/issues/606
+.test-vendor
+  -moz-osx-font-smoothing: auto

--- a/tests/sass/no-misspelled-properties.scss
+++ b/tests/sass/no-misspelled-properties.scss
@@ -18,7 +18,11 @@ $red: #ff0000;
 
 }
 
-// FIXME Currently a parse error within gonzales-pe
-// .test-interp {
-//-webkit-#{$property}: $value;
-// }
+.test-interp {
+  -webkit-#{$property}: $value;
+}
+
+// https://github.com/sasstools/sass-lint/issues/606
+.test-vendor {
+  -moz-osx-font-smoothing: auto;
+}


### PR DESCRIPTION
Fixes an issue where a double barrelled vendor prefix (-moz-osx-) wasn't being stripped correctly in order to check property spelling.

Also re enables some gonzales bound interpolation tests and adds extra tests and checks to the no-misspelled-property rule.

Fixes #606 

`DCO 1.1 Signed-off-by: Dan Purdy <danjpurdy@gmail.com>`