### PR TITLE
Added a rule to detect nbsp in selectors.

### DIFF
--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -30,6 +30,7 @@ rules:
   no-ids: 1
   no-important: 1
   no-invalid-hex: 1
+  no-invalid-whitespace: 1
   no-mergeable-selectors: 1
   no-misspelled-properties: 1
   no-qualifying-elements: 1

--- a/lib/rules/no-invalid-whitespace.js
+++ b/lib/rules/no-invalid-whitespace.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'no-invalid-whitespace',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+    var invalidWS = new RegExp(String.fromCharCode(160), 'g');
+
+    ast.traverse(function (node) {
+      if (node.type === 'selector' || node.type === 'class') {
+        var content = node.content;
+        if (invalidWS.test(content)) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'severity': parser.severity,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': 'Found invalid whitespace'
+          });
+        }
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/no-invalid-whitespace.js
+++ b/tests/rules/no-invalid-whitespace.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('no invalid whitespace - scss', function () {
+  var file = lint.file('no-invalid-whitespace.scss');
+
+  it('enforce', function (done) {
+    lint.test(file, {
+      'no-invalid-whitespace': 1
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('no invalid whitespace - sass', function () {
+  var file = lint.file('no-invalid-whitespace.sass');
+
+  it('enforce', function (done) {
+    lint.test(file, {
+      'no-invalid-whitespace': 1
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/no-invalid-whitespace.sass
+++ b/tests/sass/no-invalid-whitespace.sass
@@ -1,0 +1,9 @@
+.foo 
+  content: 'foo'
+
+.foo .bar
+  content: 'foo'
+
+.foo,
+.foo .bar
+  content: 'foo'

--- a/tests/sass/no-invalid-whitespace.scss
+++ b/tests/sass/no-invalid-whitespace.scss
@@ -1,0 +1,13 @@
+.a {
+  content: 'foo';
+}
+
+.b .c {
+  content: 'foo';
+}
+
+
+.d,
+.e .f {
+  content: 'foo';
+}


### PR DESCRIPTION
<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

**What do the changes you have made achieve?**

Adding a linter rule that detects nbsp in selectors.

**Are there any new warning messages?**
no-invalid-whitespace -> 'Found invalid whitespace'

**Have you written tests?**
yes

**Have you included relevant documentation**
no

**Which issues does this resolve?**
#775

`<DCO 1.1 Signed-off-by: Oliver Buchtala oliver.buchtala@gmail.com>`

Note:
Please take a look at the implementation. ATM I traverse all nodes, looking at `selectors` and `classes`. This I did without a complete study of the AST you are using, but instead as to fulfill the tests I added.
So I'd be happy to hear your opinion, if there might be more cases, that should be considered.