### PR TITLE
Fix incorrect rule name

### DIFF
--- a/lib/rules/empty-args.js
+++ b/lib/rules/empty-args.js
@@ -3,7 +3,7 @@
 var helpers = require('../helpers');
 
 module.exports = {
-  'name': 'no-empty-args',
+  'name': 'empty-args',
   'defaults': {
     'include': false
   },


### PR DESCRIPTION
The empty args rule was named incorrectly within the rule definition. It was labelled `no-empty-args` whereas in the docs and config file it was labelled `empty-args`.

Not a breaking changes as it's just the reported name, the default config etc was having effect as anticipated but was leading to confusion on the rule name to update.

Fixes #652 

`DCO 1.1 Signed-off-by: Dan Purdy <dan@danpurdy.co.uk>`