### PR TITLE
Update indentation to support tabs and fix bugs [SCSS | Sass]

### DIFF
--- a/docs/rules/indentation.md
+++ b/docs/rules/indentation.md
@@ -2,7 +2,7 @@
 
 Rule `indentation` will enforce an indentation size (tabs and spaces) and it will also ensure that tabs and spaces are not mixed.
 
-The mixed warnings and tabs warnings check will take into account what you have set in your config file whether it should expect to see spaces or tabs. If it encounters a tab anywhere in a file when your rule config doesn't specify tabs it will flag a lint warning, Similarly for any whitespace using spaces when tabs are specified. Obviously spaces between properties and values etc are ignored.
+The mixed spaces and tabs warnings check will take into account what you have set in your config file whether it should expect to see spaces or tabs. If it encounters a tab anywhere in a file when your rule config doesn't specify tabs it will flag a lint warning, Similarly for any whitespace using spaces when tabs are specified. Obviously spaces between properties and values etc are ignored.
 
 ## Options
 

--- a/docs/rules/indentation.md
+++ b/docs/rules/indentation.md
@@ -2,7 +2,7 @@
 
 Rule `indentation` will enforce an indentation size (tabs and spaces) and it will also ensure that tabs and spaces are not mixed.
 
-The mixed warnings and tabs warnings check will always choose the first tab or space that it comes across as the de facto standard for the file it's linting regardless of the options you have in your config. If a tab and a space both appear in the first indented property/block in your file the space will be preferred over the tab. This is purely to make sure you get accurate mixed spaces and tabs warnings throughout the file and any indented elements can be linted correctly.
+The mixed warnings and tabs warnings check will take into account what you have set in your config file whether it should expect to see spaces or tabs. If it encounters a tab anywhere in a file when your rule config doesn't specify tabs it will flag a lint warning, Similarly for any whitespace using spaces when tabs are specified. Obviously spaces between properties and values etc are ignored.
 
 ## Options
 

--- a/docs/rules/indentation.md
+++ b/docs/rules/indentation.md
@@ -1,10 +1,12 @@
 # Indentation
 
-Rule `indentation` will enforce an indentation size (in spaces) and ensure that tabs and spaces are not mixed.
+Rule `indentation` will enforce an indentation size (tabs and spaces) and it will also ensure that tabs and spaces are not mixed.
+
+The mixed warnings and tabs warnings check will always choose the first tab or space that it comes across as the de facto standard for the file it's linting regardless of the options you have in your config. If a tab and a space both appear in the first indented property/block in your file the space will be preferred over the tab. This is purely to make sure you get accurate mixed spaces and tabs warnings throughout the file and any indented elements can be linted correctly.
 
 ## Options
 
-* `size`: `number` (defaults to `2`)
+* `size`: `number` or `'tab'` (defaults to `2` spaces)
 
 ## Examples
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -188,6 +188,27 @@ helpers.isValidHex = function (str) {
   return false;
 };
 
+/**
+ * Check if a node is a newline character or not
+ *
+ * @param {Object} node - The node to test
+ * @returns {boolean} Whether the node is a newline or not
+ */
+helpers.isNewLine = function (node) {
+  // using type === instead of is just in case node happens to be a string
+  return !!(node && node.type === 'space' && node.content.match('\n'));
+};
+
+/**
+ * Check if a node is a non newline space character or not
+ *
+ * @param {Object} node - The node to test
+ * @returns {boolean} Whether the node is a non newline space or not
+ */
+helpers.isSpace = function (node) {
+  return !!(node && node.type === 'space' && !node.content.match('\n'));
+};
+
 helpers.loadConfigFile = function (configPath) {
   var fileDir = path.dirname(configPath),
       fileName = path.basename(configPath),

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -2,6 +2,27 @@
 
 var helpers = require('../helpers');
 
+/**
+ * Check if a node is a newline character or not
+ *
+ * @param {Object} node - The node to test
+ * @returns {boolean} Whether the node is a newline or not
+ */
+var isNewLine = function (node) {
+  // using type === instead of is just in case node happens to be a string
+  return node && node.type === 'space' && node.content.match('\n');
+};
+
+/**
+ * Check if a node is a non newline space character or not
+ *
+ * @param {Object} node - The node to test
+ * @returns {boolean} Whether the node is a non newline space or not
+ */
+var isSpace = function (node) {
+  return node && node.type === 'space' && !node.content.match('\n');
+};
+
 module.exports = {
   'name': 'indentation',
   'defaults': {
@@ -83,7 +104,7 @@ module.exports = {
           }
         }
         else if (n.syntax === 'sass') {
-          if (n.is('declarationDelimiter') || (n.is('space') && n.content.match('\n'))) {
+          if (n.is('declarationDelimiter') || (isNewLine(n))) {
             // Due to the way gonzales handles line endings in Sass we don't care if it's CRLF or just LF
             if (nextNode && nextNode.is('space') && nextNode.content.indexOf('\n') === -1) {
               spaceLength = nextNode.content.length;
@@ -101,7 +122,7 @@ module.exports = {
             }
           }
           // Check all the spaces in Sass that aren't newlines
-          else if (n.type === 'space' && !n.content.match('\n')) {
+          else if (isSpace(n)) {
             // This is a special condition for the first property in a block with Sass as it usually
             // doesn't have a previous node before the space appears so we need to check this is
             // valid and then we can rely on the declarationDelimiter check above.
@@ -174,7 +195,7 @@ module.exports = {
         // if a delimeter is encountered we check if it's directly after a parenthesis node
         // if it is we know next node will be the same level of indentation
         if (n.is('operator')) {
-          if (n.content === ',' && prevNode.is('parentheses')) {
+          if (n.content === ',' && prevNode.is('parentheses') && isNewLine(nextNode)) {
             if (inAtRule && !inProps) {
               level++;
               inProps = true;

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -10,26 +10,33 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [],
         inAtRule = false,
-        inProps = true,
+        inProps = false,
+        inBlock = false,
         lintSize = parser.options.size,
-        lintType = 'space';
+        lintType = 'space',
+        plural = '',
+        detected = [lintType];
 
+    // Prepare to check for mixed spaces or tabs depending on what the user has specified
     if (parser.options.size === 'tab') {
       lintSize = 1;
       lintType = 'tab';
+      detected[0] = lintType;
     }
 
     var processNode = function (node, level) {
       var i,
           n,
           prevNode,
+          nextNode,
+          sassNextNode,
+          reportNode,
+          reportCondition,
           space,
           spaceLength,
           newlineLength,
-          detected = [],
           spaceCount,
           tabCount,
-          plural = '',
           mixedWarning;
 
       level = level || 0;
@@ -41,84 +48,127 @@ module.exports = {
       for (i = 0; i < node.length; i++) {
         n = node.get(i);
         prevNode = node.get(i - 1);
+        nextNode = node.get(i + 1) || false;
+        // Due to the Sass structure in gonzales we sometimes need to check 2 ahead
+        sassNextNode = node.get(i + 2) || false;
+        reportNode = null;
 
         if (!n) {
           continue;
         }
 
-        if (n.type === 'space') {
-          // Test for CRLF first, since it includes LF
-          space = n.content.lastIndexOf('\r\n');
-          newlineLength = 2;
+        if (n.syntax === 'scss') {
+          if (n.type === 'space') {
 
-          if (space === -1) {
-            // Test for LF
-            space = n.content.lastIndexOf('\n');
-            newlineLength = 1;
+            // Test for CRLF first, since it includes LF
+            space = n.content.lastIndexOf('\r\n');
+            newlineLength = 2;
+
+            if (space === -1) {
+              // Test for LF
+              space = n.content.lastIndexOf('\n');
+              newlineLength = 1;
+            }
+
+            if (space >= 0) {
+              // Check how many spaces or tabs we have and set our plural character if necessary for
+              // our lint reporting message
+              spaceLength = n.content.slice(space + newlineLength).length;
+              spaceCount = n.content.slice(space + newlineLength).match(/ /g);
+              tabCount = n.content.slice(space + newlineLength).match(/\t/g);
+              plural = level > 1 ? 's' : '';
+              reportNode = nextNode;
+              reportCondition = i !== node.length - 1;
+            }
           }
+        }
+        else if (n.syntax === 'sass') {
+          if (n.is('declarationDelimiter') || (n.is('space') && n.content.match('\n'))) {
+            // Due to the way gonzales handles line endings in Sass we don't care if it's CRLF or just LF
+            if (nextNode && nextNode.is('space') && nextNode.content.indexOf('\n') === -1) {
+              spaceLength = nextNode.content.length;
+              spaceCount = nextNode.content.match(/ /g);
+              tabCount = nextNode.content.match(/\t/g);
+              plural = level > 1 ? 's' : '';
 
-          if (space >= 0) {
-            // Check how many spaces or tabs we have and set our plural character if necessary for
-            // our lint reporting message
-            spaceLength = n.content.slice(space + newlineLength).length;
-            spaceCount = n.content.slice(space + newlineLength).match(/ /g);
-            tabCount = n.content.slice(space + newlineLength).match(/\t/g);
-            plural = spaceLength > 1 ? 's' : '';
-
-            // if we've encountered a space check if we have before if not save a reference
-            if (spaceCount !== null && detected.indexOf('space') === -1) {
-              detected.push('space');
-            }
-
-            // if we've encountered a tab check if we have before if not save a reference
-            if (tabCount !== null && detected.indexOf('tab') === -1) {
-              detected.push('tab');
-            }
-
-            // Check if expected indentation matches what it should be
-            if (spaceLength / lintSize !== level) {
-              var next = node.content[i + 1] || false;
-
-              // ignore lines that just contain whitespace
-              if (next) {
-                if (detected.length > 1) {
-                  // Indicates we've told the user about mixed tabs and spaces in their file
-                  mixedWarning = true;
-                  // remove the last detected type from our detected array,
-                  // if we encounter a mix again we'll output again but all the while keep a reference
-                  // to the first space character (tab or space) that we encountered so as to be
-                  // consistent with our warnings
-                  detected.pop();
-
-                  result = helpers.addUnique(result, {
-                    'ruleId': parser.rule.name,
-                    'line': next.start.line,
-                    'column': next.start.column,
-                    'message': 'Mixed tabs and spaces',
-                    'severity': parser.severity
-                  });
-                }
-                // Generate a lint message if our indentation is incorrect but also prevent these
-                // messages appearing on lines with mixed tabs and spaces as we shouldn't be guessing
-                // as to a users tab size when using spaces etc
-                if (i !== node.length - 1 && !mixedWarning) {
-                  result = helpers.addUnique(result, {
-                    'ruleId': parser.rule.name,
-                    'line': next.start.line,
-                    'column': next.start.column,
-                    'message': 'Expected indentation of ' + level * lintSize + ' ' + lintType + plural + ' but found ' + spaceLength + '.',
-                    'severity': parser.severity
-                  });
-                }
-                // Reset our mixedWarning flag so we can show these again if encountered
-                mixedWarning = false;
+              // if we're at the end of a block we want to drop the level here for Sass
+              if (!node.get(i + 2)) {
+                level--;
               }
+
+              reportNode = sassNextNode;
+              reportCondition = true;
             }
           }
+          // Check all the spaces in Sass that aren't newlines
+          else if (n.type === 'space' && !n.content.match('\n')) {
+            // This is a special condition for the first property in a block with Sass as it usually
+            // doesn't have a previous node before the space appears so we need to check this is
+            // valid and then we can rely on the declarationDelimiter check above.
+            if (inBlock && (!prevNode || prevNode.is('space'))) {
+              inBlock = false;
+              spaceLength = n.content.length;
+              spaceCount = n.content.match(/ /g);
+              tabCount = n.content.match(/\t/g);
+              plural = level > 1 ? 's' : '';
+              reportNode = nextNode;
+              reportCondition = true;
+            }
+            // A extra check for tabs when using spaces as single tab characters aren't highlighted
+            // as mixed spaces and tabs without this. Spaces on the other hand are fine. Gonzales
+            // reports them a little differently.
+            else if (n.type === 'space' && lintType === 'space') {
+              tabCount = n.content.match(/\t/g);
+              reportNode = nextNode;
+              // we dont want to check the lint levels here as it could be a tab between a prop and
+              // value, totally unrealistic I know but we still want to report it.
+              reportCondition = false;
+            }
+          }
+        }
+        if (reportNode) {
+          // if we've encountered a space check if we have before if not save a reference
+          if (spaceCount !== null && detected.indexOf('space') === -1) {
+            detected.push('space');
+          }
+
+          // if we've encountered a tab check if we have before if not save a reference
+          if (tabCount !== null && detected.indexOf('tab') === -1) {
+            detected.push('tab');
+          }
+
+          if (detected.length > 1) {
+            // Indicates we've told the user about mixed tabs and spaces in their file
+            mixedWarning = true;
+            // Remove the last detected type from our detected array,
+            // if we encounter a mix again we'll output again but all the while keep a reference
+            // to the first space character (tab or space) that we encountered so as to be
+            // consistent with our warnings
+            detected.pop();
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': reportNode.start.line,
+              'column': reportNode.start.column,
+              'message': 'Mixed tabs and spaces',
+              'severity': parser.severity
+            });
+          }
+          if (reportCondition && !mixedWarning && spaceLength / lintSize !== level) {
+            // Check if expected indentation matches what it should be
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': reportNode.start.line,
+              'column': reportNode.start.column,
+              'message': 'Expected indentation of ' + level * lintSize + ' ' + lintType + plural + ' but found ' + spaceLength + '.',
+              'severity': parser.severity
+            });
+          }
+          mixedWarning = false;
         }
         // if we're in an atrule make we need to possibly handle multiline arguments
         if (n.is('atrule')) {
           inAtRule = true;
+          inBlock = false;
         }
 
         // if a delimeter is encountered we check if it's directly after a parenthesis node
@@ -143,17 +193,19 @@ module.exports = {
           || n.is('arguments')
           || (n.is('parentheses') && !node.is('atrule'))
         ) {
-          inAtRule = false;
-          inProps = false;
           level++;
         }
 
+        if (n.is('block')) {
+          inAtRule = false;
+          inProps = false;
+          inBlock = true;
+        }
         processNode(n, level);
       }
     };
 
     processNode(ast);
-
     return result;
   }
 };

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -8,7 +8,16 @@ module.exports = {
     'size': 2
   },
   'detect': function (ast, parser) {
-    var result = [];
+    var result = [],
+        inAtRule = false,
+        inProps = true,
+        lintSize = parser.options.size,
+        lintType = 'space';
+
+    if (parser.options.size === 'tab') {
+      lintSize = 1;
+      lintType = 'tab';
+    }
 
     var processNode = function (node, level) {
       var i,
@@ -16,8 +25,12 @@ module.exports = {
           prevNode,
           space,
           spaceLength,
-          count,
-          newlineLength;
+          newlineLength,
+          detected = [],
+          spaceCount,
+          tabCount,
+          plural = '',
+          mixedWarning;
 
       level = level || 0;
 
@@ -39,25 +52,44 @@ module.exports = {
           newlineLength = 2;
 
           if (space === -1) {
+            // Test for LF
             space = n.content.lastIndexOf('\n');
             newlineLength = 1;
           }
 
           if (space >= 0) {
+            // Check how many spaces or tabs we have and set our plural character if necessary for
+            // our lint reporting message
             spaceLength = n.content.slice(space + newlineLength).length;
+            spaceCount = n.content.slice(space + newlineLength).match(/ /g);
+            tabCount = n.content.slice(space + newlineLength).match(/\t/g);
+            plural = spaceLength > 1 ? 's' : '';
 
-            try {
-              count = n.content.slice(space + newlineLength).match(/ /g).length;
-            }
-            catch (e) {
-              count = 0;
+            // if we've encountered a space check if we have before if not save a reference
+            if (spaceCount !== null && detected.indexOf('space') === -1) {
+              detected.push('space');
             }
 
-            if (spaceLength / parser.options.size !== level) {
+            // if we've encountered a tab check if we have before if not save a reference
+            if (tabCount !== null && detected.indexOf('tab') === -1) {
+              detected.push('tab');
+            }
+
+            // Check if expected indentation matches what it should be
+            if (spaceLength / lintSize !== level) {
               var next = node.content[i + 1] || false;
 
+              // ignore lines that just contain whitespace
               if (next) {
-                if (count !== spaceLength) {
+                if (detected.length > 1) {
+                  // Indicates we've told the user about mixed tabs and spaces in their file
+                  mixedWarning = true;
+                  // remove the last detected type from our detected array,
+                  // if we encounter a mix again we'll output again but all the while keep a reference
+                  // to the first space character (tab or space) that we encountered so as to be
+                  // consistent with our warnings
+                  detected.pop();
+
                   result = helpers.addUnique(result, {
                     'ruleId': parser.rule.name,
                     'line': next.start.line,
@@ -66,25 +98,40 @@ module.exports = {
                     'severity': parser.severity
                   });
                 }
-                if (i !== node.length - 1) {
+                // Generate a lint message if our indentation is incorrect but also prevent these
+                // messages appearing on lines with mixed tabs and spaces as we shouldn't be guessing
+                // as to a users tab size when using spaces etc
+                if (i !== node.length - 1 && !mixedWarning) {
                   result = helpers.addUnique(result, {
                     'ruleId': parser.rule.name,
                     'line': next.start.line,
                     'column': next.start.column,
-                    'message': 'Indentation of ' + spaceLength + ', expected ' + level * parser.options.size,
+                    'message': 'Expected indentation of ' + level * lintSize + ' ' + lintType + plural + ' but found ' + spaceLength + '.',
                     'severity': parser.severity
                   });
                 }
+                // Reset our mixedWarning flag so we can show these again if encountered
+                mixedWarning = false;
               }
             }
           }
+        }
+        // if we're in an atrule make we need to possibly handle multiline arguments
+        if (n.is('atrule')) {
+          inAtRule = true;
         }
 
         // if a delimeter is encountered we check if it's directly after a parenthesis node
         // if it is we know next node will be the same level of indentation
         if (n.is('operator')) {
           if (n.content === ',' && prevNode.is('parentheses')) {
-            level--;
+            if (inAtRule && !inProps) {
+              level++;
+              inProps = true;
+            }
+            else if (!inProps) {
+              level--;
+            }
           }
         }
 
@@ -96,6 +143,8 @@ module.exports = {
           || n.is('arguments')
           || (n.is('parentheses') && !node.is('atrule'))
         ) {
+          inAtRule = false;
+          inProps = false;
           level++;
         }
 

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -2,27 +2,6 @@
 
 var helpers = require('../helpers');
 
-/**
- * Check if a node is a newline character or not
- *
- * @param {Object} node - The node to test
- * @returns {boolean} Whether the node is a newline or not
- */
-var isNewLine = function (node) {
-  // using type === instead of is just in case node happens to be a string
-  return node && node.type === 'space' && node.content.match('\n');
-};
-
-/**
- * Check if a node is a non newline space character or not
- *
- * @param {Object} node - The node to test
- * @returns {boolean} Whether the node is a non newline space or not
- */
-var isSpace = function (node) {
-  return node && node.type === 'space' && !node.content.match('\n');
-};
-
 module.exports = {
   'name': 'indentation',
   'defaults': {
@@ -104,7 +83,7 @@ module.exports = {
           }
         }
         else if (n.syntax === 'sass') {
-          if (n.is('declarationDelimiter') || (isNewLine(n))) {
+          if (n.is('declarationDelimiter') || (helpers.isNewLine(n))) {
             // Due to the way gonzales handles line endings in Sass we don't care if it's CRLF or just LF
             if (nextNode && nextNode.is('space') && nextNode.content.indexOf('\n') === -1) {
               spaceLength = nextNode.content.length;
@@ -122,7 +101,7 @@ module.exports = {
             }
           }
           // Check all the spaces in Sass that aren't newlines
-          else if (isSpace(n)) {
+          else if (helpers.isSpace(n)) {
             // This is a special condition for the first property in a block with Sass as it usually
             // doesn't have a previous node before the space appears so we need to check this is
             // valid and then we can rely on the declarationDelimiter check above.
@@ -195,7 +174,7 @@ module.exports = {
         // if a delimeter is encountered we check if it's directly after a parenthesis node
         // if it is we know next node will be the same level of indentation
         if (n.is('operator')) {
-          if (n.content === ',' && prevNode.is('parentheses') && isNewLine(nextNode)) {
+          if (n.content === ',' && prevNode.is('parentheses') && helpers.isNewLine(nextNode)) {
             if (inAtRule && !inProps) {
               level++;
               inProps = true;

--- a/tests/helpers/isNewLine.js
+++ b/tests/helpers/isNewLine.js
@@ -1,0 +1,119 @@
+'use strict';
+
+var assert = require('assert'),
+    helpers = require('../../lib/helpers'),
+    gonzales = require('gonzales-pe-sl');
+
+var lfBlock = gonzales.createNode(
+  {
+    type: 'space',
+    content: '\n',
+    syntax: 'scss',
+    start: { line: 1, column: 1 },
+    end: { line: 2, column: 1 }
+  }),
+    crlfBlock = gonzales.createNode(
+      {
+        type: 'space',
+        content: '\r\n',
+        syntax: 'scss',
+        start: { line: 1, column: 1 },
+        end: { line: 2, column: 1 }
+      }),
+    multiLfBlock = gonzales.createNode(
+      {
+        type: 'space',
+        content: '\n\n',
+        syntax: 'scss',
+        start: { line: 1, column: 1 },
+        end: { line: 3, column: 1 }
+      }),
+    multiCrLfBlock = gonzales.createNode(
+      {
+        type: 'space',
+        content: '\r\n\r\n',
+        syntax: 'scss',
+        start: { line: 1, column: 1 },
+        end: { line: 3, column: 1 }
+      }),
+    mixedBlock = gonzales.createNode(
+      {
+        type: 'space',
+        content: '    \n',
+        syntax: 'scss',
+        start: { line: 1, column: 1 },
+        end: { line: 3, column: 1 }
+      }),
+    spaceBlock = gonzales.createNode(
+      {
+        type: 'space',
+        content: '    ',
+        syntax: 'scss',
+        start: { line: 1, column: 1 },
+        end: { line: 3, column: 1 }
+      }),
+    classBlock = gonzales.createNode(
+      {
+        type: 'class',
+        content:
+        [
+          {
+            type: 'ident',
+            content: 'foo',
+            syntax: 'scss',
+            start: { line: 5, column: 2 },
+            end: { line: 5, column: 4 },
+            indexHasChanged: [ 0 ]
+          }
+        ],
+        syntax: 'scss',
+        start: { line: 5, column: 1 },
+        end: { line: 5, column: 4 },
+        indexHasChanged: [ 0 ]
+      }
+    );
+
+describe('helpers - isNewLine', function () {
+  //////////////////////////////
+  // isNewLine
+  //////////////////////////////
+  it('should return true for a LF style space node', function (done) {
+    assert.equal(true, helpers.isNewLine(lfBlock));
+    done();
+  });
+
+  it('should return true for a multi LF style space node', function (done) {
+    assert.equal(true, helpers.isNewLine(multiLfBlock));
+    done();
+  });
+
+  it('should return true for a CRLF style space node', function (done) {
+    assert.equal(true, helpers.isNewLine(crlfBlock));
+    done();
+  });
+
+  it('should return true for a multi CRLF style space node', function (done) {
+    assert.equal(true, helpers.isNewLine(multiCrLfBlock));
+    done();
+  });
+
+  it('should return true for a mixed space node that contains a new line character', function (done) {
+    assert.equal(true, helpers.isNewLine(mixedBlock));
+    done();
+  });
+
+  it('should return false for a normal space node that doesn\'t contain a new line character', function (done) {
+    assert.equal(false, helpers.isNewLine(spaceBlock));
+    done();
+  });
+
+  it('should return false for a non space node', function (done) {
+    assert.equal(false, helpers.isNewLine(classBlock));
+    done();
+  });
+
+  it('should return false when no node is provided', function (done) {
+    assert.equal(false, helpers.isNewLine());
+    done();
+  });
+});

--- a/tests/helpers/isSpace.js
+++ b/tests/helpers/isSpace.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var assert = require('assert'),
+    helpers = require('../../lib/helpers'),
+    gonzales = require('gonzales-pe-sl');
+
+var lfBlock = gonzales.createNode({
+      type: 'space',
+      content: '\n',
+      syntax: 'scss',
+      start: { line: 1, column: 1 },
+      end: { line: 2, column: 1 }
+    }),
+    crlfBlock = gonzales.createNode({
+      type: 'space',
+      content: '\r\n',
+      syntax: 'scss',
+      start: { line: 1, column: 1 },
+      end: { line: 2, column: 1 }
+    }),
+    mixedBlock = gonzales.createNode({
+      type: 'space',
+      content: '    \n',
+      syntax: 'scss',
+      start: { line: 1, column: 1 },
+      end: { line: 3, column: 1 }
+    }),
+    spaceBlock = gonzales.createNode({
+      type: 'space',
+      content: '    ',
+      syntax: 'scss',
+      start: { line: 1, column: 1 },
+      end: { line: 3, column: 1 }
+    }),
+    classBlock = gonzales.createNode({
+      type: 'class',
+      content:
+      [
+        {
+          type: 'ident',
+          content: 'foo',
+          syntax: 'scss',
+          start: { line: 5, column: 2 },
+          end: { line: 5, column: 4 },
+          indexHasChanged: [ 0 ]
+        }
+      ],
+      syntax: 'scss',
+      start: { line: 5, column: 1 },
+      end: { line: 5, column: 4 },
+      indexHasChanged: [ 0 ]
+    });
+
+describe('helpers - isSpace', function () {
+  //////////////////////////////
+  // isSpace
+  //////////////////////////////
+  it('should return false for a LF style space node', function (done) {
+    assert.equal(false, helpers.isSpace(lfBlock));
+    done();
+  });
+
+  it('should return false for a CRLF style space node', function (done) {
+    assert.equal(false, helpers.isSpace(crlfBlock));
+    done();
+  });
+
+  it('should return false for a mixed space node that contains a new line character', function (done) {
+    assert.equal(false, helpers.isSpace(mixedBlock));
+    done();
+  });
+
+  it('should return true for a normal space node that doesn\'t contain a new line character', function (done) {
+    assert.equal(true, helpers.isSpace(spaceBlock));
+    done();
+  });
+
+  it('should return false for a non space node', function (done) {
+    assert.equal(false, helpers.isSpace(classBlock));
+    done();
+  });
+
+  it('should return false when no node is provided', function (done) {
+    assert.equal(false, helpers.isSpace());
+    done();
+  });
+});

--- a/tests/rules/indentation.js
+++ b/tests/rules/indentation.js
@@ -37,16 +37,31 @@ describe('indentation - scss', function () {
 //////////////////////////////
 // Sass syntax tests
 //////////////////////////////
-// describe('indentation - sass', function () {
-//   var file = lint.file('indentation.sass');
-//
-//   // Indentation
-//   it('[size: 2]', function (done) {
-//     lint.test(file, {
-//       'indentation': 1
-//     }, function (data) {
-//       lint.assert.equal(8, data.warningCount);
-//       done();
-//     });
-//   });
-// });
+describe('indentation - sass', function () {
+  var spaceFile = lint.file('indentation/indentation-spaces.sass');
+  var tabFile = lint.file('indentation/indentation-tabs.sass');
+
+  // Indentation
+  it('[size: 2]', function (done) {
+    lint.test(spaceFile, {
+      'indentation': 1
+    }, function (data) {
+      lint.assert.equal(11, data.warningCount);
+      done();
+    });
+  });
+
+  it('[size: tab]', function (done) {
+    lint.test(tabFile, {
+      'indentation': [
+        1,
+        {
+          size: 'tab'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(11, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/rules/indentation.js
+++ b/tests/rules/indentation.js
@@ -6,13 +6,28 @@ var lint = require('./_lint');
 // SCSS syntax tests
 //////////////////////////////
 describe('indentation - scss', function () {
-  var file = lint.file('indentation.scss');
+  var spaceFile = lint.file('indentation/indentation-spaces.scss');
+  var tabFile = lint.file('indentation/indentation-tabs.scss');
 
   it('[size: 2]', function (done) {
-    lint.test(file, {
+    lint.test(spaceFile, {
       'indentation': 1
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
+      done();
+    });
+  });
+
+  it('[size: tab]', function (done) {
+    lint.test(tabFile, {
+      'indentation': [
+        1,
+        {
+          size: 'tab'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });

--- a/tests/rules/indentation.js
+++ b/tests/rules/indentation.js
@@ -13,7 +13,7 @@ describe('indentation - scss', function () {
     lint.test(spaceFile, {
       'indentation': 1
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -27,7 +27,7 @@ describe('indentation - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -46,7 +46,7 @@ describe('indentation - sass', function () {
     lint.test(spaceFile, {
       'indentation': 1
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });
@@ -60,7 +60,7 @@ describe('indentation - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(11, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });

--- a/tests/sass/indentation/indentation-spaces.sass
+++ b/tests/sass/indentation/indentation-spaces.sass
@@ -4,23 +4,25 @@ $foo: ('foo': 'bar', 'bar': ('foo': 'bze'))
   &__child
     p::first-line
       content: ''
+        content: 'ta'
 
 .foo,
 .bar
   content: 'bar'
 
     content: 'baz'
-content: 'bar'
+        content: 'bar'
 
-  @include breakpoint(500)
+  +breakpoint(500)
     content: 'baz'
-  content: 'qux'
+      // comment inside block
+      content: 'qux'
 
-  @include mixin-extra
+  +mixin-extra
     content: 'baz'
     content: 'qux'
 
-  @include mixin-empty-args()
+  +mixin-empty-args()
     content: 'baz'
     content: 'qux'
 
@@ -28,10 +30,10 @@ content: 'bar'
       content: 'bar'
 
 
-  @if (1 == 1)
-    content: 'foo'
+    @if (1 == 1)
+        content: 'foo'
 
-@mixin bar
+=bar
     content: 'bar'
 	content: 'baz'
 
@@ -52,7 +54,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
   background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%)
 
 // Top-level mixin
-@include hello(
++hello(
   $foo,
   $bar,
   $baz
@@ -60,7 +62,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 
 .foo
   // Nested Mixin
-  @include hello(
+  +hello(
     $foo,
     $bar,
     $baz
@@ -77,7 +79,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
   // User-defined function
   content: goodbye(
     $foo,
-    $bar
+      $bar
   )
 
 @function cp($target, $container)
@@ -89,10 +91,6 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
   @if ($background-size != 'mixed')
     background-size: $background-size
 
-  // @media (min--moz-device-pixel-ratio: 1.3),
-  //   (-o-min-device-pixel-ratio: 2.6/2),
-  //   (-webkit-min-device-pixel-ratio: 1.3),
-  //     (min-device-pixel-ratio: 1.3),
-  //   (min-resolution: 1.3dppx) {
-  //     background-image: url('../images/#{$filename}@2x.#{$extension}')
-  //       color: red
+  @media (min--moz-device-pixel-ratio: 1.3)
+    background-image: url('../images/#{$filename}@2x.#{$extension}')
+  	  color: red

--- a/tests/sass/indentation/indentation-spaces.sass
+++ b/tests/sass/indentation/indentation-spaces.sass
@@ -94,3 +94,14 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
   @media (min--moz-device-pixel-ratio: 1.3)
     background-image: url('../images/#{$filename}@2x.#{$extension}')
   	  color: red
+
+.test
+  @media (max-width: 800px), (max-height: 600px)
+      #unit
+        margin: 16px
+
+// Gonzales issue with media queries
+// .test
+//   @media (max-width: 800px), (max-height: 600px)
+//         #unit
+//           margin: 16px

--- a/tests/sass/indentation/indentation-spaces.sass
+++ b/tests/sass/indentation/indentation-spaces.sass
@@ -1,0 +1,98 @@
+$foo: ('foo': 'bar', 'bar': ('foo': 'bze'))
+
+.parent
+  &__child
+    p::first-line
+      content: ''
+
+.foo,
+.bar
+  content: 'bar'
+
+    content: 'baz'
+content: 'bar'
+
+  @include breakpoint(500)
+    content: 'baz'
+  content: 'qux'
+
+  @include mixin-extra
+    content: 'baz'
+    content: 'qux'
+
+  @include mixin-empty-args()
+    content: 'baz'
+    content: 'qux'
+
+    .qux
+      content: 'bar'
+
+
+  @if (1 == 1)
+    content: 'foo'
+
+@mixin bar
+    content: 'bar'
+	content: 'baz'
+
+.color
+  color: rgba(255, 255, 255, 0.3)
+
+$colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #987), not: (test: #fff)))
+
+.multilineprops
+  background: transparent linear-gradient(
+    to bottom,
+      #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  )
+
+.multilineprops-extra
+  background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%)
+
+// Top-level mixin
+@include hello(
+  $foo,
+  $bar,
+  $baz
+)
+
+.foo
+  // Nested Mixin
+  @include hello(
+    $foo,
+    $bar,
+    $baz
+  )
+
+  // CSS built-in function
+  background: transparent linear-gradient(
+    to bottom,
+    #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  )
+
+  // User-defined function
+  content: goodbye(
+    $foo,
+    $bar
+  )
+
+@function cp($target, $container)
+  @return calc-percent($target, $container)
+
+// Issue #426 - Unexpected indenting enforcement on multiline rules
+=hidpi-background-image($filename, $background-size: 'mixed', $extension: png)
+  background-image: url('../images/#{$filename}.#{$extension}')
+  @if ($background-size != 'mixed')
+    background-size: $background-size
+
+  // @media (min--moz-device-pixel-ratio: 1.3),
+  //   (-o-min-device-pixel-ratio: 2.6/2),
+  //   (-webkit-min-device-pixel-ratio: 1.3),
+  //     (min-device-pixel-ratio: 1.3),
+  //   (min-resolution: 1.3dppx) {
+  //     background-image: url('../images/#{$filename}@2x.#{$extension}')
+  //       color: red

--- a/tests/sass/indentation/indentation-spaces.scss
+++ b/tests/sass/indentation/indentation-spaces.scss
@@ -131,3 +131,15 @@ $colors: (
         color: red;
     }
 }
+
+@media (max-width: 800px), (max-height: 600px) {
+  #unit {
+    margin: 16px;
+  }
+}
+
+@media (max-width: 800px), (max-height: 600px) {
+    #unit {
+      margin: 16px;
+    }
+}

--- a/tests/sass/indentation/indentation-spaces.scss
+++ b/tests/sass/indentation/indentation-spaces.scss
@@ -115,3 +115,19 @@ $colors: (
 @function cp($target, $container) {
   @return calc-percent($target, $container);
 }
+
+// Issue #426 - Unexpected indenting enforcement on multiline rules
+@mixin hidpi-background-image($filename, $background-size: 'mixed', $extension: png) {
+  background-image: url('../images/#{$filename}.#{$extension}');
+  @if ($background-size != 'mixed') {
+    background-size: $background-size;
+  }
+  @media (min--moz-device-pixel-ratio: 1.3),
+    (-o-min-device-pixel-ratio: 2.6/2),
+    (-webkit-min-device-pixel-ratio: 1.3),
+      (min-device-pixel-ratio: 1.3),
+    (min-resolution: 1.3dppx) {
+      background-image: url('../images/#{$filename}@2x.#{$extension}');
+        color: red;
+    }
+}

--- a/tests/sass/indentation/indentation-tabs.sass
+++ b/tests/sass/indentation/indentation-tabs.sass
@@ -94,3 +94,14 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 	@media (min--moz-device-pixel-ratio: 1.3)
 		background-image: url('../images/#{$filename}@2x.#{$extension}')
 	  	color: red
+
+.test
+	@media (max-width: 800px), (max-height: 600px)
+			#unit
+				margin: 16px
+
+// Gonzales issue with media queries
+// .test
+// 	@media (max-width: 800px), (max-height: 600px)
+// 			#unit
+// 				margin: 16px

--- a/tests/sass/indentation/indentation-tabs.sass
+++ b/tests/sass/indentation/indentation-tabs.sass
@@ -4,23 +4,25 @@ $foo: ('foo': 'bar', 'bar': ('foo': 'bze'))
 	&__child
 		p::first-line
 			content: ''
+				content: 'ta'
 
 .foo,
 .bar
 	content: 'bar'
 
 		content: 'baz'
-content: 'bar'
+				content: 'bar'
 
-	@include breakpoint(500)
+	+breakpoint(500)
 		content: 'baz'
-	content: 'qux'
+			// comment inside block
+			content: 'qux'
 
-	@include mixin-extra
+	+mixin-extra
 		content: 'baz'
 		content: 'qux'
 
-	@include mixin-empty-args()
+	+mixin-empty-args()
 		content: 'baz'
 		content: 'qux'
 
@@ -28,10 +30,10 @@ content: 'bar'
 			content: 'bar'
 
 
-	@if (1 == 1)
-		content: 'foo'
+		@if (1 == 1)
+				content: 'foo'
 
-@mixin bar
+=bar
 		content: 'bar'
   content: 'baz'
 
@@ -52,7 +54,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 	background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%)
 
 // Top-level mixin
-@include hello(
++hello(
 	$foo,
 	$bar,
 	$baz
@@ -60,7 +62,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 
 .foo
 	// Nested Mixin
-	@include hello(
+	+hello(
 		$foo,
 		$bar,
 		$baz
@@ -77,7 +79,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 	// User-defined function
 	content: goodbye(
 		$foo,
-		$bar
+			$bar
 	)
 
 @function cp($target, $container)
@@ -89,10 +91,6 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 	@if ($background-size != 'mixed')
 		background-size: $background-size
 
-	// @media (min--moz-device-pixel-ratio: 1.3),
-	//	 (-o-min-device-pixel-ratio: 2.6/2),
-	//	 (-webkit-min-device-pixel-ratio: 1.3),
-	//		 (min-device-pixel-ratio: 1.3),
-	//	 (min-resolution: 1.3dppx) {
-	//		 background-image: url('../images/#{$filename}@2x.#{$extension}')
-	//			 color: red
+	@media (min--moz-device-pixel-ratio: 1.3)
+		background-image: url('../images/#{$filename}@2x.#{$extension}')
+	  	color: red

--- a/tests/sass/indentation/indentation-tabs.sass
+++ b/tests/sass/indentation/indentation-tabs.sass
@@ -1,0 +1,98 @@
+$foo: ('foo': 'bar', 'bar': ('foo': 'bze'))
+
+.parent
+	&__child
+		p::first-line
+			content: ''
+
+.foo,
+.bar
+	content: 'bar'
+
+		content: 'baz'
+content: 'bar'
+
+	@include breakpoint(500)
+		content: 'baz'
+	content: 'qux'
+
+	@include mixin-extra
+		content: 'baz'
+		content: 'qux'
+
+	@include mixin-empty-args()
+		content: 'baz'
+		content: 'qux'
+
+		.qux
+			content: 'bar'
+
+
+	@if (1 == 1)
+		content: 'foo'
+
+@mixin bar
+		content: 'bar'
+  content: 'baz'
+
+.color
+	color: rgba(255, 255, 255, 0.3)
+
+$colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #987), not: (test: #fff)))
+
+.multilineprops
+	background: transparent linear-gradient(
+		to bottom,
+			#ff0000 0%,
+		#00ff00 40%,
+		#0000ff 40%
+	)
+
+.multilineprops-extra
+	background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%)
+
+// Top-level mixin
+@include hello(
+	$foo,
+	$bar,
+	$baz
+)
+
+.foo
+	// Nested Mixin
+	@include hello(
+		$foo,
+		$bar,
+		$baz
+	)
+
+	// CSS built-in function
+	background: transparent linear-gradient(
+		to bottom,
+		#ff0000 0%,
+		#00ff00 40%,
+		#0000ff 40%
+	)
+
+	// User-defined function
+	content: goodbye(
+		$foo,
+		$bar
+	)
+
+@function cp($target, $container)
+	@return calc-percent($target, $container)
+
+// Issue #426 - Unexpected indenting enforcement on multiline rules
+=hidpi-background-image($filename, $background-size: 'mixed', $extension: png)
+	background-image: url('../images/#{$filename}.#{$extension}')
+	@if ($background-size != 'mixed')
+		background-size: $background-size
+
+	// @media (min--moz-device-pixel-ratio: 1.3),
+	//	 (-o-min-device-pixel-ratio: 2.6/2),
+	//	 (-webkit-min-device-pixel-ratio: 1.3),
+	//		 (min-device-pixel-ratio: 1.3),
+	//	 (min-resolution: 1.3dppx) {
+	//		 background-image: url('../images/#{$filename}@2x.#{$extension}')
+	//			 color: red

--- a/tests/sass/indentation/indentation-tabs.scss
+++ b/tests/sass/indentation/indentation-tabs.scss
@@ -125,9 +125,9 @@ $colors: (
 	@media (min--moz-device-pixel-ratio: 1.3),
 		(-o-min-device-pixel-ratio: 2.6/2),
 		(-webkit-min-device-pixel-ratio: 1.3),
-		  (min-device-pixel-ratio: 1.3),
+			(min-device-pixel-ratio: 1.3),
 		(min-resolution: 1.3dppx) {
 			background-image: url('../images/#{$filename}@2x.#{$extension}');
-        color: red;
+				color: red;
 		}
 }

--- a/tests/sass/indentation/indentation-tabs.scss
+++ b/tests/sass/indentation/indentation-tabs.scss
@@ -1,0 +1,133 @@
+$foo: (
+	'foo': 'bar',
+	'bar': (
+		'foo': 'bze'
+	)
+);
+
+.parent {
+	&__child {
+		p::first-line {
+			content: '';
+		}
+	}
+}
+
+.foo,
+.bar {
+	content: 'bar';
+
+		content: 'baz';
+content: 'bar';
+
+	@include breakpoint(500) {
+		content: 'baz';
+	content: 'qux';
+	}
+
+	@include mixin-extra {
+		content: 'baz';
+		content: 'qux';
+	}
+
+	@include mixin-empty-args() {
+		content: 'baz';
+		content: 'qux';
+	}
+
+		.qux {
+			content: 'bar';
+		}
+
+	@if (1 == 1) {
+		content: 'foo';
+	}
+}
+
+@mixin bar {
+		content: 'bar';
+  content: 'baz';
+}
+
+.color {
+	color: rgba(255, 255, 255, 0.3);
+}
+
+$colors: (
+	base: (
+		red: #fff,
+		blue: #fff
+	),
+	text: (
+		default: #fff,
+		light: (
+			brap: #987
+		),
+		not: (
+			test: #fff
+		)
+	)
+);
+
+.multilineprops {
+	background: transparent linear-gradient(
+		to bottom,
+			#ff0000 0%,
+		#00ff00 40%,
+		#0000ff 40%
+	);
+}
+
+.multilineprops-extra {
+	background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%);
+}
+
+// Top-level mixin
+@include hello(
+	$foo,
+	$bar,
+	$baz
+);
+
+.foo {
+	// Nested Mixin
+	@include hello(
+		$foo,
+		$bar,
+		$baz
+	);
+
+	// CSS built-in function
+	background: transparent linear-gradient(
+		to bottom,
+		#ff0000 0%,
+		#00ff00 40%,
+		#0000ff 40%
+	);
+
+	// User-defined function
+	content: goodbye(
+		$foo,
+		$bar
+	);
+}
+
+@function cp($target, $container) {
+	@return calc-percent($target, $container);
+}
+
+// Issue #426 - Unexpected indenting enforcement on multiline rules
+@mixin hidpi-background-image($filename, $background-size: 'mixed', $extension: png) {
+	background-image: url('../images/#{$filename}.#{$extension}');
+	@if ($background-size != 'mixed') {
+		background-size: $background-size;
+	}
+	@media (min--moz-device-pixel-ratio: 1.3),
+		(-o-min-device-pixel-ratio: 2.6/2),
+		(-webkit-min-device-pixel-ratio: 1.3),
+		  (min-device-pixel-ratio: 1.3),
+		(min-resolution: 1.3dppx) {
+			background-image: url('../images/#{$filename}@2x.#{$extension}');
+        color: red;
+		}
+}

--- a/tests/sass/indentation/indentation-tabs.scss
+++ b/tests/sass/indentation/indentation-tabs.scss
@@ -131,3 +131,15 @@ $colors: (
 				color: red;
 		}
 }
+
+@media (max-width: 800px), (max-height: 600px) {
+	#unit {
+		margin: 16px;
+	}
+}
+
+@media (max-width: 800px), (max-height: 600px) {
+		#unit {
+			margin: 16px;
+		}
+}


### PR DESCRIPTION
The indentation rule now supports tabs, you can specify this in your config by including the string `'tab'` instead of just a integer as you would for spaces.

```yaml
indentation:
  - 1
  -
    size: 'tab'
```

It also fixes the issue with multiline arguments to atrules. 

~~`Sass` syntax is still broken, but more consistently broken now and Ive got work in progress to sort it.~~

Lines that previously reported `mixed tabs and space` warnings also used to attempt to provide a incorrect indentation value such as ` 1 expected 2` I've removed this as it seems silly to try and lint something that is clearly an error and the mixed warning will suffice to show there's an issue with that line. 

The first space character encountered in the file will be taken as the de facto for the file and generate mixed warnings thereafter if a different character is encountered regardless of whether you've chosen tabs or spaces. If a tab and space are encountered on the first line of your file in a mixed fashion it will favour the space. I'm open to updating this functionality though. 

Split the test files into tabs and spaces versions for now. Both include mixed warnings so please be careful if editing these.

Fixes #426 
Fixes #382 
Closes #592 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
