### PR TITLE
Adding path absolute polyfill

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,8 @@
 var yaml = require('js-yaml'),
     fs = require('fs'),
     path = require('path'),
-    merge = require('merge');
+    merge = require('merge'),
+    pathIsAbsolute = require('path-is-absolute');
 
 var cacheConfig = {},
     cacheEnabled = false;
@@ -79,7 +80,7 @@ module.exports = function (options, configPath) {
       configPath = findFile(false, '.sass-lint.yml');
     }
   }
-  else if (!path.isAbsolute(configPath)) {
+  else if (!pathIsAbsolute(configPath)) {
     configPath = path.resolve(process.cwd(), configPath);
   }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash.capitalize": "^4.1.0",
     "lodash.kebabcase": "^4.0.0",
     "merge": "^1.2.0",
+    "path-is-absolute": "^1.0.0",
     "util": "^0.10.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi
    This PR is for: https://github.com/sasstools/sass-lint/issues/672
I'm not sure if there is any testing you would like to see here. Travis already seems to be testing it on node 0.10, though when testing, the fs-extra package is patching the path module with the isAbsolute function, https://github.com/jprichardson/node-fs-extra/blob/9ed01a7bc016731798ebb2eee9b5933860d46811/lib/ensure/symlink-paths.js#L3, so this was not caught in tests.

DCO 1.1 Signed-off-by: Anand <ianand2@gmail.com>