### PR TITLE
Fix two issues with no-misspelled-properties rule 

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -350,4 +350,21 @@ helpers.collectSuffixExtensions = function (ruleset, selectorType) {
   return parentSelectors.concat(selectorList);
 };
 
+/**
+ * Check for the partial match of a string in an array
+ *
+ * @param {string} needle - The value to match
+ * @param {Array} haystack - The array of values to try and match to
+ * @returns {Boolean} Whether there is a partial match or not
+ */
+helpers.isPartialStringMatch = function (needle, haystack) {
+  for (var i = 0; i < haystack.length; i++) {
+    if (haystack[i].indexOf(needle) >= 0) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 module.exports = helpers;

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -7,6 +7,34 @@ var helpers = require('../helpers'),
 
 var properties = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
 
+/**
+ * Get all valid properties
+ *
+ * @param {Array} props - The list of default valid properties
+ * @param {Array} extras - The user specified list of valid properties
+ * @returns {Array} Combined list
+ */
+var getCombinedList = function (props, extras) {
+  return Object.assign([], props, extras);
+};
+
+/**
+ * Check for partial match
+ *
+ * @param {string} prop - The prop to validate
+ * @param {Array} props - Array of valid properties
+ * @returns {Boolean} Whether prop partially matches list or not
+ */
+var isPartialStringMatch = function (prop, props) {
+  for (var i = 0; i < props.length; i++) {
+    if (props[i].indexOf(prop) >= 0) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 module.exports = {
   'name': 'no-misspelled-properties',
   'defaults': {
@@ -17,13 +45,18 @@ module.exports = {
 
     ast.traverseByType('property', function (node) {
       if (node.first().is('ident')) {
-        var curProperty = node.first().content;
+        var curProperty = node.first().content,
+            propertyList = getCombinedList(properties, parser.options['extra-properties']);
 
         if (curProperty.charAt(0) === '-') {
           curProperty = helpers.stripPrefix(curProperty);
         }
 
-        if (curProperty.length > 0 && properties.indexOf(curProperty) === -1 && parser.options['extra-properties'].indexOf(curProperty) === -1) {
+        if (isPartialStringMatch(curProperty, propertyList)) {
+          return false;
+        }
+
+        if (curProperty.length > 0) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
             'line': node.start.line,
@@ -33,7 +66,10 @@ module.exports = {
           });
         }
       }
+
+      return false;
     });
+
     return result;
   }
 };

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -15,7 +15,7 @@ var properties = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data'
  * @returns {Array} Combined list
  */
 var getCombinedList = function (props, extras) {
-  return Object.assign([], props, extras);
+  return props.concat(extras);
 };
 
 module.exports = {

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -8,7 +8,7 @@ var helpers = require('../helpers'),
 var properties = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
 
 /**
- * Get all valid properties
+ * Combine the valid property array and the array of extras into a new array
  *
  * @param {Array} props - The list of default valid properties
  * @param {Array} extras - The user specified list of valid properties
@@ -16,23 +16,6 @@ var properties = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data'
  */
 var getCombinedList = function (props, extras) {
   return Object.assign([], props, extras);
-};
-
-/**
- * Check for partial match
- *
- * @param {string} prop - The prop to validate
- * @param {Array} props - Array of valid properties
- * @returns {Boolean} Whether prop partially matches list or not
- */
-var isPartialStringMatch = function (prop, props) {
-  for (var i = 0; i < props.length; i++) {
-    if (props[i].indexOf(prop) >= 0) {
-      return true;
-    }
-  }
-
-  return false;
 };
 
 module.exports = {
@@ -52,7 +35,7 @@ module.exports = {
           curProperty = helpers.stripPrefix(curProperty);
         }
 
-        if (isPartialStringMatch(curProperty, propertyList)) {
+        if (helpers.isPartialStringMatch(curProperty, propertyList)) {
           return false;
         }
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1294,4 +1294,55 @@ describe('helpers', function () {
       ['a', 'b', 'ac', 'bc', 'ad', 'bd', 'ace', 'bce', 'ade', 'bde', 'acf', 'bcf', 'adf', 'bdf']
     );
   });
+
+  //////////////////////////////
+  // isPartialStringMatch
+  //////////////////////////////
+  it('isPartialStringMatch - [needle: \'foo\', haystack: [\'foo\'] - true]', function () {
+    var result = helpers.isPartialStringMatch('foo', ['foo']);
+
+    assert.equal(true, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'bar\', haystack: [\'foo\'] - false]', function () {
+    var result = helpers.isPartialStringMatch('bar', ['foo']);
+
+    assert.equal(false, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'foo\', haystack: [\'foo-bar\'] - true]', function () {
+    var result = helpers.isPartialStringMatch('foo', ['foo-bar']);
+
+    assert.equal(true, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'bar\', haystack: [\'foo-bar\'] - true]', function () {
+    var result = helpers.isPartialStringMatch('bar', ['foo-bar']);
+
+    assert.equal(true, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'baz\', haystack: [\'foo\', \'bar\'] - false]', function () {
+    var result = helpers.isPartialStringMatch('baz', ['foo', 'bar']);
+
+    assert.equal(false, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'baz\', haystack: [\'foo\', \'bar\', \'baz\'] - true]', function () {
+    var result = helpers.isPartialStringMatch('baz', ['foo', 'bar', 'baz']);
+
+    assert.equal(true, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'foo-bar\', haystack: [\'foo\', \'bar\'] - false]', function () {
+    var result = helpers.isPartialStringMatch('foo-bar', ['foo', 'bar']);
+
+    assert.equal(false, result);
+  });
+
+  it('isPartialStringMatch - [needle: \'foo-bar\', haystack: [\'baz\', \'qux\', \'foo\', \'bar\'] - false]', function () {
+    var result = helpers.isPartialStringMatch('foo-bar', ['baz', 'qux', 'foo', 'bar']);
+
+    assert.equal(false, result);
+  });
 });

--- a/tests/rules/no-misspelled-properties.js
+++ b/tests/rules/no-misspelled-properties.js
@@ -12,7 +12,7 @@ describe('no misspelled properties - scss', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });
@@ -45,7 +45,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(1, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });
@@ -61,7 +61,7 @@ describe('no misspelled properties - sass', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });
@@ -94,7 +94,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(1, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-misspelled-properties.sass
+++ b/tests/sass/no-misspelled-properties.sass
@@ -20,3 +20,29 @@ $red: #ff0000
 // https://github.com/sasstools/sass-lint/issues/606
 .test-vendor
   -moz-osx-font-smoothing: auto
+
+
+.foo
+  font:
+    family: fantasy
+    size: 12px
+  border:
+    top:
+      right: 1px solid #fff
+      left:
+        color: red
+    left: 2px solid #000
+
+.bar
+  font:
+    famizy: fantasy
+    size: 12px
+  boder:
+    top:
+      rigt: 1px solid #fff
+      left:
+        color: red
+    left: 2px solid #000
+
+.foo
+  margin-#{$property-y}: -2 * $hint-arrow-width

--- a/tests/sass/no-misspelled-properties.scss
+++ b/tests/sass/no-misspelled-properties.scss
@@ -26,3 +26,40 @@ $red: #ff0000;
 .test-vendor {
   -moz-osx-font-smoothing: auto;
 }
+
+
+.foo {
+  font: {
+    family: fantasy;
+    size: 12px;
+  }
+  border: {
+    top: {
+      right: 1px solid #fff;
+      left: {
+        color: red;
+      }
+    }
+    left: 2px solid #000;
+  }
+}
+
+.bar {
+  font: {
+    famizy: fantasy;
+    size: 12px;
+  }
+  boder: {
+    top: {
+      rigt: 1px solid #fff;
+      left: {
+        color: red;
+      }
+    }
+    left: 2px solid #000;
+  }
+}
+
+.foo {
+  margin-#{$property-y}: -2 * $hint-arrow-width;
+}


### PR DESCRIPTION
**What do the changes you have made achieve?**

Fix two issues ( #352, #679 ) related to the `no-misspelled-properties` rule

**Are there any new warning messages?**

No

**Have you written tests?**

Yes

**Have you included relevant documentation**

N/A

**Which issues does this resolve?**

Closes #352 
Closes #679 

`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`
