### PR TITLE
Add no color hex rule

### DIFF
--- a/docs/rules/no-color-hex.md
+++ b/docs/rules/no-color-hex.md
@@ -1,0 +1,33 @@
+# No Color Hex
+
+Rule `no-color-hex` will disallow the use of hexadecimal colors
+
+## Examples
+
+When enabled the following are disallowed.
+
+```scss
+$foo-color: #456;
+
+.bar {
+  background: linear-gradient(top, #3ff, #ddd);
+}
+
+.baz {
+  color: #fff;
+}
+```
+
+When enabled the following are allowed:
+
+```scss
+$foo-color: red;
+
+.bar {
+  background: linear-gradient(top, blue, green);
+}
+
+.baz {
+  color: white;
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -18,6 +18,7 @@ rules:
 
   # Disallows
   no-attribute-selectors: 0
+  no-color-hex: 0
   no-color-keywords: 1
   no-color-literals: 1
   no-combinators: 0

--- a/lib/rules/no-color-hex.js
+++ b/lib/rules/no-color-hex.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-color-hex',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('color', function (value) {
+      result = helpers.addUnique(result, {
+        'ruleId': parser.rule.name,
+        'line': value.start.line,
+        'column': value.start.column,
+        'message': 'Hexadecimal colors should not be used',
+        'severity': parser.severity
+      });
+    });
+    return result;
+  }
+};

--- a/tests/rules/no-color-hex.js
+++ b/tests/rules/no-color-hex.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('no color hex - scss', function () {
+  var file = lint.file('no-color-hex.scss');
+
+  it('enforce', function (done) {
+    lint.test(file, {
+      'no-color-hex': 1
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('no color hex - sass', function () {
+  var file = lint.file('no-color-hex.sass');
+
+  it('enforce', function (done) {
+    lint.test(file, {
+      'no-color-hex': 1
+    }, function (data) {
+      lint.assert.equal(9, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/no-color-hex.sass
+++ b/tests/sass/no-color-hex.sass
@@ -1,0 +1,25 @@
+$foo-color: #123
+
+.foo
+  background: linear-gradient(top, #cc2, #44d)
+  color: #fff
+
+
+$bar-color: #112233
+
+.bar
+  background: linear-gradient(top, #cccc22, #4444dd)
+  color: #ffffff
+
+.baz
+  border-color: #123456
+
+
+// color literals, rgb and hsl values currently don't get returned
+// by the AST's color type
+
+$qux-color: red
+$rgb-color: rgb(255, 255, 255)
+$rgba-color: rgba(0, 0, 0, .1)
+$hsl-color: hsl(40, 50%, 50%)
+$hsla-color: hsla(40, 50%, 50%, .3)

--- a/tests/sass/no-color-hex.scss
+++ b/tests/sass/no-color-hex.scss
@@ -1,0 +1,26 @@
+$foo-color: #123;
+
+.foo {
+  background: linear-gradient(top, #cc2, #44d);
+  color: #fff;
+}
+
+$bar-color: #112233;
+
+.bar {
+  background: linear-gradient(top, #cccc22, #4444dd);
+  color: #ffffff;
+}
+
+.baz {
+  border-color: #123456;
+}
+
+// color literals, rgb and hsl values currently don't get returned
+// by the AST's color type
+
+$qux-color: red;
+$rgb-color: rgb(255, 255, 255);
+$rgba-color: rgba(0, 0, 0, .1);
+$hsl-color: hsl(40, 50%, 50%);
+$hsla-color: hsla(40, 50%, 50%, .3);


### PR DESCRIPTION
Adds the `no-color-hex` rule to disallow the use of hexadecimal colors

closes #753 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
