### PR TITLE
Add max-line-length rule

### DIFF
--- a/docs/rules/max-line-length.md
+++ b/docs/rules/max-line-length.md
@@ -2,6 +2,10 @@
 
 Rule `max-line-length` will enforce that lines do not exceed a max length / limit.
 
+## Options
+
+* `length`: `number`, (defaults to 80)
+
 ## Examples
 
 When enabled, the following are disallowed:

--- a/docs/rules/max-line-length.md
+++ b/docs/rules/max-line-length.md
@@ -1,0 +1,20 @@
+# Max Line Length
+
+Rule `max-line-length` will enforce that lines do not exceed a max length / limit.
+
+## Examples
+
+When enabled, the following are disallowed:
+
+```scss
+.really--long--class-name--that-unfortunately--isnt--very--succint--and-looks-stupid {
+  color: red;
+}
+
+// ==============================================================================
+//
+// This comment is too long clearly, we should probably make sure we have a rule to
+// determine when we breach this length
+//
+// ==============================================================================
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -67,6 +67,7 @@ rules:
   hex-notation: 1
   indentation: 1
   leading-zero: 1
+  max-line-length: 0
   nesting-depth: 1
   property-sort-order: 1
   pseudo-element: 1

--- a/lib/rules/max-line-length.js
+++ b/lib/rules/max-line-length.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'max-line-length',
+  'defaults': {
+    length: 80
+  },
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('space', function (space) {
+      var lineLength = 0;
+      if (helpers.hasEOL(space.content)) {
+        lineLength = space.start.column - 1;
+      }
+
+      if (lineLength > parser.options.length) {
+        result = helpers.addUnique(result, {
+          'ruleId': parser.rule.name,
+          'severity': parser.severity,
+          'line': space.start.line,
+          'column': 0,
+          'message': 'line ' + space.start.line + ' exceeds the maximum line length of ' + parser.options.length
+        });
+      }
+    });
+
+    return result;
+  }
+};

--- a/tests/rules/max-line-length.js
+++ b/tests/rules/max-line-length.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('max-line-length - scss', function () {
+  var file = lint.file('max-line-length.scss');
+
+  it('enforce [default]', function (done) {
+    lint.test(file, {
+      'max-line-length': 1
+    }, function (data) {
+      lint.assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  it('enforce [length: 79]', function (done) {
+    lint.test(file, {
+      'max-line-length': [
+        1,
+        {
+          length: 79
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('max-line-length - sass', function () {
+  var file = lint.file('max-line-length.sass');
+
+  it('enforce', function (done) {
+    lint.test(file, {
+      'max-line-length': 1
+    }, function (data) {
+      lint.assert.equal(5, data.warningCount);
+      done();
+    });
+  });
+
+  it('enforce [length: 79]', function (done) {
+    lint.test(file, {
+      'max-line-length': [
+        1,
+        {
+          length: 79
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/max-line-length.sass
+++ b/tests/sass/max-line-length.sass
@@ -1,0 +1,20 @@
+.really--long--class-name--that-unfortunately--isnt--very--succint--and-looks-stupid
+  color: red
+
+@function($aReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariableName)
+  @return 'test'
+
+// ==============================================================================
+//
+// This comment is too long clearly, we should probably make sure we have a rule to
+// determine when we breach this length
+//
+// ==============================================================================
+
+
+// =============================================================================
+//
+// This comment comment on the other hand should be the perfect length, unless a
+// user decides to make their max line length === 79!
+//
+// =============================================================================

--- a/tests/sass/max-line-length.scss
+++ b/tests/sass/max-line-length.scss
@@ -1,0 +1,22 @@
+.really--long--class-name--that-unfortunately--isnt--very--succint--and-looks-stupid {
+  color: red;
+}
+
+@function($aReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariableName) {
+  @return 'test';
+}
+
+// ==============================================================================
+//
+// This comment is too long clearly, we should probably make sure we have a rule to
+// determine when we breach this length
+//
+// ==============================================================================
+
+
+// =============================================================================
+//
+// This comment comment on the other hand should be the perfect length, unless a
+// user decides to make their max line length === 79!
+//
+// =============================================================================


### PR DESCRIPTION
Adds the `max-line-length` rule by default it is disabled in the config. 
It specifies a default value of 80 characters long.
If a line breaches the default or user set limit it will warn with the message:
`line 1 exceeds the maximum line length of 80`

closes #833 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

