### PR TITLE
Fix bug where `findFile` wouldn't recurse

### DIFF
--- a/lib/config-helpers.js
+++ b/lib/config-helpers.js
@@ -28,10 +28,10 @@ var findFile = function findFile (configPath, filename) {
   configPath = configPath || path.join(process.cwd(), filename);
 
   if (configPath && fs.existsSync(configPath)) {
-    dirname = path.dirname(configPath);
-    parentDirname = path.dirname(dirname);
     return fs.realpathSync(configPath);
   }
+  dirname = path.dirname(configPath);
+  parentDirname = path.dirname(dirname);
 
   if (dirname === null || dirname === HOME || dirname === parentDirname) {
     return null;


### PR DESCRIPTION
**What do the changes you have made achieve?**
Enables you to have a package.json or sass-lint.yml higher up in the directory hierarchy, by modifying config-helpers#findFile. Before it would not properly recurse to the parent directory, but simply give up if the file was not in in the cwd.

**Are there any new warning messages?**
No

**Have you written tests?**
No

**Have you included relevant documentation**
No

**Which issues does this resolve?**
https://github.com/sasstools/sass-lint/issues/756

`<DCO 1.1 Signed-off-by: johannes wikner johannes.wikner@gmail.com>`

