### PR TITLE
Fix shorthand-values

### DIFF
--- a/lib/rules/shorthand-values.js
+++ b/lib/rules/shorthand-values.js
@@ -93,7 +93,13 @@ var scanValue = function (node) {
       fullVal += '#' + val.content + '';
     }
 
-    else if (val.is('operator') || val.is('ident') || val.is('number') || val.is('unaryOperator')) {
+    else if (
+      val.is('operator') ||
+      val.is('ident') ||
+      val.is('number') ||
+      val.is('unaryOperator') ||
+      val.is('string')
+    ) {
       fullVal += val.content;
     }
 

--- a/tests/rules/shorthand-values.js
+++ b/tests/rules/shorthand-values.js
@@ -12,7 +12,7 @@ describe('shorthand values - scss', function () {
     lint.test(file, {
       'shorthand-values': 1
     }, function (data) {
-      lint.assert.equal(77, data.warningCount);
+      lint.assert.equal(78, data.warningCount);
       done();
     });
   });
@@ -44,7 +44,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });
@@ -60,7 +60,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(46, data.warningCount);
+      lint.assert.equal(47, data.warningCount);
       done();
     });
   });
@@ -92,7 +92,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(58, data.warningCount);
+      lint.assert.equal(59, data.warningCount);
       done();
     });
   });
@@ -109,7 +109,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(65, data.warningCount);
+      lint.assert.equal(66, data.warningCount);
       done();
     });
   });
@@ -126,7 +126,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(58, data.warningCount);
+      lint.assert.equal(59, data.warningCount);
       done();
     });
   });
@@ -144,7 +144,7 @@ describe('shorthand values - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(77, data.warningCount);
+      lint.assert.equal(78, data.warningCount);
       done();
     });
   });
@@ -161,7 +161,7 @@ describe('shorthand values - sass', function () {
     lint.test(file, {
       'shorthand-values': 1
     }, function (data) {
-      lint.assert.equal(77, data.warningCount);
+      lint.assert.equal(78, data.warningCount);
       done();
     });
   });
@@ -193,7 +193,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(39, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });
@@ -209,7 +209,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(46, data.warningCount);
+      lint.assert.equal(47, data.warningCount);
       done();
     });
   });
@@ -241,7 +241,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(58, data.warningCount);
+      lint.assert.equal(59, data.warningCount);
       done();
     });
   });
@@ -258,7 +258,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(65, data.warningCount);
+      lint.assert.equal(66, data.warningCount);
       done();
     });
   });
@@ -275,7 +275,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(58, data.warningCount);
+      lint.assert.equal(59, data.warningCount);
       done();
     });
   });
@@ -293,7 +293,7 @@ describe('shorthand values - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(77, data.warningCount);
+      lint.assert.equal(78, data.warningCount);
       done();
     });
   });

--- a/tests/sass/shorthand-values.sass
+++ b/tests/sass/shorthand-values.sass
@@ -305,3 +305,10 @@
 
 .test
   border-color: transparent #095b97 transparent #095b97
+
+// Issue #847 - Ignoring function arguments
+.foo
+  padding: 0 size('half-shim') 0 size('spacer')
+
+.foo
+  padding: 0 size('half-shim') 0 size('half-shim')

--- a/tests/sass/shorthand-values.scss
+++ b/tests/sass/shorthand-values.scss
@@ -369,3 +369,12 @@
 .test {
   border-color: transparent #095b97 transparent #095b97;
 }
+
+// Issue #847 - Ignoring function arguments
+.foo {
+  padding: 0 size('half-shim') 0 size('spacer');
+}
+
+.foo {
+  padding: 0 size('half-shim') 0 size('half-shim');
+}


### PR DESCRIPTION
For some reason the shorthand-values rule was missing the string node type and therefore any string encountered came back as null.

Fixes #847 
`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

