### PR TITLE
Issue with hex colours in shorthand values

### DIFF
--- a/lib/rules/shorthand-values.js
+++ b/lib/rules/shorthand-values.js
@@ -89,6 +89,10 @@ var scanValue = function (node) {
       fullVal += '#{' + scanValue(val.content) + '}';
     }
 
+    else if (val.is('color')) {
+      fullVal += '#' + val.content + '';
+    }
+
     else if (val.is('operator') || val.is('ident') || val.is('number') || val.is('unaryOperator')) {
       fullVal += val.content;
     }

--- a/tests/rules/shorthand-values.js
+++ b/tests/rules/shorthand-values.js
@@ -12,7 +12,7 @@ describe('shorthand values - scss', function () {
     lint.test(file, {
       'shorthand-values': 1
     }, function (data) {
-      lint.assert.equal(76, data.warningCount);
+      lint.assert.equal(77, data.warningCount);
       done();
     });
   });
@@ -44,7 +44,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(38, data.warningCount);
+      lint.assert.equal(39, data.warningCount);
       done();
     });
   });
@@ -60,7 +60,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(45, data.warningCount);
+      lint.assert.equal(46, data.warningCount);
       done();
     });
   });
@@ -92,7 +92,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(57, data.warningCount);
+      lint.assert.equal(58, data.warningCount);
       done();
     });
   });
@@ -109,7 +109,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(64, data.warningCount);
+      lint.assert.equal(65, data.warningCount);
       done();
     });
   });
@@ -126,7 +126,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(57, data.warningCount);
+      lint.assert.equal(58, data.warningCount);
       done();
     });
   });
@@ -144,7 +144,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(76, data.warningCount);
+      lint.assert.equal(77, data.warningCount);
       done();
     });
   });
@@ -161,7 +161,7 @@ describe('shorthand values - sass', function () {
     lint.test(file, {
       'shorthand-values': 1
     }, function (data) {
-      lint.assert.equal(76, data.warningCount);
+      lint.assert.equal(77, data.warningCount);
       done();
     });
   });
@@ -193,7 +193,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(38, data.warningCount);
+      lint.assert.equal(39, data.warningCount);
       done();
     });
   });
@@ -209,7 +209,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(45, data.warningCount);
+      lint.assert.equal(46, data.warningCount);
       done();
     });
   });
@@ -241,7 +241,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(57, data.warningCount);
+      lint.assert.equal(58, data.warningCount);
       done();
     });
   });
@@ -258,7 +258,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(64, data.warningCount);
+      lint.assert.equal(65, data.warningCount);
       done();
     });
   });
@@ -275,7 +275,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(57, data.warningCount);
+      lint.assert.equal(58, data.warningCount);
       done();
     });
   });
@@ -293,7 +293,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(76, data.warningCount);
+      lint.assert.equal(77, data.warningCount);
       done();
     });
   });

--- a/tests/sass/shorthand-values.sass
+++ b/tests/sass/shorthand-values.sass
@@ -297,3 +297,11 @@
 
 .value-four-diff-four-interp-function-mixed
   margin: calc(#{$doc-header-height} + #{$global-whitespace--regular}) calc(#{$doc-header-height} + #{$global-whitespace--regular}) calc(#{$doc-header-height} - #{$global-whitespace--regular}) calc(#{$doc-header-height} - #{$global-whitespace--regular})
+
+// issue #772 - Issue with colours not being correctly interpreted
+// should be ignored;
+.test
+  border-color: transparent transparent transparent #095b97
+
+.test
+  border-color: transparent #095b97 transparent #095b97

--- a/tests/sass/shorthand-values.scss
+++ b/tests/sass/shorthand-values.scss
@@ -359,3 +359,13 @@
 .value-four-diff-four-interp-function-mixed {
   margin: calc(#{$doc-header-height} + #{$global-whitespace--regular}) calc(#{$doc-header-height} + #{$global-whitespace--regular}) calc(#{$doc-header-height} - #{$global-whitespace--regular}) calc(#{$doc-header-height} - #{$global-whitespace--regular});
 }
+
+// issue #772 - Issue with colours not being correctly interpreted
+// should be ignored;
+.test {
+  border-color: transparent transparent transparent #095b97;
+}
+
+.test {
+  border-color: transparent #095b97 transparent #095b97;
+}


### PR DESCRIPTION
Shorthand values wasn't correctly interpresting colour values. This PR corrects that.

fixes #772 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

