### PR TITLE
Fix gulp ignores

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var slConfig = require('./lib/config'),
     slRules = require('./lib/rules'),
     glob = require('glob'),
     path = require('path'),
-    fs = require('fs-extra');
+    fs = require('fs-extra'),
+    globule = require('globule');
 
 var sassLint = function (config) {
   config = require('./lib/config')(config);
@@ -140,6 +141,31 @@ sassLint.lintText = function (file, options, configPath) {
     'warningCount': warnings,
     'errorCount': errors,
     'messages': results
+  };
+};
+
+/**
+ * Handles ignored files for plugins such as the gulp plugin. Checks every file passed to it against
+ * the ignores as specified in our users config or passed in options.
+ *
+ * @param {object} file - The file/text to be linted
+ * @param {object} options - The user defined options directly passed in
+ * @param {object} configPath - Path to a config file
+ * @returns {object} Return the results of lintText - a results object
+ */
+sassLint.lintFileText = function (file, options, configPath) {
+  var config = this.getConfig(options, configPath);
+  var ignores = config.files ? config.files.ignore : [];
+
+  if (!globule.isMatch(ignores, file.filename)) {
+    return this.lintText(file, options, configPath);
+  }
+
+  return {
+    'filePath': file.filename,
+    'warningCount': 0,
+    'errorCount': 0,
+    'messages': []
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -154,8 +154,8 @@ sassLint.lintText = function (file, options, configPath) {
  * @returns {object} Return the results of lintText - a results object
  */
 sassLint.lintFileText = function (file, options, configPath) {
-  var config = this.getConfig(options, configPath);
-  var ignores = config.files ? config.files.ignore : [];
+  var config = this.getConfig(options, configPath),
+      ignores = config.files ? config.files.ignore : [];
 
   if (!globule.isMatch(ignores, file.filename)) {
     return this.lintText(file, options, configPath);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^2.7.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.0",
+    "globule": "^1.0.0",
     "gonzales-pe-sl": "3.2.8",
     "js-yaml": "^3.5.4",
     "lodash.capitalize": "^4.1.0",

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var assert = require('assert'),
-    lint = require('../index');
+    equal = require('deep-equal'),
+    lint = require('../index'),
+    fs = require('fs');
 
 var lintFile = function lintFile (file, options, cb) {
   cb = cb || options;
@@ -53,95 +55,165 @@ var resultsObj = [{
     severity: 2
   }]
 }];
+var emptyResult = {
+  filePath: 'tests/cli/cli.scss',
+  warningCount: 0,
+  errorCount: 0,
+  messages: []
+};
+var oneWarningResult = {
+  filePath: 'tests/cli/cli.scss',
+  warningCount: 1,
+  errorCount: 0,
+  messages: [
+    {
+      ruleId: 'no-color-literals',
+      line: 2,
+      column: 10,
+      message: 'Color literals such as \'red\' should only be used in variable declarations',
+      severity: 1
+    }
+  ]
+};
 
-describe('sass lint', function () {
-  //////////////////////////////
-  // Not Error on Empty Files
-  //////////////////////////////
-  it('should not error if a file is empty', function (done) {
-    lintFile('empty-file.scss', function (data) {
-      assert.equal(0, data.warningCount);
-      assert.equal(0, data.errorCount);
-      assert.equal(0, data.messages.length);
+
+describe('sassLint', function () {
+  describe('default functionality', function () {
+    //////////////////////////////
+    // Not Error on Empty Files
+    //////////////////////////////
+    it('should not error if a file is empty', function (done) {
+      lintFile('empty-file.scss', function (data) {
+        assert.equal(0, data.warningCount);
+        assert.equal(0, data.errorCount);
+        assert.equal(0, data.messages.length);
+        done();
+      });
+    });
+
+    //////////////////////////////
+    // Parse Errors should return as lint errors
+    //////////////////////////////
+    it('Parse Errors should return as lint errors', function (done) {
+      lintFile('parse.scss', function (data) {
+        assert.equal(1, data.errorCount);
+        done();
+      });
+    });
+
+    it('Parse Errors should not include warnings too', function (done) {
+      lintFile('parse.scss', function (data) {
+        assert.equal(0, data.warningCount);
+        done();
+      });
+    });
+
+    it('Parse Errors should return as severity 2', function (done) {
+      lintFile('parse.scss', function (data) {
+        var severity = data.messages[0].severity;
+
+        assert.equal(2, severity);
+        done();
+      });
+    });
+
+    it('Parse Errors should return the correct error message', function (done) {
+      lintFile('parse.scss', function (data) {
+        var message = data.messages[0].message,
+            expected = 'Please check validity of the block starting from line #5';
+
+        assert.equal(expected, message);
+        done();
+      });
+    });
+
+    it('Parse Errors should return the rule ID \'Fatal\'', function (done) {
+      lintFile('parse.scss', function (data) {
+        var ruleId = data.messages[0].ruleId,
+            expected = 'Fatal';
+
+        assert.equal(expected, ruleId);
+        done();
+      });
+    });
+  });
+
+
+  describe('detect counts', function () {
+    //////////////////////////////
+    // Error count
+    //////////////////////////////
+    it('should equal 2 errors', function (done) {
+      var result = lint.errorCount(resultsObj);
+
+      assert.equal(2, result.count);
+      done();
+    });
+
+    //////////////////////////////
+    // Warning count
+    //////////////////////////////
+    it('should equal 3 warnings', function (done) {
+      var result = lint.warningCount(resultsObj);
+
+      assert.equal(3, result.count);
+      done();
+    });
+
+    //////////////////////////////
+    // Result count
+    //////////////////////////////
+    it('should equal 5 overall detects', function (done) {
+      var result = lint.resultCount(resultsObj);
+
+      assert.equal(5, result);
       done();
     });
   });
 
   //////////////////////////////
-  // Parse Errors should return as lint errors
+  // lintFileText
   //////////////////////////////
-  it('Parse Errors should return as lint errors', function (done) {
-    lintFile('parse.scss', function (data) {
-      assert.equal(1, data.errorCount);
+
+  describe('lintFileText', function () {
+    var file;
+    var fileObj;
+
+    beforeEach(function () {
+      file = fs.readFileSync('tests/cli/cli.scss');
+      fileObj = {
+        'text': file,
+        'format': 'scss',
+        'filename': 'tests/cli/cli.scss'
+      };
+    });
+
+    it('should ignore a file from the ignore section of a config file', function (done) {
+      var result = lint.lintFileText(fileObj, {}, 'tests/yml/.ignore-file.yml');
+      assert(
+        equal(
+          result,
+          emptyResult,
+          {
+            'strict': true
+          }
+        )
+      );
       done();
     });
-  });
 
-  it('Parse Errors should not include warnings too', function (done) {
-    lintFile('parse.scss', function (data) {
-      assert.equal(0, data.warningCount);
+    it('should lint a file from when no ignores are specified', function (done) {
+      var result = lint.lintFileText(fileObj, {}, 'tests/yml/.no-merge-default.yml');
+      assert(
+        equal(
+          result,
+          oneWarningResult,
+          {
+            'strict': true
+          }
+        )
+      );
       done();
     });
-  });
-
-  it('Parse Errors should return as severity 2', function (done) {
-    lintFile('parse.scss', function (data) {
-      var severity = data.messages[0].severity;
-
-      assert.equal(2, severity);
-      done();
-    });
-  });
-
-  it('Parse Errors should return the correct error message', function (done) {
-    lintFile('parse.scss', function (data) {
-      var message = data.messages[0].message,
-          expected = 'Please check validity of the block starting from line #5';
-
-      assert.equal(expected, message);
-      done();
-    });
-  });
-
-  it('Parse Errors should return the rule ID \'Fatal\'', function (done) {
-    lintFile('parse.scss', function (data) {
-      var ruleId = data.messages[0].ruleId,
-          expected = 'Fatal';
-
-      assert.equal(expected, ruleId);
-      done();
-    });
-  });
-});
-
-describe('sassLint detect counts', function () {
-  //////////////////////////////
-  // Error count
-  //////////////////////////////
-  it('should equal 2 errors', function (done) {
-    var result = lint.errorCount(resultsObj);
-
-    assert.equal(2, result.count);
-    done();
-  });
-
-  //////////////////////////////
-  // Warning count
-  //////////////////////////////
-  it('should equal 3 warnings', function (done) {
-    var result = lint.warningCount(resultsObj);
-
-    assert.equal(3, result.count);
-    done();
-  });
-
-  //////////////////////////////
-  // Result count
-  //////////////////////////////
-  it('should equal 5 overall detects', function (done) {
-    var result = lint.resultCount(resultsObj);
-
-    assert.equal(5, result);
-    done();
   });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -176,8 +176,8 @@ describe('sassLint', function () {
   //////////////////////////////
 
   describe('lintFileText', function () {
-    var file;
-    var fileObj;
+    var file,
+        fileObj;
 
     beforeEach(function () {
       file = fs.readFileSync('tests/cli/cli.scss');

--- a/tests/main.js
+++ b/tests/main.js
@@ -189,7 +189,7 @@ describe('sassLint', function () {
     });
 
     it('should ignore a file from the ignore section of a config file', function (done) {
-      var result = lint.lintFileText(fileObj, {}, 'tests/yml/.ignore-file.yml');
+      var result = lint.lintFileText(fileObj, {options: {'cache-config': false}}, 'tests/yml/.ignore-file.yml');
       assert(
         equal(
           result,
@@ -203,7 +203,7 @@ describe('sassLint', function () {
     });
 
     it('should lint a file from when no ignores are specified', function (done) {
-      var result = lint.lintFileText(fileObj, {}, 'tests/yml/.no-merge-default.yml');
+      var result = lint.lintFileText(fileObj, {options: {'cache-config': false}}, 'tests/yml/.no-merge-default.yml');
       assert(
         equal(
           result,

--- a/tests/yml/.ignore-file.yml
+++ b/tests/yml/.ignore-file.yml
@@ -1,0 +1,9 @@
+options:
+  formatter: stylish
+  cache-config: false
+  merge-default-rules: false
+files:
+  include: '**/*.s+(a|c)ss'
+  ignore: '**/cli.scss'
+rules:
+  no-color-literals: 1


### PR DESCRIPTION
Part 1 regarding the fixing of ignores from the gulp-sass-lint plugin the second part will follow in the gulp-sass-lint repo

closes #451
fixes #452 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
