### PR TITLE
Fix sass-lint 1.6 final-newline rule issues

### DIFF
--- a/lib/rules/final-newline.js
+++ b/lib/rules/final-newline.js
@@ -2,6 +2,18 @@
 
 var helpers = require('../helpers');
 
+/**
+ * Get the 'last' node of the tree to test for an EOL
+ *
+ * @param {Object} node - The node who's last child we want to return
+ * @returns {Object} The last node
+ */
+var getLastNode = function (node) {
+  var last = node.last();
+
+  return last ? getLastNode(last) : node;
+};
+
 module.exports = {
   'name': 'final-newline',
   'defaults': {
@@ -9,22 +21,20 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [],
-        last = ast.content[ast.content.length - 1],
+        last,
         error = {
           'ruleId': parser.rule.name,
           'severity': parser.severity
         };
 
+    // If the syntax is Sass we must recursively loop to determine the last node.
+    // This is not required for SCSS which will always use the last node in the
+    // content of the parent stylesheet node
     if (ast.syntax === 'sass') {
-      if (typeof last.last('block') === 'object') {
-        var lastBlock = last.last('block');
-
-        if (lastBlock && lastBlock.content.length > 0) {
-          if (lastBlock.content[lastBlock.length - 1]) {
-            last = lastBlock.content[lastBlock.length - 1];
-          }
-        }
-      }
+      last = getLastNode(ast);
+    }
+    else {
+      last = ast.content[ast.content.length - 1];
     }
 
     if (!last.is('space') && !last.is('declarationDelimiter')) {

--- a/lib/rules/final-newline.js
+++ b/lib/rules/final-newline.js
@@ -5,7 +5,7 @@ var helpers = require('../helpers');
 /**
  * Get the 'last' node of the tree to test for an EOL
  *
- * @param {Object} node - The node who's last child we want to return
+ * @param {Object} node - The node whose last child we want to return
  * @returns {Object} The last node
  */
 var getLastNode = function (node) {

--- a/tests/rules/final-newline.js
+++ b/tests/rules/final-newline.js
@@ -7,8 +7,7 @@ var lint = require('./_lint');
 //////////////////////////////
 describe('final newline - scss', function () {
 
-  // With newline (testing file without)
-  it('with newline [include: true]', function (done) {
+  it('none [include: true]', function (done) {
     var file = lint.file('final-newline--none.scss');
 
     lint.test(file, {
@@ -19,7 +18,7 @@ describe('final newline - scss', function () {
     });
   });
 
-  it('with newline [include: false]', function (done) {
+  it('none [include: false]', function (done) {
     var file = lint.file('final-newline--none.scss');
 
     lint.test(file, {
@@ -63,8 +62,7 @@ describe('final newline - scss', function () {
     });
   });
 
-  // No newline (testing file with)
-  it('no newline [include: true]', function (done) {
+  it('with return [include: true]', function (done) {
     var file = lint.file('final-newline--return.scss');
 
     lint.test(file, {
@@ -75,8 +73,62 @@ describe('final newline - scss', function () {
     });
   });
 
-  it('no newline [include: false]', function (done) {
+  it('with return [include: false]', function (done) {
     var file = lint.file('final-newline--return.scss');
+
+    lint.test(file, {
+      'final-newline': [
+        1,
+        {
+          'include': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  it('with import [include: true]', function (done) {
+    var file = lint.file('final-newline--import.scss');
+
+    lint.test(file, {
+      'final-newline': 1
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('with import [include: false]', function (done) {
+    var file = lint.file('final-newline--import.scss');
+
+    lint.test(file, {
+      'final-newline': [
+        1,
+        {
+          'include': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  it('with nested [include: true]', function (done) {
+    var file = lint.file('final-newline--nested.scss');
+
+    lint.test(file, {
+      'final-newline': 1
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('with nested [include: false]', function (done) {
+    var file = lint.file('final-newline--nested.scss');
 
     lint.test(file, {
       'final-newline': [
@@ -97,8 +149,7 @@ describe('final newline - scss', function () {
 //////////////////////////////
 describe('final newline - sass', function () {
 
-  // With newline (testing file without)
-  it('with newline [include: true]', function (done) {
+  it('none [include: true]', function (done) {
     var file = lint.file('final-newline--none.sass');
 
     lint.test(file, {
@@ -109,7 +160,7 @@ describe('final newline - sass', function () {
     });
   });
 
-  it('with newline [include: false]', function (done) {
+  it('none [include: false]', function (done) {
     var file = lint.file('final-newline--none.sass');
 
     lint.test(file, {
@@ -153,8 +204,7 @@ describe('final newline - sass', function () {
     });
   });
 
-  // No newline (testing file with)
-  it('no newline [include: true]', function (done) {
+  it('with return [include: true]', function (done) {
     var file = lint.file('final-newline--return.sass');
 
     lint.test(file, {
@@ -165,8 +215,62 @@ describe('final newline - sass', function () {
     });
   });
 
-  it('no newline [include: false]', function (done) {
+  it('with return [include: false]', function (done) {
     var file = lint.file('final-newline--return.sass');
+
+    lint.test(file, {
+      'final-newline': [
+        1,
+        {
+          'include': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  it('with import [include: true]', function (done) {
+    var file = lint.file('final-newline--import.sass');
+
+    lint.test(file, {
+      'final-newline': 1
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('with import [include: false]', function (done) {
+    var file = lint.file('final-newline--import.sass');
+
+    lint.test(file, {
+      'final-newline': [
+        1,
+        {
+          'include': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+
+  it('with nested [include: true]', function (done) {
+    var file = lint.file('final-newline--nested.sass');
+
+    lint.test(file, {
+      'final-newline': 1
+    }, function (data) {
+      lint.assert.equal(0, data.warningCount);
+      done();
+    });
+  });
+
+  it('with nested [include: false]', function (done) {
+    var file = lint.file('final-newline--nested.sass');
 
     lint.test(file, {
       'final-newline': [

--- a/tests/sass/final-newline--import.sass
+++ b/tests/sass/final-newline--import.sass
@@ -1,0 +1,1 @@
+@import 'foo'

--- a/tests/sass/final-newline--import.scss
+++ b/tests/sass/final-newline--import.scss
@@ -1,0 +1,1 @@
+@import 'foo';

--- a/tests/sass/final-newline--nested.sass
+++ b/tests/sass/final-newline--nested.sass
@@ -1,0 +1,3 @@
+.foo
+  @if $foo == 'bar'
+    content: 'bar'

--- a/tests/sass/final-newline--nested.scss
+++ b/tests/sass/final-newline--nested.scss
@@ -1,0 +1,5 @@
+.foo {
+  @if $foo == 'bar' {
+    content: 'bar';
+  }
+}

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -503,4 +503,4 @@ $norf: (5 % 2);
 }
 
 // Imports
-@import 'bar/foo'
+@import 'bar/foo';


### PR DESCRIPTION
Fixes two issues with the final-newline rule and the sass syntax, that popped up after the update to 1.6.

Fixes #627 
Fixes #630 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com