### PR TITLE
url-quotes rule now points to start of string instead of end

### DIFF
--- a/lib/rules/url-quotes.js
+++ b/lib/rules/url-quotes.js
@@ -17,8 +17,8 @@ module.exports = {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,
               'severity': parser.severity,
-              'line': item.end.line,
-              'column': item.end.column,
+              'line': item.start.line,
+              'column': item.start.column,
               'message': 'Quotes around URLs are required'
             });
           }


### PR DESCRIPTION
`url-quotes` rule will now point to the start of the string and no longer the end

Fixes issue #712
`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`

