### PR TITLE
Update color literals

### DIFF
--- a/docs/rules/no-color-literals.md
+++ b/docs/rules/no-color-literals.md
@@ -12,11 +12,13 @@ Other color functions, such as `adjust-color` and `mix`, may be used, but the or
 
 ## Options
 
+* `allow-map-identifiers`: `true`/`false` (defaults to `true`)
 * `allow-rgba`: `true`/`false` (defaults to `false`)
+* `allow-variable-identifiers`: `true`/`false` (defaults to `true`)
 
 ## Examples
 
-When enabled and `allow-rgba` is set to `false` the following are disallowed.
+When enabled and default options are used the following are disallowed.
 
 ```scss
 .literal {
@@ -39,22 +41,27 @@ When enabled and `allow-rgba` is set to `false` the following are disallowed.
   color: #fff;
 }
 
+// rgb function passed directly as function argument
 .adj {
   color: adjust-color(rgb(255, 0, 0), $blue: 5);
 }
 
+// hsl function passed directly as function argument
 .scale {
   color: scale-color(hsl(120, 70%, 80%), $lightness: 50%);
 }
 
+// hsl function passed directly as function argument
 .change {
   color: change-color(hsl(25, 100%, 80%), $lightness: 40%, $alpha: .8);
 }
 
+// color literal passed directly as function argument
 .function {
   color: test(#fff);
 }
 
+// color functions used directly as property values
 .rgb {
   color: rgb(255, 255, 255);
 }
@@ -71,16 +78,9 @@ When enabled and `allow-rgba` is set to `false` the following are disallowed.
   color: hsla(40, 50%, 50%, .3);
 }
 
-//  using color literals as property names
-$colors: (
-  red: #fff,
-  blue : (
-    orange: #fff
-  )
-);
 ```
 
-When enabled and `allow-rgba` is set to `false` the following are allowed.
+When enabled and default options are used the following are allowed.
 
 ```scss
 $literal: mediumslateblue;
@@ -89,6 +89,17 @@ $rgb: rgb(255, 255, 255);
 $rgba: rgba(255, 255, 255, .3);
 $hsl: hsl(40, 50%, 50%);
 $hsla: hsla(40, 50%, 50%, .3);
+
+// using color literals as property names
+$colors: (
+  red: #fff,
+  blue : (
+    orange: #fff
+  )
+);
+
+// using color literals as variable identifiers
+$black: #000;
 
 .literal {
   color: $literal;
@@ -139,7 +150,11 @@ $hsla: hsla(40, 50%, 50%, .3);
 }
 ```
 
-In addition, when enabled and `allow-rgba` is set to `true`, the following will be allowed:
+---
+
+## [allow-rgba: true]
+
+When enabled and `allow-rgba` is set to `true`, the following will be allowed:
 
 ```scss
 // rgba in variables is still fine
@@ -160,4 +175,62 @@ In addition, when enabled and `allow-rgba` is set to `true`, the following will 
   color: rgba(0, 0, 0, .3);
   color: rgba(black, .3);
 }
+```
+
+---
+
+## [allow-variable-identifiers: false]
+
+When enabled and `allow-variable-identifiers` is set to `false`, the following will be disallowed
+
+```scss
+
+// variable uses a color literal as an identifier
+$black: #000
+
+// variable using a color literal as an identifier is passed to a function
+.test {
+  color: adjust-color($off-red, $blue: 5)
+}
+```
+
+When enabled and `allow-variable-identifiers` is set to `false`, the following will be allowed
+
+```scss
+
+// variable not directly using a color literal as an identifier
+$primary-black: #000
+
+```
+
+---
+
+## [allow-map-identifiers: false]
+
+When enabled and `allow-map-identifiers` is set to `false`, the following will be disallowed
+
+```scss
+
+// map identifiers red, blue and orange share their name with a
+// color literal and therefore shouldn't be used
+$colors: (
+  red: #f00,
+  blue: (
+    orange: $orange
+  )
+)
+
+```
+
+When enabled and `allow-map-identifiers` is set to `false`, the following will be allowed
+
+```scss
+
+$colors: (
+  primary-red: #f00,
+  map-blue: (
+    off-orange: $orange
+  )
+)
+
 ```

--- a/docs/rules/no-color-literals.md
+++ b/docs/rules/no-color-literals.md
@@ -192,6 +192,7 @@ $black: #000
 .test {
   color: adjust-color($off-red, $blue: 5)
 }
+
 ```
 
 When enabled and `allow-variable-identifiers` is set to `false`, the following will be allowed

--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -68,9 +68,9 @@ var checkHexPrefix = function (nodeType) {
 module.exports = {
   'name': 'no-color-literals',
   'defaults': {
-    'allow-variable-identifiers': true,
     'allow-map-identifiers': true,
-    'allow-rgba': false
+    'allow-rgba': false,
+    'allow-variable-identifiers': true
   },
   'detect': function (ast, parser) {
     var result = [],

--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -8,13 +8,68 @@ var helpers = require('../helpers'),
 var colorFunctions = ['rgb', 'rgba', 'hsl', 'hsla'],
     cssColors = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'literals.yml'), 'utf8')).split(' ');
 
+/**
+ * Returns a copy of the colour functions array
+ *
+ * @param {Array} colorFunctionsArr - The color functions array we wish to clone
+ * @returns {Array} A copy of the color functions array.
+ */
 var getColorFunctionsCopy = function (colorFunctionsArr) {
   return colorFunctionsArr.slice();
+};
+
+/**
+ * Checks if the next node along is an operator of type ':'
+ *
+ * @param {Object} parent - The parent node
+ * @param {number} i - The current child position in the parent node
+ * @returns {boolean} If the sibling node is the correct type of operator
+ */
+var checkNextIsOperator = function (parent, i) {
+  var next = parent.content[i + 1] && parent.content[i + 1].type === 'operator' && parent.content[i + 1].content === ':';
+  var spacedNext = parent.content[i + 2] && parent.content[i + 2].type === 'operator' && parent.content[i + 2].content === ':';
+
+  return next || spacedNext;
+};
+
+/**
+ * Check nested function arguments for colors/idents or further nested functions
+ *
+ * @param {Object} node - The node we're checking
+ * @returns {boolean} Whether the node matches the specified types
+ */
+var checkForNestedFuncArgs = function (node) {
+  return node.type === 'color' || node.type === 'ident' || node.type === 'function';
+};
+
+/**
+ * Check if the value is a color literal
+ *
+ * @param {Object} node - The node we're checking
+ * @param {Array} validColorFunctions - The array of valid color function types to check against
+ * @returns {boolean} Whether the node matches the specified types
+ */
+var checkIsLiteral = function (node, validColorFunctions) {
+  return cssColors.indexOf(node.content) !== -1 || helpers.isValidHex(node.content) || validColorFunctions.indexOf(node.content) !== -1;
+};
+
+/**
+ * Checks the see if the node type is a hex value if so return the correct prefix
+ *
+ * @param {String} nodeType - The node type identifier
+ * @returns {String} Either a '#' or an empty string
+ */
+var checkHexPrefix = function (nodeType) {
+  var prefix = nodeType === 'color' ? '#' : '';
+
+  return prefix;
 };
 
 module.exports = {
   'name': 'no-color-literals',
   'defaults': {
+    'allow-variable-identifiers': true,
+    'allow-map-identifiers': true,
     'allow-rgba': false
   },
   'detect': function (ast, parser) {
@@ -25,113 +80,134 @@ module.exports = {
       validColorFunctions.splice(validColorFunctions.indexOf('rgba'), 1);
     }
 
-    ast.traverseByType('value', function (node, i, parent) {
-      node.forEach(function (valElem) {
-        var declarationType = parent.content[0].content[0].type;
+    ast.traverseByTypes(['value', 'variable'], function (node, i, parent) {
 
-        // check type is color, content isn't a css color literal but also it's not a variable
-        if ((valElem.type === 'color' || cssColors.indexOf(valElem.content) !== -1) && valElem.type !== 'variable') {
-          if (declarationType === 'ident') {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': valElem.start.line,
-              'column': valElem.start.column,
-              'message': 'Color literals such as \'' + valElem.content + '\' should only be used in variable declarations',
-              'severity': parser.severity
-            });
-          }
+      // If we don't literals as variable names then check each variable name
+      if (node.is('variable') && !parser.options['allow-variable-identifiers']) {
+        if (cssColors.indexOf(node.content[0].content) !== -1) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': 'Color literals should not be used as variable names',
+            'severity': parser.severity
+          });
         }
-
-        // if not a color value or a variable then check if it's a function
-        else if (valElem.type === 'function') {
-          var funcType = valElem.content[0].content;
-
-          // check it's not a blacklisted color function and even if it is that it's not assigned to a variable
-          if (validColorFunctions.indexOf(funcType) !== -1 && declarationType !== 'variable') {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': valElem.start.line,
-              'column': valElem.start.column,
-              'message': 'Color functions such as \'' + funcType + '\' should only be used in variable declarations',
-              'severity': parser.severity
-            });
+      }
+      // check the value nodes
+      else if (node.is('value')) {
+        node.forEach(function (valElem) {
+          var declarationType = parent.content[0].content[0].type;
+          // check type is color, content isn't a css color literal
+          if (valElem.type === 'color' || cssColors.indexOf(valElem.content) !== -1) {
+            if (declarationType === 'ident') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': valElem.start.line,
+                'column': valElem.start.column,
+                'message': 'Color literals such as \'' + checkHexPrefix(valElem.type) + valElem.content + '\' should only be used in variable declarations',
+                'severity': parser.severity
+              });
+            }
           }
 
-          // if rgba usage is allowed we need to make sure only variables are being passed to it.
-          else if (parser.options['allow-rgba'] && funcType === 'rgba' && valElem.content[1].content[0].type !== 'variable' && declarationType !== 'variable' ) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': valElem.start.line,
-              'column': valElem.start.column,
-              'message': 'A color in variable form must be passed to rgba, literals are restricted',
-              'severity': parser.severity
-            });
-          }
+          // if not a color value or a variable then check if it's a function
+          else if (valElem.type === 'function') {
+            var funcType = valElem.content[0].content;
 
-          // if a non color function we should check it's arguments
-          else {
-            valElem.content.forEach( function (funcContent) {
-              if (funcContent.type === 'arguments') {
-                funcContent.forEach(function (funcArgs) {
+            // check it's not a blacklisted color function and even if it is that it's not assigned to a variable
+            if (validColorFunctions.indexOf(funcType) !== -1 && declarationType !== 'variable') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': valElem.start.line,
+                'column': valElem.start.column,
+                'message': 'Color functions such as \'' + funcType + '\' should only be used in variable declarations',
+                'severity': parser.severity
+              });
+            }
 
-                  // if the arguments are not functions themselves
-                  if (funcArgs.type !== 'function') {
+            // if rgba usage is allowed we need to make sure only variables are being passed to it.
+            else if (
+              parser.options['allow-rgba'] &&
+              funcType === 'rgba' &&
+              valElem.content[1].content[0].type !== 'variable' &&
+              declarationType !== 'variable'
+            ) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': valElem.start.line,
+                'column': valElem.start.column,
+                'message': 'A color in variable form must be passed to rgba, literals are restricted',
+                'severity': parser.severity
+              });
+            }
 
-                    // check if the argument types are therefore color literals
-                    if ((funcArgs.type === 'color' || funcArgs.type === 'ident') && (cssColors.indexOf(funcArgs.content) !== -1 || helpers.isValidHex(funcArgs.content))) {
-                      result = helpers.addUnique(result, {
-                        'ruleId': parser.rule.name,
-                        'line': funcArgs.start.line,
-                        'column': funcArgs.start.column,
-                        'message': 'Color literals such as \'' + funcArgs.content + '\' should not be passed to functions, use variables',
-                        'severity': parser.severity
-                      });
-                    }
-                  }
-
-                  // if the argument is a function itself
-                  else {
-
-                    // loop its arguments
-                    funcArgs.forEach( function (nestedFuncArgs) {
-
-                      // check again for color literals or blacklisted color functions
-                      if (
-                        (nestedFuncArgs.type === 'color' || nestedFuncArgs.type === 'ident' || nestedFuncArgs.type === 'function') &&
-                        (cssColors.indexOf(nestedFuncArgs.content) !== -1 || helpers.isValidHex(nestedFuncArgs.content) || validColorFunctions.indexOf(nestedFuncArgs.content) !== -1 )
-                      ) {
+            // if a non color function we should check its arguments
+            else {
+              valElem.content.forEach( function (funcContent) {
+                if (funcContent.type === 'arguments') {
+                  funcContent.forEach(function (funcArgs) {
+                    // if the arguments are not functions themselves
+                    if (funcArgs.type !== 'function') {
+                      // check if the argument types are therefore color literals
+                      if ((funcArgs.type === 'color' || funcArgs.type === 'ident') && (cssColors.indexOf(funcArgs.content) !== -1 || helpers.isValidHex(funcArgs.content))) {
                         result = helpers.addUnique(result, {
                           'ruleId': parser.rule.name,
-                          'line': nestedFuncArgs.start.line,
-                          'column': nestedFuncArgs.start.column,
-                          'message': 'Color functions such as \'' + nestedFuncArgs.content + '\' should not be passed to functions, use variables',
+                          'line': funcArgs.start.line,
+                          'column': funcArgs.start.column,
+                          'message': 'Color literals such as \'' + checkHexPrefix(funcArgs.type) + funcArgs.content + '\' should not be passed to functions, use variables',
                           'severity': parser.severity
                         });
                       }
-                    });
-                  }
+                    }
+
+                    // if the argument is a function itself
+                    else {
+                      // loop its arguments
+                      funcArgs.forEach( function (nestedFuncArgs) {
+                        // check again for color literals or blacklisted color functions
+                        if (
+                          checkForNestedFuncArgs(nestedFuncArgs) &&
+                          checkIsLiteral(nestedFuncArgs, validColorFunctions)
+                        ) {
+                          result = helpers.addUnique(result, {
+                            'ruleId': parser.rule.name,
+                            'line': nestedFuncArgs.start.line,
+                            'column': nestedFuncArgs.start.column,
+                            'message': 'Color functions such as \'' + nestedFuncArgs.content + '\' should not be passed to functions, use variables',
+                            'severity': parser.severity
+                          });
+                        }
+                      });
+                    }
+                  });
+                }
+              });
+            }
+          }
+
+          // if not allowing literals as map identifiers check to see if the property names
+          // are the same as color literals - this is bad
+          else if (valElem.type === 'parentheses' && !parser.options['allow-map-identifiers']) {
+            valElem.traverse(function (mapVals, idx, mapValsParent) {
+              // check if the parent is a variable to allow variables named after CSS colors, e.g. `$black`
+              if (
+                mapVals.type === 'ident' &&
+                checkNextIsOperator(mapValsParent, idx) &&
+                cssColors.indexOf(mapVals.content) !== -1
+              ) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': mapVals.start.line,
+                  'column': mapVals.start.column,
+                  'message': 'Color literals should not be used as map identifiers',
+                  'severity': parser.severity
                 });
               }
             });
           }
-        }
-
-        // if a map / list check to see if it's property names are the same as color literals - this is bad
-        else if (valElem.type === 'parentheses') {
-          valElem.traverse( function (mapVals, idx, mapValsParent) {
-            // check if the parent is a variable to allow variables named after CSS colors, e.g. `$black`
-            if (mapVals.type === 'ident' && mapValsParent.type !== 'variable' && cssColors.indexOf(mapVals.content) !== -1) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': mapVals.start.line,
-                'column': mapVals.start.column,
-                'message': 'Color literals such as \'' + mapVals.content + '\' should not be used as map identifiers',
-                'severity': parser.severity
-              });
-            }
-          });
-        }
-      });
+        });
+      }
     });
     return result;
   }

--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -118,8 +118,9 @@ module.exports = {
 
         // if a map / list check to see if it's property names are the same as color literals - this is bad
         else if (valElem.type === 'parentheses') {
-          valElem.traverse( function (mapVals) {
-            if (mapVals.type === 'ident' && cssColors.indexOf(mapVals.content) !== -1 ) {
+          valElem.traverse( function (mapVals, idx, mapValsParent) {
+            // check if the parent is a variable to allow variables named after CSS colors, e.g. `$black`
+            if (mapVals.type === 'ident' && mapValsParent.type !== 'variable' && cssColors.indexOf(mapVals.content) !== -1) {
               result = helpers.addUnique(result, {
                 'ruleId': parser.rule.name,
                 'line': mapVals.start.line,

--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -60,9 +60,7 @@ var checkIsLiteral = function (node, validColorFunctions) {
  * @returns {String} Either a '#' or an empty string
  */
 var checkHexPrefix = function (nodeType) {
-  var prefix = nodeType === 'color' ? '#' : '';
-
-  return prefix;
+  return nodeType === 'color' ? '#' : '';
 };
 
 module.exports = {

--- a/tests/rules/no-color-literals.js
+++ b/tests/rules/no-color-literals.js
@@ -12,7 +12,7 @@ describe('no color literals - scss', function () {
     lint.test(file, {
       'no-color-literals': 1
     }, function (data) {
-      lint.assert.equal(19, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,51 @@ describe('no color literals - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(18, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allow-variable-identifiers: false]', function (done) {
+    lint.test(file, {
+      'no-color-literals': [
+        1,
+        {
+          'allow-variable-identifiers': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allow-map-identifiers: false]', function (done) {
+    lint.test(file, {
+      'no-color-literals': [
+        1,
+        {
+          'allow-map-identifiers': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(19, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allow-rgba: true, allow-variable-identifiers: false, allow-map-identifiers: false ]', function (done) {
+    lint.test(file, {
+      'no-color-literals': [
+        1,
+        {
+          'allow-rgba': true,
+          'allow-variable-identifiers': false,
+          'allow-map-identifiers': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(22, data.warningCount);
       done();
     });
   });
@@ -42,7 +86,7 @@ describe('no color literals - sass', function () {
     lint.test(file, {
       'no-color-literals': 1
     }, function (data) {
-      lint.assert.equal(19, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -56,7 +100,51 @@ describe('no color literals - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(18, data.warningCount);
+      lint.assert.equal(15, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allow-variable-identifiers: false]', function (done) {
+    lint.test(file, {
+      'no-color-literals': [
+        1,
+        {
+          'allow-variable-identifiers': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(20, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allow-map-identifiers: false]', function (done) {
+    lint.test(file, {
+      'no-color-literals': [
+        1,
+        {
+          'allow-map-identifiers': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(19, data.warningCount);
+      done();
+    });
+  });
+
+  it('[allow-rgba: true, allow-variable-identifiers: false, allow-map-identifiers: false ]', function (done) {
+    lint.test(file, {
+      'no-color-literals': [
+        1,
+        {
+          'allow-rgba': true,
+          'allow-variable-identifiers': false,
+          'allow-map-identifiers': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(22, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-color-literals.sass
+++ b/tests/sass/no-color-literals.sass
@@ -52,9 +52,10 @@
 
 
 // disallowed - using color literals as property names
-$colors: (red: #fff, blue : ( orange: #fff ) )
+$colors: (red: #fff, blue: (orange: #fff), font-color: $black)
 
 // allowed
+$black: #000
 $literal: mediumslateblue
 $hexVar: #fff
 $rgb: rgb(255, 255, 255)

--- a/tests/sass/no-color-literals.scss
+++ b/tests/sass/no-color-literals.scss
@@ -60,6 +60,7 @@ $colors: (
 );
 
 // allowed
+$black: #000;
 $literal: mediumslateblue;
 $hexVar: #fff;
 $rgb: rgb(255, 255, 255);
@@ -118,3 +119,8 @@ $hsla: hsla(40, 50%, 50%, .3);
 .rgba-enabled {
   color: rgba($hexVar, .3);
 }
+
+// allowed - using variables named after colors as map values
+$colors: (
+  font-color: $black,
+);

--- a/tests/sass/no-color-literals.scss
+++ b/tests/sass/no-color-literals.scss
@@ -56,17 +56,20 @@ $colors: (
   red: #fff,
   blue : (
     orange: #fff
-  )
+  ),
+  font-color: $black
 );
 
 // allowed
-$black: #000;
 $literal: mediumslateblue;
 $hexVar: #fff;
 $rgb: rgb(255, 255, 255);
 $rgba: rgba(255, 255, 255, .3);
 $hsl: hsl(40, 50%, 50%);
 $hsla: hsla(40, 50%, 50%, .3);
+
+// allowed by default, disallowed when allow-variable-identifiers: false
+$black: #000;
 
 .literal {
   color: $literal;
@@ -119,8 +122,3 @@ $hsla: hsla(40, 50%, 50%, .3);
 .rgba-enabled {
   color: rgba($hexVar, .3);
 }
-
-// allowed - using variables named after colors as map values
-$colors: (
-  font-color: $black,
-);


### PR DESCRIPTION
Carrying on from the changes proposed in #539 I've gone back and had a quick review of the rule.

Added two extra options
* `allow-variable-identifiers` (default `true`)
* `allow-map-identifiers` (default `true`)

The first option allows you to disallow the use of color-literals as variable identifiers/names but is disabled by default due to the feedback we received around this rule.

The second option allows you to disallow the use of color literals as map identifiers which to me seemed the logical extension of the option above but suited different use cases to the above.

Added extra tests and necessary documentation

closes #538 
closes #539

`DCO 1.1 Signed-off-by: Dan Purdy <dan@danpurdy.co.uk>`