### PR TITLE
Fix indentation for multiline values

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -12,9 +12,12 @@ module.exports = {
         inAtRule = false,
         inProps = false,
         inBlock = false,
+        inVal = false,
+        inMap = false,
         lintSize = parser.options.size,
         lintType = 'space',
         plural = '',
+        valAlignment = null,
         detected = [lintType];
 
     // Prepare to check for mixed spaces or tabs depending on what the user has specified
@@ -153,15 +156,29 @@ module.exports = {
               'severity': parser.severity
             });
           }
-          if (reportCondition && !mixedWarning && spaceLength / lintSize !== level) {
-            // Check if expected indentation matches what it should be
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': reportNode.start.line,
-              'column': reportNode.start.column,
-              'message': 'Expected indentation of ' + level * lintSize + ' ' + lintType + plural + ' but found ' + spaceLength + '.',
-              'severity': parser.severity
-            });
+          if (reportCondition && !mixedWarning) {
+            // If we are inside a value node there could be multilevel values which would be aligned by column count
+            // and not necessarily by lint level
+            if (inVal && valAlignment && spaceLength !== valAlignment && spaceLength / lintSize !== level) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': reportNode.start.line,
+                'column': reportNode.start.column,
+                'message': 'Expected indentation of ' + valAlignment + ' ' + lintType + plural + ' but found ' + spaceLength + '.',
+                'severity': parser.severity
+              });
+            }
+            // Otherwise check we aren't in a value and then do the usual checks to see if we're not at the correct level
+            else if (!inVal && spaceLength / lintSize !== level) {
+              // Check if expected indentation matches what it should be
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': reportNode.start.line,
+                'column': reportNode.start.column,
+                'message': 'Expected indentation of ' + level * lintSize + ' ' + lintType + plural + ' but found ' + spaceLength + '.',
+                'severity': parser.severity
+              });
+            }
           }
           mixedWarning = false;
         }
@@ -183,6 +200,21 @@ module.exports = {
               level--;
             }
           }
+        }
+
+        if (n.is('property') && n.contains('variable')) {
+          inMap = true;
+        }
+
+        if (n.is('value') && !inMap) {
+          inVal = true;
+          valAlignment = n.start.column - 1;
+        }
+
+        if (n.is('declarationDelimiter') && ( inVal || inMap) ) {
+          inVal = false;
+          inMap = false;
+          valAlignment = null;
         }
 
         // if a block node is encountered we first check to see if it's within an include/function

--- a/tests/rules/indentation.js
+++ b/tests/rules/indentation.js
@@ -13,7 +13,7 @@ describe('indentation - scss', function () {
     lint.test(spaceFile, {
       'indentation': 1
     }, function (data) {
-      lint.assert.equal(14, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -27,7 +27,7 @@ describe('indentation - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(14, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });

--- a/tests/sass/indentation/indentation-spaces.scss
+++ b/tests/sass/indentation/indentation-spaces.scss
@@ -173,3 +173,21 @@ $textsizes: (
     m: 13px
   ),
 );
+
+// Issue #591 - multiline structures
+@font-face {
+  font-family: "Freight Sans Pro";
+  src: url("../fonts/FreightSansProMedium.woff") format("woff"),
+        url("../fonts/FreightSansProMedium.ttf")  format("truetype"),
+       url("../fonts/FreightSansProMedium.ttf")  format("truetype");
+}
+
+.foo {
+  transition: transform $in-out-speed,
+              visibility 0s $in-out-speed;
+}
+
+.bar {
+  transition: transform $in-out-speed,
+    visibility 0s $in-out-speed;
+}

--- a/tests/sass/indentation/indentation-tabs.scss
+++ b/tests/sass/indentation/indentation-tabs.scss
@@ -173,3 +173,21 @@ $textsizes: (
 		m: 13px
 	),
 );
+
+// Issue #591 - multiline structures
+@font-face {
+	font-family: "Freight Sans Pro";
+	src: url("../fonts/FreightSansProMedium.woff") format("woff"),
+				url("../fonts/FreightSansProMedium.ttf")	format("truetype"),
+			 url("../fonts/FreightSansProMedium.ttf")	format("truetype");
+}
+
+.foo {
+	transition: transform $in-out-speed,
+							visibility 0s $in-out-speed;
+}
+
+.bar {
+	transition: transform $in-out-speed,
+		visibility 0s $in-out-speed;
+}


### PR DESCRIPTION
Fixes the indentation rule for use with multiline values

fixes #591 
looking to fix the indentation issues in #464 too

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

