### PR TITLE
Fix issue where partially matching rules effect each others severity levels

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -42,7 +42,7 @@ module.exports = function (config) {
 
     // Only seek out rules that are enabled
     if (severity !== 0) {
-      var fileName = rule + '.js';
+      var fileName = '/' + rule + '.js';
 
       ruleSearch = searchArray(rules, fileName);
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -42,7 +42,7 @@ module.exports = function (config) {
 
     // Only seek out rules that are enabled
     if (severity !== 0) {
-      var fileName = path.join('/', rule + '.js');
+      var fileName = path.normalize(path.join('/', rule + '.js'));
 
       ruleSearch = searchArray(rules, fileName);
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -42,7 +42,7 @@ module.exports = function (config) {
 
     // Only seek out rules that are enabled
     if (severity !== 0) {
-      var fileName = '/' + rule + '.js';
+      var fileName = path.join('/', rule + '.js');
 
       ruleSearch = searchArray(rules, fileName);
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -42,7 +42,10 @@ module.exports = function (config) {
 
     // Only seek out rules that are enabled
     if (severity !== 0) {
-      ruleSearch = searchArray(rules, rule);
+      var fileName = rule + '.js';
+
+      ruleSearch = searchArray(rules, fileName);
+
       if (ruleSearch >= 0) {
         loadRule = require(rules[ruleSearch]);
 


### PR DESCRIPTION
**NOTE This won't pass the tests until #683 and #685 are fixed.** 

---

Currently rule `foo` will effect `foo-bar` due to the way we're pairing rules with their files.

Note - Solution seems a bit dirty - so open to suggestions.

Closes #687 

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com