### PR TITLE
Increase Mocha timeout to 3000ms from 2000ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "preversion": "npm test",
     "pretest": "eslint .",
-    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec tests tests/rules",
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec -t 3000 tests tests/rules",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "bin": {


### PR DESCRIPTION
With the hope that AppVeyor will stop timing out and failing the tests.

DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com