### PR TITLE
Add pseudo-element rule

### DIFF
--- a/docs/rules/pseudo-element.md
+++ b/docs/rules/pseudo-element.md
@@ -1,0 +1,32 @@
+# Pseudo-element
+
+Rule `pseudo-element` will enforce that:
+
+* Pseudo-**elements** must start with **double colons**.
+* Pseudo-**classes** must start with **single colon**.
+
+## Examples
+
+When enabled, the following are allowed:
+
+```scss
+.foo::before {
+  content: "bar";
+}
+
+.foo:hover {
+  content: "bar";
+}
+```
+
+When enabled, the following are disallowed:
+
+```scss
+.foo:before {
+  content: "bar";
+}
+
+.foo::hover {
+  content: "bar";
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -68,6 +68,7 @@ rules:
   url-quotes: 1
   variable-for-property: 1
   zero-unit: 1
+  pseudo-element: 1
 
   # Inner Spacing
   space-after-comma: 1

--- a/lib/rules/pseudo-element.js
+++ b/lib/rules/pseudo-element.js
@@ -76,7 +76,7 @@ module.exports = {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Pseudo-classes must start with double colons',
+          'message': 'Pseudo-classes must start with single colon',
           'severity': parser.severity
         });
       }

--- a/lib/rules/pseudo-element.js
+++ b/lib/rules/pseudo-element.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+var pseudoElements = [
+  'after',
+  'before',
+  'first-letter',
+  'first-line',
+  'selection',
+  'backdrop'
+];
+
+var pseudoClasses = [
+  'active',
+  'checked',
+  'disabled',
+  'empty',
+  'enabled',
+  'first-child',
+  'first-of-type',
+  'focus',
+  'hover',
+  'in-range',
+  'invalid',
+  'lang',
+  'last-child',
+  'last-of-type',
+  'link',
+  'not',
+  'nth-child',
+  'nth-last-child',
+  'nth-last-of-type',
+  'nth-of-type',
+  'only-of-type',
+  'only-child',
+  'optional',
+  'out-of-range',
+  'read-only',
+  'read-write',
+  'required',
+  'root',
+  'target',
+  'valid',
+  'visited'
+];
+
+var isPseudoElement = function isPseudoElement (name) {
+  return pseudoElements.indexOf(name) !== -1;
+};
+
+var isPseudoClass = function isPseudoClass (name) {
+  return pseudoClasses.indexOf(name) !== -1;
+};
+
+module.exports = {
+  'name': 'colons',
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('pseudoClass', function (node) {
+      if (isPseudoElement(node.content[0].content)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Pseudo-elements must start with double colons',
+          'severity': parser.severity
+        });
+      }
+    });
+
+    ast.traverseByType('pseudoElement', function (node) {
+      if (isPseudoClass(node.content[0].content)) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': node.start.line,
+          'column': node.start.column,
+          'message': 'Pseudo-classes must start with double colons',
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/lib/rules/pseudo-element.js
+++ b/lib/rules/pseudo-element.js
@@ -45,12 +45,16 @@ var pseudoClasses = [
   'visited'
 ];
 
+var prefixFree = function prefixFree (name) {
+  return name.charAt(0) === '-' ? helpers.stripPrefix(name) : name;
+};
+
 var isPseudoElement = function isPseudoElement (name) {
-  return pseudoElements.indexOf(name) !== -1;
+  return pseudoElements.indexOf(prefixFree(name)) !== -1;
 };
 
 var isPseudoClass = function isPseudoClass (name) {
-  return pseudoClasses.indexOf(name) !== -1;
+  return pseudoClasses.indexOf(prefixFree(name)) !== -1;
 };
 
 module.exports = {

--- a/tests/rules/pseudo-element.js
+++ b/tests/rules/pseudo-element.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('pseudo-element - scss', function () {
+  var file = lint.file('pseudo-element.scss');
+
+  var byAttribute = function byAttribute (key, value) {
+    return function filterByAttribute (element) {
+      return element[key].match(value);
+    };
+  };
+
+  it('enforces double colons for pseudo-elements', function (done) {
+    lint.test(file, {
+      'pseudo-element': 1
+    }, function (data) {
+      var pseudoElementRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-elements/));
+      lint.assert.equal(37, data.warningCount);
+      lint.assert.equal(6, pseudoElementRelatedWarnings.length);
+      done();
+    });
+  });
+
+  it('enforces single colon for pseudo-classes', function (done) {
+    lint.test(file, {
+      'pseudo-element': 1
+    }, function (data) {
+      var pseudoClassRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-classes/));
+      lint.assert.equal(37, data.warningCount);
+      lint.assert.equal(31, pseudoClassRelatedWarnings.length);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('pseudo-element - scss', function () {
+  var file = lint.file('pseudo-element.sass');
+
+  var byAttribute = function byAttribute (key, value) {
+    return function filterByAttribute (element) {
+      return element[key].match(value);
+    };
+  };
+
+  it('enforces double colons for pseudo-elements', function (done) {
+    lint.test(file, {
+      'pseudo-element': 1
+    }, function (data) {
+      var pseudoElementRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-elements/));
+      lint.assert.equal(37, data.warningCount);
+      lint.assert.equal(6, pseudoElementRelatedWarnings.length);
+      done();
+    });
+  });
+
+  it('enforces single colon for pseudo-classes', function (done) {
+    lint.test(file, {
+      'pseudo-element': 1
+    }, function (data) {
+      var pseudoClassRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-classes/));
+      lint.assert.equal(37, data.warningCount);
+      lint.assert.equal(31, pseudoClassRelatedWarnings.length);
+      done();
+    });
+  });
+});

--- a/tests/rules/pseudo-element.js
+++ b/tests/rules/pseudo-element.js
@@ -19,8 +19,8 @@ describe('pseudo-element - scss', function () {
       'pseudo-element': 1
     }, function (data) {
       var pseudoElementRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-elements/));
-      lint.assert.equal(37, data.warningCount);
-      lint.assert.equal(6, pseudoElementRelatedWarnings.length);
+      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(7, pseudoElementRelatedWarnings.length);
       done();
     });
   });
@@ -30,8 +30,8 @@ describe('pseudo-element - scss', function () {
       'pseudo-element': 1
     }, function (data) {
       var pseudoClassRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-classes/));
-      lint.assert.equal(37, data.warningCount);
-      lint.assert.equal(31, pseudoClassRelatedWarnings.length);
+      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(32, pseudoClassRelatedWarnings.length);
       done();
     });
   });
@@ -40,7 +40,7 @@ describe('pseudo-element - scss', function () {
 //////////////////////////////
 // Sass syntax tests
 //////////////////////////////
-describe('pseudo-element - scss', function () {
+describe('pseudo-element - sass', function () {
   var file = lint.file('pseudo-element.sass');
 
   var byAttribute = function byAttribute (key, value) {
@@ -54,8 +54,8 @@ describe('pseudo-element - scss', function () {
       'pseudo-element': 1
     }, function (data) {
       var pseudoElementRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-elements/));
-      lint.assert.equal(37, data.warningCount);
-      lint.assert.equal(6, pseudoElementRelatedWarnings.length);
+      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(7, pseudoElementRelatedWarnings.length);
       done();
     });
   });
@@ -65,8 +65,8 @@ describe('pseudo-element - scss', function () {
       'pseudo-element': 1
     }, function (data) {
       var pseudoClassRelatedWarnings = data.messages.filter(byAttribute('message', /Pseudo-classes/));
-      lint.assert.equal(37, data.warningCount);
-      lint.assert.equal(31, pseudoClassRelatedWarnings.length);
+      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(32, pseudoClassRelatedWarnings.length);
       done();
     });
   });

--- a/tests/sass/pseudo-element.sass
+++ b/tests/sass/pseudo-element.sass
@@ -1,0 +1,224 @@
+.right-element::after
+  content: "right-element"
+
+.right-element::before
+  content: "right-element"
+
+.right-element::first-letter
+  content: "right-element"
+
+.right-element::first-line
+  content: "right-element"
+
+.right-element::selection
+  content: "right-element"
+
+.right-element::backdrop
+  content: "right-element"
+
+
+.wrong-element:after
+  content: "wrong-element"
+
+.wrong-element:before
+  content: "wrong-element"
+
+.wrong-element:first-letter
+  content: "wrong-element"
+
+.wrong-element:first-line
+  content: "wrong-element"
+
+.wrong-element:selection
+  content: "wrong-element"
+
+.wrong-element:backdrop
+  content: "wrong-element"
+
+
+.right-selector:active
+  content: "right-selector"
+
+.right-selector:checked
+  content: "right-selector"
+
+.right-selector:disabled
+  content: "right-selector"
+
+.right-selector:empty
+  content: "right-selector"
+
+.right-selector:enabled
+  content: "right-selector"
+
+.right-selector:first-child
+  content: "right-selector"
+
+.right-selector:first-of-type
+  content: "right-selector"
+
+.right-selector:focus
+  content: "right-selector"
+
+.right-selector:hover
+  content: "right-selector"
+
+.right-selector:in-range
+  content: "right-selector"
+
+.right-selector:invalid
+  content: "right-selector"
+
+.right-selector:lang
+  content: "right-selector"
+
+.right-selector:last-child
+  content: "right-selector"
+
+.right-selector:last-of-type
+  content: "right-selector"
+
+.right-selector:link
+  content: "right-selector"
+
+.right-selector:not
+  content: "right-selector"
+
+.right-selector:nth-child
+  content: "right-selector"
+
+.right-selector:nth-last-child
+  content: "right-selector"
+
+.right-selector:nth-last-of-type
+  content: "right-selector"
+
+.right-selector:nth-of-type
+  content: "right-selector"
+
+.right-selector:only-of-type
+  content: "right-selector"
+
+.right-selector:only-child
+  content: "right-selector"
+
+.right-selector:optional
+  content: "right-selector"
+
+.right-selector:out-of-range
+  content: "right-selector"
+
+.right-selector:read-only
+  content: "right-selector"
+
+.right-selector:read-write
+  content: "right-selector"
+
+.right-selector:required
+  content: "right-selector"
+
+.right-selector:root
+  content: "right-selector"
+
+.right-selector:target
+  content: "right-selector"
+
+.right-selector:valid
+  content: "right-selector"
+
+.right-selector:visited
+  content: "right-selector"
+
+
+.wrong-selector::active
+  content: "wrong-selector"
+
+.wrong-selector::checked
+  content: "wrong-selector"
+
+.wrong-selector::disabled
+  content: "wrong-selector"
+
+.wrong-selector::empty
+  content: "wrong-selector"
+
+.wrong-selector::enabled
+  content: "wrong-selector"
+
+.wrong-selector::first-child
+  content: "wrong-selector"
+
+.wrong-selector::first-of-type
+  content: "wrong-selector"
+
+.wrong-selector::focus
+  content: "wrong-selector"
+
+.wrong-selector::hover
+  content: "wrong-selector"
+
+.wrong-selector::in-range
+  content: "wrong-selector"
+
+.wrong-selector::invalid
+  content: "wrong-selector"
+
+.wrong-selector::lang
+  content: "wrong-selector"
+
+.wrong-selector::last-child
+  content: "wrong-selector"
+
+.wrong-selector::last-of-type
+  content: "wrong-selector"
+
+.wrong-selector::link
+  content: "wrong-selector"
+
+.wrong-selector::not
+  content: "wrong-selector"
+
+.wrong-selector::nth-child
+  content: "wrong-selector"
+
+.wrong-selector::nth-last-child
+  content: "wrong-selector"
+
+.wrong-selector::nth-last-of-type
+  content: "wrong-selector"
+
+.wrong-selector::nth-of-type
+  content: "wrong-selector"
+
+.wrong-selector::only-of-type
+  content: "wrong-selector"
+
+.wrong-selector::only-child
+  content: "wrong-selector"
+
+.wrong-selector::optional
+  content: "wrong-selector"
+
+.wrong-selector::out-of-range
+  content: "wrong-selector"
+
+.wrong-selector::read-only
+  content: "wrong-selector"
+
+.wrong-selector::read-write
+  content: "wrong-selector"
+
+.wrong-selector::required
+  content: "wrong-selector"
+
+.wrong-selector::root
+  content: "wrong-selector"
+
+.wrong-selector::target
+  content: "wrong-selector"
+
+.wrong-selector::valid
+  content: "wrong-selector"
+
+.wrong-selector::visited
+  content: "wrong-selector"

--- a/tests/sass/pseudo-element.sass
+++ b/tests/sass/pseudo-element.sass
@@ -16,6 +16,9 @@
 .right-element::backdrop
   content: "right-element"
 
+.right-element::-ms-backdrop
+  content: "right-prefixed-element"
+
 
 .wrong-element:after
   content: "wrong-element"
@@ -34,6 +37,9 @@
 
 .wrong-element:backdrop
   content: "wrong-element"
+
+.wrong-element:-ms-backdrop
+  content: "wrong-prefixed-element"
 
 
 .right-selector:active
@@ -113,6 +119,9 @@
 
 .right-selector:read-write
   content: "right-selector"
+
+.right-selector:-moz-read-write
+  content: "right-prefixed-selector"
 
 .right-selector:required
   content: "right-selector"
@@ -207,6 +216,9 @@
 
 .wrong-selector::read-write
   content: "wrong-selector"
+
+.wrong-selector::-moz-read-write
+  content: "wrong-prefixed-selector"
 
 .wrong-selector::required
   content: "wrong-selector"

--- a/tests/sass/pseudo-element.scss
+++ b/tests/sass/pseudo-element.scss
@@ -16,6 +16,10 @@
 .right-element::backdrop {
   content: "right-element";
 }
+.right-element::-ms-backdrop {
+  content: "right-prefixed-element";
+}
+
 
 .wrong-element:after {
   content: "wrong-element";
@@ -34,6 +38,9 @@
 }
 .wrong-element:backdrop {
   content: "wrong-element";
+}
+.wrong-element:-ms-backdrop {
+  content: "wrong-prefixed-element";
 }
 
 .right-selector:active {
@@ -113,6 +120,9 @@
 }
 .right-selector:read-write {
   content: "right-selector";
+}
+.right-selector:-moz-read-write {
+  content: "right-prefixed-selector";
 }
 .right-selector:required {
   content: "right-selector";
@@ -207,6 +217,9 @@
 }
 .wrong-selector::read-write {
   content: "wrong-selector";
+}
+.wrong-selector::-moz-read-write {
+  content: "wrong-prefixed-selector";
 }
 .wrong-selector::required {
   content: "wrong-selector";

--- a/tests/sass/pseudo-element.scss
+++ b/tests/sass/pseudo-element.scss
@@ -1,0 +1,225 @@
+.right-element::after {
+  content: "right-element";
+}
+.right-element::before {
+  content: "right-element";
+}
+.right-element::first-letter {
+  content: "right-element";
+}
+.right-element::first-line {
+  content: "right-element";
+}
+.right-element::selection {
+  content: "right-element";
+}
+.right-element::backdrop {
+  content: "right-element";
+}
+
+.wrong-element:after {
+  content: "wrong-element";
+}
+.wrong-element:before {
+  content: "wrong-element";
+}
+.wrong-element:first-letter {
+  content: "wrong-element";
+}
+.wrong-element:first-line {
+  content: "wrong-element";
+}
+.wrong-element:selection {
+  content: "wrong-element";
+}
+.wrong-element:backdrop {
+  content: "wrong-element";
+}
+
+.right-selector:active {
+  content: "right-selector";
+}
+.right-selector:checked {
+  content: "right-selector";
+}
+.right-selector:disabled {
+  content: "right-selector";
+}
+.right-selector:empty {
+  content: "right-selector";
+}
+.right-selector:enabled {
+  content: "right-selector";
+}
+.right-selector:first-child {
+  content: "right-selector";
+}
+.right-selector:first-of-type {
+  content: "right-selector";
+}
+.right-selector:focus {
+  content: "right-selector";
+}
+.right-selector:hover {
+  content: "right-selector";
+}
+.right-selector:in-range {
+  content: "right-selector";
+}
+.right-selector:invalid {
+  content: "right-selector";
+}
+.right-selector:lang {
+  content: "right-selector";
+}
+.right-selector:last-child {
+  content: "right-selector";
+}
+.right-selector:last-of-type {
+  content: "right-selector";
+}
+.right-selector:link {
+  content: "right-selector";
+}
+.right-selector:not {
+  content: "right-selector";
+}
+.right-selector:nth-child {
+  content: "right-selector";
+}
+.right-selector:nth-last-child {
+  content: "right-selector";
+}
+.right-selector:nth-last-of-type {
+  content: "right-selector";
+}
+.right-selector:nth-of-type {
+  content: "right-selector";
+}
+.right-selector:only-of-type {
+  content: "right-selector";
+}
+.right-selector:only-child {
+  content: "right-selector";
+}
+.right-selector:optional {
+  content: "right-selector";
+}
+.right-selector:out-of-range {
+  content: "right-selector";
+}
+.right-selector:read-only {
+  content: "right-selector";
+}
+.right-selector:read-write {
+  content: "right-selector";
+}
+.right-selector:required {
+  content: "right-selector";
+}
+.right-selector:root {
+  content: "right-selector";
+}
+.right-selector:target {
+  content: "right-selector";
+}
+.right-selector:valid {
+  content: "right-selector";
+}
+.right-selector:visited {
+  content: "right-selector";
+}
+
+.wrong-selector::active {
+  content: "wrong-selector";
+}
+.wrong-selector::checked {
+  content: "wrong-selector";
+}
+.wrong-selector::disabled {
+  content: "wrong-selector";
+}
+.wrong-selector::empty {
+  content: "wrong-selector";
+}
+.wrong-selector::enabled {
+  content: "wrong-selector";
+}
+.wrong-selector::first-child {
+  content: "wrong-selector";
+}
+.wrong-selector::first-of-type {
+  content: "wrong-selector";
+}
+.wrong-selector::focus {
+  content: "wrong-selector";
+}
+.wrong-selector::hover {
+  content: "wrong-selector";
+}
+.wrong-selector::in-range {
+  content: "wrong-selector";
+}
+.wrong-selector::invalid {
+  content: "wrong-selector";
+}
+.wrong-selector::lang {
+  content: "wrong-selector";
+}
+.wrong-selector::last-child {
+  content: "wrong-selector";
+}
+.wrong-selector::last-of-type {
+  content: "wrong-selector";
+}
+.wrong-selector::link {
+  content: "wrong-selector";
+}
+.wrong-selector::not {
+  content: "wrong-selector";
+}
+.wrong-selector::nth-child {
+  content: "wrong-selector";
+}
+.wrong-selector::nth-last-child {
+  content: "wrong-selector";
+}
+.wrong-selector::nth-last-of-type {
+  content: "wrong-selector";
+}
+.wrong-selector::nth-of-type {
+  content: "wrong-selector";
+}
+.wrong-selector::only-of-type {
+  content: "wrong-selector";
+}
+.wrong-selector::only-child {
+  content: "wrong-selector";
+}
+.wrong-selector::optional {
+  content: "wrong-selector";
+}
+.wrong-selector::out-of-range {
+  content: "wrong-selector";
+}
+.wrong-selector::read-only {
+  content: "wrong-selector";
+}
+.wrong-selector::read-write {
+  content: "wrong-selector";
+}
+.wrong-selector::required {
+  content: "wrong-selector";
+}
+.wrong-selector::root {
+  content: "wrong-selector";
+}
+.wrong-selector::target {
+  content: "wrong-selector";
+}
+.wrong-selector::valid {
+  content: "wrong-selector";
+}
+.wrong-selector::visited {
+  content: "wrong-selector";
+}


### PR DESCRIPTION
Resolves #662 

I've followed the same idea as https://github.com/brigade/scss-lint/pull/634/files. If the rule `pseudo-element` is enabled:
* **double** colons are enforced for pseudo-**elements**
* **single** colon is enforced for pseudo-**classes**.

_**NOTE:** I'd call this a WIP, as it does not consider vendor-prefixed pseudo elements and classes. Or should we take this as separate issue?_

---

`DCO 1.1 Signed-off-by: Guilherme Johansson Tramontina <guilherme.tramontina@gmail.com>`