### PR TITLE
Add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+
+Please include as much information as possible about your issue/request.
+
+Make sure you've read through [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#submitting-issues) first.
+
+If you would like to propose a feature please ignore some of the headings below but include as much information as possible and possible test case code samples.
+-->
+
+
+What version of Sass Lint are you using?
+
+Please include any relevant parts of your configuration
+
+What did you do? Please include the actual source code causing the issue.
+
+What did you expect to happen?
+
+What actually happened? Please include any error messages given to you by Sass Lint.
+
+If you're using a IDE plugin have you tried the CLI too?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 Please include as much information as possible about your issue/request.
 
-Make sure you've read through [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#submitting-issues) first.
+Make sure you've read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#submitting-issues) first.
 
-If you would like to propose a feature please ignore some of the headings below but include as much information as possible and possible test case code samples.
+If you would like to propose a feature please ignore some of the headings below but include as much information as you can and if possible any relevant test case code samples.
 -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+## New Pull Request Information
+
+Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.
+
+Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.
+
+Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.
+
+You must also include your agreement to the developer certificate of origin below.
+
+-->
+
+**What do the changes you have made achieve?**
+
+**Are there any new warning messages?**
+
+**Have you written tests?**
+
+**Have you included relevant documentation**
+
+**Which issues does this resolve?**
+
+`<DCO 1.1 Signed-off-by: YOUR_FULL_NAME YOUR_EMAIL>`


### PR DESCRIPTION
Adds templates for the Pull requests and issues.

Willing to add or remove content from these but thought this was a decent place to start.

The issue template borrows heavily from the ESlint and linter-sass-lint templates.

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`