### PR TITLE
Add changes to run isEnabledFilter after checking if the ast has content and is 

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@ sassLint.lintText = function (file, options, configPath) {
       results = [],
       errors = 0,
       warnings = 0,
-      ruleToggles = getToggledRules(ast),
-      isEnabledFilter = isResultEnabled(ruleToggles);
+      ruleToggles = null,
+      isEnabledFilter = null;
 
   try {
     ast = groot(file.text, file.format, file.filename);
@@ -125,9 +125,9 @@ sassLint.lintText = function (file, options, configPath) {
   }
 
   if (ast.content && ast.content.length > 0) {
-
     ruleToggles = getToggledRules(ast);
     isEnabledFilter = isResultEnabled(ruleToggles);
+
     rules.forEach(function (rule) {
       detects = rule.rule.detect(ast, rule)
         .filter(isEnabledFilter);

--- a/index.js
+++ b/index.js
@@ -125,6 +125,9 @@ sassLint.lintText = function (file, options, configPath) {
   }
 
   if (ast.content && ast.content.length > 0) {
+
+    ruleToggles = getToggledRules(ast);
+    isEnabledFilter = isResultEnabled(ruleToggles);
     rules.forEach(function (rule) {
       detects = rule.rule.detect(ast, rule)
         .filter(isEnabledFilter);


### PR DESCRIPTION
This PR tries to resolve the issue with disable linter programatically as mentioned under feature request # 70.

As a part of the PR:

Added code block after conditional check to see if the ast has been created properly.
There are no associated warning or new test cases.



. Resolves #70

DCO 1.1 Signed-off-by: Saptarshi Dutta <saptarshidutta31@yahoo.co.in>