### PR TITLE
Correct typos and add jsdoc comment to pseudo-element rule

### DIFF
--- a/lib/rules/pseudo-element.js
+++ b/lib/rules/pseudo-element.js
@@ -12,20 +12,38 @@ var pseudoElements = yaml.safeLoad(
       fs.readFileSync(path.join(__dirname, '../../data', 'pseudoClasses.yml'), 'utf8')
     ).split(' ');
 
+/**
+ * Get prefix free version of string
+ *
+ * @param {Object|string} name - The value to test
+ * @returns {string} A prefix free version of the string
+ */
 var prefixFree = function prefixFree (name) {
   return typeof name === 'string' && name.charAt(0) === '-' ? helpers.stripPrefix(name) : name;
 };
 
+/**
+ * Check if string is pseudo-element
+ *
+ * @param {string} name - The name to check
+ * @returns {Boolean} Whether or not name is pseudo-element
+ */
 var isPseudoElement = function isPseudoElement (name) {
   return pseudoElements.indexOf(prefixFree(name)) !== -1;
 };
 
+/**
+ * Check if string is pseudo-class
+ *
+ * @param {string} name - The name to check
+ * @returns {Boolean} Whether or not name is pseudo-class
+ */
 var isPseudoClass = function isPseudoClass (name) {
   return pseudoClasses.indexOf(prefixFree(name)) !== -1;
 };
 
 module.exports = {
-  'name': 'colons',
+  'name': 'pseudo-element',
   'detect': function (ast, parser) {
     var result = [];
 
@@ -47,7 +65,7 @@ module.exports = {
           'ruleId': parser.rule.name,
           'line': node.start.line,
           'column': node.start.column,
-          'message': 'Pseudo-classes must start with single colon',
+          'message': 'Pseudo-classes must start with a single colon',
           'severity': parser.severity
         });
       }

--- a/lib/rules/pseudo-element.js
+++ b/lib/rules/pseudo-element.js
@@ -13,7 +13,8 @@ var pseudoElements = yaml.safeLoad(
     ).split(' ');
 
 /**
- * Get prefix free version of string
+ * Check if the given argument is a prefixed string. If it is we return an unprefixed
+ * version, else return it unmodified
  *
  * @param {Object|string} name - The value to test
  * @returns {string} A prefix free version of the string
@@ -23,7 +24,7 @@ var prefixFree = function prefixFree (name) {
 };
 
 /**
- * Check if string is pseudo-element
+ * Determine if the given string matches a pseudo-element
  *
  * @param {string} name - The name to check
  * @returns {Boolean} Whether or not name is pseudo-element
@@ -33,7 +34,7 @@ var isPseudoElement = function isPseudoElement (name) {
 };
 
 /**
- * Check if string is pseudo-class
+ * Determine if the given string matches a pseudo-class
  *
  * @param {string} name - The name to check
  * @returns {Boolean} Whether or not name is pseudo-class


### PR DESCRIPTION
Fixes a few typos in the rule file and adds some basic jsdoc comments.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com