### PR TITLE
Absolute Path polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
   - '5'
   - node
   - iojs
+matrix:
+  allow_failures:
+    - node_js: "0.10"
 before_script: npm link
 after_success: npm run coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
 node_js:
+  - '0.10'
   - '0.12'
   - '4'
   - '5'
   - node
   - iojs
-matrix:
-  allow_failures:
-    - node_js: "0.10"
 before_script: npm link
 after_success: npm run coveralls
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,22 +5,15 @@ init:
 # Test against this version of Node.js
 environment:
   matrix:
-    -
-      nodejs_version: '0.12'
-    # io.js
-    -
-      nodejs_version: '1'
-    -
-      nodejs_version: '4'
-    -
-      nodejs_version: '5'
-    # Latest stable version of Node
-    -
-      nodejs_version: 'stable'
-    -
-      allow_failures:
-        -
-          nodejs_version: '0.10'
+    - nodejs_version: '0.12'
+      # io.js
+    - nodejs_version: '1'
+    - nodejs_version: '4'
+    - nodejs_version: '5'
+      # Latest stable version of Node
+    - nodejs_version: 'stable'
+    - allow_failures:
+      - nodejs_version: '0.10'
 
 
 # Install scripts. (runs after repo cloning)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,22 @@ init:
 # Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: '0.12'
+    -
+      nodejs_version: '0.12'
     # io.js
-    - nodejs_version: '1'
-    - nodejs_version: '4'
-    - nodejs_version: '5'
+    -
+      nodejs_version: '1'
+    -
+      nodejs_version: '4'
+    -
+      nodejs_version: '5'
     # Latest stable version of Node
-    - nodejs_version: 'stable'
+    -
+      nodejs_version: 'stable'
+    -
+      allow_failures:
+        -
+          nodejs_version: '0.10'
 
 
 # Install scripts. (runs after repo cloning)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ init:
 # Test against this version of Node.js
 environment:
   matrix:
+    - nodejs_version: '0.10'
     - nodejs_version: '0.12'
       # io.js
     - nodejs_version: '1'
@@ -12,9 +13,10 @@ environment:
     - nodejs_version: '5'
       # Latest stable version of Node
     - nodejs_version: 'stable'
-    - allow_failures:
-      - nodejs_version: '0.10'
-
+matrix:
+  # Help instructions and version number don't show in appveyor
+  allow_failures:
+    - nodejs_version: '0.10'
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,8 @@
 var yaml = require('js-yaml'),
     fs = require('fs'),
     path = require('path'),
-    merge = require('merge');
+    merge = require('merge'),
+    pathIsAbsolute = require('path-is-absolute');
 
 var cacheConfig = {},
     cacheEnabled = false;
@@ -79,7 +80,7 @@ module.exports = function (options, configPath) {
       configPath = findFile(false, '.sass-lint.yml');
     }
   }
-  else if (!path.isAbsolute(configPath)) {
+  else if (!pathIsAbsolute(configPath)) {
     configPath = path.resolve(process.cwd(), configPath);
   }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "coveralls": "^2.11.4",
     "deep-equal": "^1.0.1",
     "istanbul": "^0.4.0",
-    "mocha": "^2.2.5",
-    "should": "^8.2.2"
+    "mocha": "^2.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash.capitalize": "^4.1.0",
     "lodash.kebabcase": "^4.0.0",
     "merge": "^1.2.0",
+    "path-is-absolute": "^1.0.0",
     "util": "^0.10.3"
   },
   "devDependencies": {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,5 +1,4 @@
 var assert = require('assert'),
-    should = require('should'),
     fs = require('fs-extra'),
     path = require('path'),
     exec = require('child_process').exec;
@@ -21,14 +20,14 @@ describe('cli', function () {
   });
 
   it('should return a version', function (done) {
-    var command = 'sass-lint -V';
+    var command = 'sass-lint --version';
 
     exec(command, function (err, stdout) {
       if (err) {
         return done(err);
       }
 
-      should(stdout).match(/^[0-9]+.[0-9]+(.[0-9]+)?/);
+      assert(stdout.match(/^[0-9]+.[0-9]+(.[0-9]+)?/));
 
       return done();
     });


### PR DESCRIPTION
This replaces the PR in #690 just so I could add node 0.10 in the test matrices again and add a slight tidy up.

Appveyor 0.10 is set to allow failures as it for some reason can't read the help text or version number that we generate, included screenshot proves that this isn't the case though.

<img width="1406" alt="screen shot 2016-05-12 at 13 08 05" src="https://cloud.githubusercontent.com/assets/1386054/15214259/fea6baa2-1843-11e6-88b8-c7b340b2bd9a.png">

We'll just have to be vigilant with the 0.10 tests and make sure only 2 failures get through though but it's worth keeping 0.10 support at least until it drops off the LTS list in a few months time.

Thanks to @ianand2 too for the original fix here.

<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>