### PR TITLE
Tidy mergeable selectors

### DIFF
--- a/lib/rules/no-mergeable-selectors.js
+++ b/lib/rules/no-mergeable-selectors.js
@@ -1,119 +1,16 @@
 'use strict';
 
-var helpers = require('../helpers');
+var helpers = require('../helpers'),
+    selectorHelpers = require('../selector-helpers');
 
 var mergeableNodes = ['atrule', 'include', 'ruleset'],
     validAtRules = ['media'],
-    simpleIdents = ['ident', 'number', 'operator', 'combinator', 'string', 'parentSelector', 'delimiter', 'typeSelector', 'attributeMatch'],
     curLevel = 0,
     curSelector = [],
     parentSelector = [],
     selectorList = [],
     syntax = '';
 
-
-/**
- * Adds grammar around our content blocks to construct selectors with
- * more readable formats.
- *
- * @param {object} val - The current value node
- * @param {string} prefix - The grammar to prefix the value with
- * @param {string} suffix - The grammar to add after the value
- * @returns {string} The correct readable format
- */
-var addGrammar = function (val, prefix, suffix) {
-  return prefix + val.content + suffix;
-};
-
-/**
- * Adds grammar around our content blocks to construct selectors with
- * more readable formats and loops the content as they're within sub blocks.
- *
- * @param {object} val - The current value node
- * @param {string} prefix - The grammar to prefix the value with
- * @param {string} suffix - The grammar to add after the value
- * @param {function} constructSelector - The callback we wish to use which means constructSelector in this instance
- * @returns {string} The correct readable format
- */
-var constructSubSelector = function (val, prefix, suffix, constructSelector) {
-  var content = prefix;
-  val.forEach(function (subItem) {
-    content += constructSelector(subItem);
-  });
-
-  return content + suffix;
-};
-
-/**
- * Constructs a syntax complete selector for our selector matching and warning output
- *
- * @param {object} val - The current node / part of our selector
- * @returns {string} - Content: The current node with correct syntax e.g. class my-class = '.my-class'
- */
-var constructSelector = function (val) {
-  var content = null;
-
-  if (val.is('id')) {
-    content = addGrammar(val, '#', '');
-  }
-
-  else if (val.is('class')) {
-    content = addGrammar(val, '.', '');
-  }
-
-  else if (simpleIdents.indexOf(val.type) !== -1) {
-    content = val.content;
-  }
-
-  else if (val.is('attributeSelector')) {
-    content = constructSubSelector(val, '[', ']', constructSelector);
-  }
-
-  else if (val.is('atkeyword')) {
-    content = constructSubSelector(val, '@', '', constructSelector);
-  }
-
-  else if (val.is('placeholder')) {
-    content = constructSubSelector(val, '%', '', constructSelector);
-  }
-
-  else if (val.is('variable')) {
-    content = constructSubSelector(val, '$', '', constructSelector);
-  }
-
-  else if (val.is('pseudoClass')) {
-    content = addGrammar(val, ':', '');
-  }
-
-  else if (val.is('pseudoElement')) {
-    content = addGrammar(val, '::', '');
-  }
-
-  else if (val.is('nth')) {
-    content = addGrammar(val, '(', ')');
-  }
-
-  else if (val.is('nthSelector')) {
-    content = constructSubSelector(val, ':', '', constructSelector);
-  }
-
-  else if (val.is('parentheses')) {
-    content = constructSubSelector(val, '(', ')', constructSelector);
-  }
-
-  else if (val.is('space')) {
-    content = ' ';
-  }
-
-  else if (val.is('parentSelectorExtension') || val.is('attributeName') || val.is('attributeValue') || val.is('dimension')) {
-    content = constructSubSelector(val, '', '', constructSelector);
-  }
-
-  else if (val.is('interpolation')) {
-    content = constructSubSelector(val, '#{', '}', constructSelector);
-  }
-  return content;
-};
 
 /**
  * Traverses a block and calls our callback function for each block encountered
@@ -161,11 +58,11 @@ var checkRuleset = function (ruleNode) {
     if (!ruleNodeItem.is('block')) {
       if (ruleNodeItem.is('selector')) {
         ruleNodeItem.forEach(function (selectorContent) {
-          ruleSet += constructSelector(selectorContent);
+          ruleSet += selectorHelpers.constructSelector(selectorContent);
         });
       }
       else if (ruleNodeItem.is('delimiter') || ruleNodeItem.is('space')) {
-        ruleSet += constructSelector(ruleNodeItem);
+        ruleSet += selectorHelpers.constructSelector(ruleNodeItem);
       }
     }
   });
@@ -184,7 +81,7 @@ var checkAtRule = function (atRule) {
   var test = '';
   atRule.forEach(function (atRuleItem) {
     if (!atRuleItem.is('block')) {
-      test += constructSelector(atRuleItem);
+      test += selectorHelpers.constructSelector(atRuleItem);
     }
   });
   updateList(test, true, atRule.start.line, atRule.start.column);


### PR DESCRIPTION
Follows on from #818 

Because the construct selector functionality was moved in that PR i've removed it from the specific rule here to keep things a little more DRY

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
