### PR TITLE
Fix comments warning as selectors

### DIFF
--- a/lib/rules/single-line-per-selector.js
+++ b/lib/rules/single-line-per-selector.js
@@ -2,6 +2,31 @@
 
 var helpers = require('../helpers');
 
+/**
+ * Checks a ruleset for selectors or EOL characters. If a selector is found before an EOL
+ * then it returns the selector node for reporting or returns false
+ *
+ * @param {Object} ruleset - The ruleset node
+ * @param {number} index - The current index of the delimiter
+ * @returns {Object|boolean} Either the selector node or false
+ */
+var checkLineForSelector = function (ruleset, index) {
+  var curIndex = index += 1;
+  if (ruleset.content[curIndex]) {
+    for (; curIndex < ruleset.content.length; curIndex++) {
+      var curType = ruleset.content[curIndex].type;
+      if (curType === 'space' && helpers.hasEOL(ruleset.content[curIndex])) {
+        return false;
+      }
+      if (curType === 'selector' || curType === 'typeSelector') {
+        return ruleset.content[curIndex];
+      }
+    }
+  }
+
+  return false;
+};
+
 module.exports = {
   'name': 'single-line-per-selector',
   'defaults': {},
@@ -10,22 +35,16 @@ module.exports = {
 
     ast.traverseByType('ruleset', function (ruleset) {
       ruleset.forEach('delimiter', function (delimiter, j) {
-        var next = ruleset.content[j + 1] || false;
+        var next = checkLineForSelector(ruleset, j);
 
         if (next) {
-          if (next.is('selector')) {
-            next = next.content[0];
-          }
-
-          if (!(next.is('space') && helpers.hasEOL(next.content))) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': next.start.line,
-              'column': next.start.column,
-              'message': 'Selectors must be placed on new lines',
-              'severity': parser.severity
-            });
-          }
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': next.start.line,
+            'column': next.start.column,
+            'message': 'Selectors must be placed on new lines',
+            'severity': parser.severity
+          });
         }
       });
     });

--- a/tests/sass/single-line-per-selector.sass
+++ b/tests/sass/single-line-per-selector.sass
@@ -48,3 +48,12 @@
 .foo
   .bar &, .baz &
     content: 'foo'
+
+// Issue #789 - Issue with comments being warned as selector content on single lines
+button,
+html,
+html input[type='button'], // 6
+input[type='reset'],
+input[type='submit']
+  -webkit-appearance: button; // 7
+  cursor: pointer; // 8

--- a/tests/sass/single-line-per-selector.scss
+++ b/tests/sass/single-line-per-selector.scss
@@ -54,3 +54,13 @@
     content: 'foo';
   }
 }
+
+// Issue #789 - Issue with comments being warned as selector content on single lines
+button,
+html,
+html input[type='button'], // 6
+input[type='reset'],
+input[type='submit'] {
+    -webkit-appearance: button; // 7
+    cursor: pointer; // 8
+}


### PR DESCRIPTION
As described in #789 comments or any non selector content was raising a lint warning as if it were a selector in the `single-line-per-selector` rule. I've slightly refactored it to check all along a line looking for selectors and EOL characters to properly take the context into account.

fixes #789 
`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

