### PR TITLE
Fix incorrect rule name for no-trailing-zero

### DIFF
--- a/tests/rules/no-trailing-zero.js
+++ b/tests/rules/no-trailing-zero.js
@@ -10,7 +10,7 @@ describe('no trailing zero - scss', function () {
 
   it('enforce', function (done) {
     lint.test(file, {
-      'trailing-zero': 1
+      'no-trailing-zero': 1
     }, function (data) {
       lint.assert.equal(8, data.warningCount);
       done();
@@ -26,7 +26,7 @@ describe('no trailing zero - sass', function () {
 
   it('enforce', function (done) {
     lint.test(file, {
-      'trailing-zero': 1
+      'no-trailing-zero': 1
     }, function (data) {
       lint.assert.equal(8, data.warningCount);
       done();


### PR DESCRIPTION
The test was using the incorrect rule name.

Closes #685 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com