### PR TITLE
Attribute quotes rule

### DIFF
--- a/docs/rules/attribute-quotes.md
+++ b/docs/rules/attribute-quotes.md
@@ -1,0 +1,61 @@
+# Attribute Quotes
+
+Rule `attribute-quotes` will enforce the use of the use of quotes in attribute values.
+
+## Options
+
+* `include`: `true`/`false` (defaults to `true`)
+
+## Examples
+
+### `include`
+
+When `include: true`, the following are allowed. When `include: false`, the following are disallowed:
+
+```scss
+
+span[lang="pt"] {
+  color: green;
+}
+
+span[lang~="en-us"] {
+  color: blue;
+}
+
+span[class^="main"] {
+  background-color: yellow;
+}
+
+a[href*="example"] {
+  background-color: #CCCCCC;
+}
+
+input[type="email" i] {
+  border-color: blue;
+}
+```
+
+When `include: false`, the following are allowed. When `include: true`, the following are disallowed:
+
+```scss
+
+span[lang=pt] {
+  color: green;
+}
+
+span[lang~=en-us] {
+  color: blue;
+}
+
+span[class^=main] {
+  background-color: yellow;
+}
+
+a[href*=example] {
+  background-color: #CCCCCC;
+}
+
+input[type=email i] {
+  border-color: blue;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -52,6 +52,7 @@ rules:
   variable-name-format: 1
 
   # Style Guide
+  attribute-quotes: 1
   bem-depth: 0
   border-zero: 1
   brace-style: 1

--- a/lib/rules/attribute-quotes.js
+++ b/lib/rules/attribute-quotes.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'attribute-quotes',
+  'defaults': {
+    'include': true
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('attributeValue', function (item) {
+      if (item.content[0].is('string') && !parser.options.include) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': item.start.line,
+          'column': item.start.column,
+          'message': 'Attribute values should not be surrounded by quotes',
+          'severity': parser.severity
+        });
+      }
+      else if (item.content[0].is('ident') && parser.options.include) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'line': item.start.line,
+          'column': item.start.column,
+          'message': 'Attribute values should be surrounded by quotes',
+          'severity': parser.severity
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/attribute-quotes.js
+++ b/tests/rules/attribute-quotes.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('attribute-quotes - scss', function () {
+  var file = lint.file('attribute-quotes.scss');
+
+  it('[default] include [include: true]', function (done) {
+    lint.test(file, {
+      'attribute-quotes': 1
+    }, function (data) {
+      lint.assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  it('exclude [include: false]', function (done) {
+    lint.test(file, {
+      'attribute-quotes': [
+        1,
+        {
+          'include': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('attribute-quotes - sass', function () {
+  var file = lint.file('attribute-quotes.scss');
+
+  it('[default] include [include: true]', function (done) {
+    lint.test(file, {
+      'attribute-quotes': 1
+    }, function (data) {
+      lint.assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  it('exclude [include: false]', function (done) {
+    lint.test(file, {
+      'attribute-quotes': [
+        1,
+        {
+          'include': false
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(7, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/attribute-quotes.sass
+++ b/tests/sass/attribute-quotes.sass
@@ -1,0 +1,62 @@
+span[lang]
+  font-weight: bold
+
+////////////////////////////
+// No Quotes - Default warnings
+////////////////////////////
+
+span[lang=pt]
+  color: green
+
+span[lang~=en-us]
+  color: blue
+
+// TODO currently a parse error in gonzales-pe
+// span[lang|="zh"] {color: red;}
+
+// TODO currently a parse error in gonzales-pe
+// a[href^=#] {
+//   background-color: gold;
+// }
+
+span[class^=main]
+  background-color: yellow
+
+// TODO currently a parse error in gonzales-pe
+// a[href$=.cn] {
+//   color: red;
+// }
+
+a[href*=example]
+  background-color: #CCCCCC
+
+input[type=email i]
+  border-color: blue
+
+////////////////////////////
+// Quotes - exclude option warnings
+////////////////////////////
+
+span[lang="pt"]
+  color: green
+
+span[lang~="en-us"]
+  color: blue
+
+// TODO currently a parse error in gonzales-pe
+// span[lang|="zh"] {color: red;}
+
+a[href^="#"]
+  background-color: gold
+
+span[class^="main"]
+  background-color: yellow
+
+a[href$=".cn"]
+  color: red
+
+a[href*="example"]
+  background-color: #CCCCCC
+
+input[type="email" i]
+  border-color: blue

--- a/tests/sass/attribute-quotes.scss
+++ b/tests/sass/attribute-quotes.scss
@@ -1,0 +1,75 @@
+span[lang] {
+  font-weight: bold;
+}
+
+////////////////////////////
+// No Quotes - Default warnings
+////////////////////////////
+
+span[lang=pt] {
+  color: green;
+}
+
+span[lang~=en-us] {
+  color: blue;
+}
+
+// TODO currently a parse error in gonzales-pe
+// span[lang|="zh"] {color: red;}
+
+// TODO currently a parse error in gonzales-pe
+// a[href^=#] {
+//   background-color: gold;
+// }
+
+span[class^=main] {
+  background-color: yellow;
+}
+
+// TODO currently a parse error in gonzales-pe
+// a[href$=.cn] {
+//   color: red;
+// }
+
+a[href*=example] {
+  background-color: #CCCCCC;
+}
+
+input[type=email i] {
+  border-color: blue;
+}
+
+////////////////////////////
+// Quotes - exclude option warnings
+////////////////////////////
+
+span[lang="pt"] {
+  color: green;
+}
+
+span[lang~="en-us"] {
+  color: blue;
+}
+
+// TODO currently a parse error in gonzales-pe
+// span[lang|="zh"] {color: red;}
+
+a[href^="#"] {
+  background-color: gold;
+}
+
+span[class^="main"] {
+  background-color: yellow;
+}
+
+a[href$=".cn"] {
+  color: red;
+}
+
+a[href*="example"] {
+  background-color: #CCCCCC;
+}
+
+input[type="email" i] {
+  border-color: blue;
+}


### PR DESCRIPTION
Adds a new rule - `attribute-quotes`

Enforces the use of quotes in attribute values, defaults to include true but can be set to false. Warning messages `Attribute values should be surrounded by quotes` and `Attribute values should not be surrounded by quotes`

Closes #707 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

p.s. it almost seems too simple to be true.. someone break it please :)