### PR TITLE
Fix issue with indentation and import at-rule and maps

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -166,14 +166,9 @@ module.exports = {
           mixedWarning = false;
         }
         // if we're in an atrule make we need to possibly handle multiline arguments
-        if (n.is('atrule')) {
+        if (n.is('atrule') && n.contains('block')) {
           inAtRule = true;
           inBlock = false;
-        }
-
-        // We should move out of the at-rule if it's an import as we dont want to look for multi level arguments etc
-        if (inAtRule && n.is('ident') && n.content === 'import') {
-          inAtRule = false;
         }
 
         // if a delimeter is encountered we check if it's directly after a parenthesis node
@@ -209,7 +204,7 @@ module.exports = {
         processNode(n, level);
       }
     };
-    helpers.log(ast);
+
     processNode(ast);
     return result;
   }

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -171,6 +171,11 @@ module.exports = {
           inBlock = false;
         }
 
+        // We should move out of the at-rule if it's an import as we dont want to look for multi level arguments etc
+        if (inAtRule && n.is('ident') && n.content === 'import') {
+          inAtRule = false;
+        }
+
         // if a delimeter is encountered we check if it's directly after a parenthesis node
         // if it is we know next node will be the same level of indentation
         if (n.is('operator')) {
@@ -204,7 +209,7 @@ module.exports = {
         processNode(n, level);
       }
     };
-
+    helpers.log(ast);
     processNode(ast);
     return result;
   }

--- a/tests/rules/indentation.js
+++ b/tests/rules/indentation.js
@@ -13,7 +13,7 @@ describe('indentation - scss', function () {
     lint.test(spaceFile, {
       'indentation': 1
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -27,7 +27,7 @@ describe('indentation - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });

--- a/tests/sass/indentation/indentation-spaces.scss
+++ b/tests/sass/indentation/indentation-spaces.scss
@@ -143,3 +143,18 @@ $colors: (
       margin: 16px;
     }
 }
+
+// Issue #783 and issue #779 - Import rule throws off indentation of maps etc
+
+@import 'echo-base/defaults/breakpoints';
+
+$textsizes: (
+  xs: (
+    s: 10px,
+    m: 10px
+  ),
+  s: (
+    s: 12px,
+    m: 13px
+  ),
+);

--- a/tests/sass/indentation/indentation-spaces.scss
+++ b/tests/sass/indentation/indentation-spaces.scss
@@ -144,7 +144,7 @@ $colors: (
     }
 }
 
-// Issue #783 and issue #779 - Import rule throws off indentation of maps etc
+// Issue #783 and issue #779 - at-rule throws off indentation of maps etc
 
 @import 'echo-base/defaults/breakpoints';
 
@@ -152,6 +152,21 @@ $textsizes: (
   xs: (
     s: 10px,
     m: 10px
+  ),
+  s: (
+    s: 12px,
+      m: 13px
+  ),
+);
+
+@function em($pixels, $context: $font-size-base) {
+  @return #{($pixels / $context)}rem;
+}
+
+$textsizes: (
+  xs: (
+    s: 10px,
+      m: 10px
   ),
   s: (
     s: 12px,

--- a/tests/sass/indentation/indentation-tabs.scss
+++ b/tests/sass/indentation/indentation-tabs.scss
@@ -143,3 +143,18 @@ $colors: (
 			margin: 16px;
 		}
 }
+
+// Issue #783 and issue #779 - Import rule throws off indentation of maps etc
+
+@import 'echo-base/defaults/breakpoints';
+
+$textsizes: (
+	xs: (
+		s: 10px,
+		m: 10px
+	),
+	s: (
+		s: 12px,
+		m: 13px
+	),
+);

--- a/tests/sass/indentation/indentation-tabs.scss
+++ b/tests/sass/indentation/indentation-tabs.scss
@@ -144,7 +144,7 @@ $colors: (
 		}
 }
 
-// Issue #783 and issue #779 - Import rule throws off indentation of maps etc
+// Issue #783 and issue #779 - at-rule throws off indentation of maps etc
 
 @import 'echo-base/defaults/breakpoints';
 
@@ -152,6 +152,21 @@ $textsizes: (
 	xs: (
 		s: 10px,
 		m: 10px
+	),
+	s: (
+		s: 12px,
+			m: 13px
+	),
+);
+
+@function em($pixels, $context: $font-size-base) {
+	@return #{($pixels / $context)}rem;
+}
+
+$textsizes: (
+	xs: (
+		s: 10px,
+			m: 10px
 	),
 	s: (
 		s: 12px,


### PR DESCRIPTION
~~Fixes an issue with the indentation rule where an at-rule (@import) wasn't correctly being exited from and thus threw all maps directly below it off.~~

Actually fixes an issue where at rules that didn't contain blocks were incorrectly identified and caused issues with anything following them.

fixes #779
fixes #783 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

