### PR TITLE
Fix incorrect rule test for no-empty-rulesets

### DIFF
--- a/tests/rules/no-empty-rulesets.js
+++ b/tests/rules/no-empty-rulesets.js
@@ -10,7 +10,7 @@ describe('no empty rulesets - scss', function () {
 
   it('enforce', function (done) {
     lint.test(file, {
-      'empty-ruleset': 1
+      'no-empty-rulesets': 1
     }, function (data) {
       lint.assert.equal(3, data.warningCount);
       done();


### PR DESCRIPTION
The test was using the incorrect rule name.

Closes #684 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com