### PR TITLE
Fix issue with placeholder name format with interpolation

### DIFF
--- a/lib/rules/placeholder-name-format.js
+++ b/lib/rules/placeholder-name-format.js
@@ -18,60 +18,60 @@ module.exports = {
           strippedName,
           violationMessage = false;
 
-      strippedName = name;
+      if (node.first().is('ident')) {
+        strippedName = name;
+        if (parser.options['allow-leading-underscore'] && name[0] === '_') {
+          strippedName = name.slice(1);
+        }
 
-      if (parser.options['allow-leading-underscore'] && name[0] === '_') {
-        strippedName = name.slice(1);
-      }
+        switch (parser.options.convention) {
+        case 'hyphenatedlowercase':
+          if (!helpers.isHyphenatedLowercase(strippedName)) {
+            violationMessage = 'Placeholder \'%' + name + '\' should be written in lowercase with hyphens';
+          }
+          break;
+        case 'camelcase':
+          if (!helpers.isCamelCase(strippedName)) {
+            violationMessage = 'Placeholder \'%' + name + '\' should be written in camelCase';
+          }
+          break;
+        case 'snakecase':
+          if (!helpers.isSnakeCase(strippedName)) {
+            violationMessage = 'Placeholder \'%' + name + '\' should be written in snake_case';
+          }
+          break;
+        case 'strictbem':
+          if (!helpers.isStrictBEM(strippedName)) {
+            violationMessage = 'Placeholder \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
+          }
+          break;
+        case 'hyphenatedbem':
+          if (!helpers.isHyphenatedBEM(strippedName)) {
+            violationMessage = 'Placeholder \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
+          }
+          break;
+        default:
+          if (!(new RegExp(parser.options.convention).test(strippedName))) {
+            violationMessage = 'Placeholder \'%' + name + '\' should match regular expression /' + parser.options.convention + '/';
 
-      switch (parser.options.convention) {
-      case 'hyphenatedlowercase':
-        if (!helpers.isHyphenatedLowercase(strippedName)) {
-          violationMessage = 'Placeholder \'%' + name + '\' should be written in lowercase with hyphens';
-        }
-        break;
-      case 'camelcase':
-        if (!helpers.isCamelCase(strippedName)) {
-          violationMessage = 'Placeholder \'%' + name + '\' should be written in camelCase';
-        }
-        break;
-      case 'snakecase':
-        if (!helpers.isSnakeCase(strippedName)) {
-          violationMessage = 'Placeholder \'%' + name + '\' should be written in snake_case';
-        }
-        break;
-      case 'strictbem':
-        if (!helpers.isStrictBEM(strippedName)) {
-          violationMessage = 'Placeholder \'.' + name + '\' should be written in BEM (Block Element Modifier) format';
-        }
-        break;
-      case 'hyphenatedbem':
-        if (!helpers.isHyphenatedBEM(strippedName)) {
-          violationMessage = 'Placeholder \'.' + name + '\' should be written in hyphenated BEM (Block Element Modifier) format';
-        }
-        break;
-      default:
-        if (!(new RegExp(parser.options.convention).test(strippedName))) {
-          violationMessage = 'Placeholder \'%' + name + '\' should match regular expression /' + parser.options.convention + '/';
-
-          // convention-message overrides violationMessage
-          if (parser.options['convention-explanation']) {
-            violationMessage = parser.options['convention-explanation'];
+            // convention-message overrides violationMessage
+            if (parser.options['convention-explanation']) {
+              violationMessage = parser.options['convention-explanation'];
+            }
           }
         }
-      }
 
-      if (violationMessage) {
-        result = helpers.addUnique(result, {
-          'ruleId': parser.rule.name,
-          'line': node.start.line,
-          'column': node.start.column,
-          'message': violationMessage,
-          'severity': parser.severity
-        });
+        if (violationMessage) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': violationMessage,
+            'severity': parser.severity
+          });
+        }
       }
     });
-
     return result;
   }
 };

--- a/tests/sass/placeholder-name-format.sass
+++ b/tests/sass/placeholder-name-format.sass
@@ -51,3 +51,8 @@
 
 .class
   @extend %snake_case
+
+// Issue: https://github.com/sasstools/sass-lint/issues/625
+// variables/interpolation should be ignored
+%#{$var}
+  content: ''

--- a/tests/sass/placeholder-name-format.scss
+++ b/tests/sass/placeholder-name-format.scss
@@ -69,3 +69,9 @@
 .class {
   @extend %snake_case;
 }
+
+// Issue: https://github.com/sasstools/sass-lint/issues/625
+// variables/interpolation should be ignored
+%#{$var} {
+  content: '';
+}


### PR DESCRIPTION
Fixes #625 

Makes sure that the placeholder name is an ident rather than interpolation or a variable etc.

`DCO 1.1 Signed-off-by: Dan Purdy <dan@danpurdy.co.uk>`