### PR TITLE
Add vim plugin to the list of IDE integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,4 @@ Our AST is [Gonzales-PE](https://github.com/tonyganch/gonzales-pe/tree/dev). Eac
 * [Brackets](https://github.com/petetnt/brackets-sass-lint)
 * [IntelliJ IDEA, RubyMine, WebStorm, PhpStorm, PyCharm](https://github.com/idok/sass-lint-plugin)
 * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=glen-84.sass-lint)
+* [Vim](https://github.com/gcorne/vim-sass-lint)


### PR DESCRIPTION
Recently installed and is working great.

Closes [#832](https://github.com/sasstools/sass-lint/issues/832)

`<DCO 1.1 Signed-off-by: Henry Baughman hbaughman.dev@gmail.com>`

