### PR TITLE
Reimplement max-warnings as a proper option

### DIFF
--- a/docs/options/max-warnings.md
+++ b/docs/options/max-warnings.md
@@ -1,0 +1,29 @@
+# Max warnings
+
+An error will be thrown if the total number of warnings exceeds the `max-warnings` setting.
+
+## Examples
+
+This can be set as a command-line option:
+
+``` bash
+$ sass-lint --max-warnings 50
+```
+
+In `.sass-lint.yml`:
+
+``` yaml
+options:
+  max-warnings: 50
+```
+
+Or inside a script:
+
+``` javascript
+var sassLint = require('sass-lint'),
+    config = {options: {'max-warnings': 50}};
+
+results = sassLint.lintFiles('sass/**/*.scss', config)
+sassLint.failOnError(results, config);
+```
+

--- a/docs/sass-lint.yml
+++ b/docs/sass-lint.yml
@@ -9,6 +9,8 @@ options:
   formatter: html
   # Output file instead of logging results
   output-file: 'linters/sass-lint.html'
+  # Raise an error if more than 50 warnings are generated
+  max-warnings: 50
 # File Options
 files:
   include: 'sass/**/*.s+(a|c)ss'

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var slConfig = require('./lib/config'),
     groot = require('./lib/groot'),
+    exceptions = require('./lib/exceptions'),
     helpers = require('./lib/helpers'),
     slRules = require('./lib/rules'),
     glob = require('glob'),
@@ -284,14 +285,30 @@ sassLint.outputResults = function (results, options, configPath) {
  * Throws an error if there are any errors detected. The error includes a count of all errors
  * and a list of all files that include errors.
  *
- * @param {object} results our results object
+ * @param {object} results - our results object
+ * @param {object} [options] - extra options to use when running failOnError, e.g. max-warnings
+ * @param {string} [configPath] - path to the config file
  * @returns {void}
  */
-sassLint.failOnError = function (results) {
-  var errorCount = this.errorCount(results);
+sassLint.failOnError = function (results, options, configPath) {
+  // Default parameters
+  options = typeof options !== 'undefined' ? options : {};
+  configPath = typeof configPath !== 'undefined' ? configPath : null;
+
+  var errorCount = this.errorCount(results),
+      warningCount = this.warningCount(results),
+      configOptions = this.getConfig(options, configPath).options;
 
   if (errorCount.count > 0) {
-    throw new Error(errorCount.count + ' errors were detected in \n- ' + errorCount.files.join('\n- '));
+    throw new exceptions.SassLintFailureError(errorCount.count + ' errors were detected in \n- ' + errorCount.files.join('\n- '));
+  }
+
+  if (!isNaN(configOptions['max-warnings']) && warningCount.count > configOptions['max-warnings']) {
+    throw new exceptions.MaxWarningsExceededError(
+      'Number of warnings (' + warningCount.count +
+      ') exceeds the allowed maximum of ' + configOptions['max-warnings'] +
+      '.\n'
+    );
   }
 };
 

--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var util = require('util');
+
+module.exports = {
+  SassLintFailureError: function (message) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = 'SassLintFailureError';
+    this.message = message;
+  },
+  MaxWarningsExceededError: function (message) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = 'MaxWarningsExceededError';
+    this.message = message;
+  }
+};
+
+util.inherits(module.exports.SassLintFailureError, Error);
+util.inherits(module.exports.MaxWarningsExceededError, Error);

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -383,27 +383,27 @@ describe('cli', function () {
 
   });
 
-  it('should exit with exit code 1 when quiet', function (done) {
+  it('should exit with error when quiet', function (done) {
     var command = 'sass-lint -c tests/yml/.error-output.yml tests/cli/cli-error.scss --verbose --no-exit';
 
     exec(command, function (err) {
-      if (err.code === 1) {
+      if (err) {
         return done();
       }
 
-      return done(new Error('Error code not 1'));
+      return done(new Error('No error on exit'));
     });
   });
 
-  it('should exit with exit code 1 when more warnings than --max-warnings', function (done) {
+  it('should exit with error when more warnings than --max-warnings', function (done) {
     var command = 'sass-lint -c tests/yml/.color-keyword-errors.yml tests/cli/cli.scss --max-warnings 0';
 
     exec(command, function (err) {
-      if (err && err.code === 1) {
+      if (err) {
         return done();
       }
 
-      return done(new Error('Error code not 1'));
+      return done(new Error('No error on exit'));
     });
   });
 

--- a/tests/failures.js
+++ b/tests/failures.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var lint = require('../index'),
+    assert = require('assert'),
+    exceptions = require('../lib/exceptions');
+
+describe('failures', function () {
+  it('should raise SassLintFailureError if indentation is set to error', function (done) {
+    assert.throws(
+      function () {
+        var results = lint.lintFiles('tests/sass/indentation/indentation-spaces.scss', {rules: {indentation: 2}});  // 14 errors
+        lint.failOnError(results); // Set indentation to error
+      },
+      exceptions.SassLintFailureError
+    );
+    assert.throws(
+      function () {
+        var results = lint.lintFiles('tests/sass/indentation/indentation-spaces.scss', {}, 'tests/yml/.indentation-error.yml');  // 14 errors
+        lint.failOnError(results); // Set indentation to error
+      },
+      exceptions.SassLintFailureError
+    );
+
+    done();
+  });
+
+  it('should not raise error if indentation is only set to warn', function (done) {
+    // These should produce 55 warnings and 0 errors
+    var directResults = lint.lintFiles('sass/indentation/indentation-spaces.scss', {rules: {indentation: 1}});
+    var configResults = lint.lintFiles('sass/indentation/indentation-spaces.scss', {}, 'yml/.indentation-warn.yml');
+    lint.failOnError(directResults);
+    lint.failOnError(configResults);
+
+    done();
+  });
+
+  it('should raise MaxWarningsExceededError if warnings exceed `max-warnings` setting', function (done) {
+    assert.throws(
+      function () {
+        var results = lint.lintFiles('tests/sass/indentation/indentation-spaces.scss', {});  // 55 warnings
+        lint.failOnError(results, {options: {'max-warnings': 10}});
+      },
+      exceptions.MaxWarningsExceededError
+    );
+    assert.throws(
+      function () {
+        var results = lint.lintFiles('tests/sass/indentation/indentation-spaces.scss', {});  // 55 warnings
+        lint.failOnError(results, {}, 'tests/yml/.max-10-warnings.yml');
+      },
+      exceptions.MaxWarningsExceededError
+    );
+
+    done();
+  });
+
+  it('should raise MaxWarningsExceededError if warnings exceed `max-warnings` of zero', function (done) {
+    assert.throws(
+      function () {
+        var results = lint.lintFiles('tests/sass/indentation/indentation-spaces.scss', {});  // 55 warnings
+        lint.failOnError(results, {options: {'max-warnings': 0}});
+      },
+      exceptions.MaxWarningsExceededError
+    );
+    assert.throws(
+      function () {
+        var results = lint.lintFiles('tests/sass/indentation/indentation-spaces.scss', {});  // 55 warnings
+        lint.failOnError(results, {}, 'tests/yml/.max-0-warnings.yml');
+      },
+      exceptions.MaxWarningsExceededError
+    );
+
+    done();
+  });
+
+  it('should not raise error if warnings do not exceed `max-warnings` setting', function (done) {
+    var results = lint.lintFiles('sass/indentation/indentation-spaces.scss', {});  // 55 warnings
+    lint.failOnError(results, {'max-warnings': 100}); // should succceed
+    lint.failOnError(results, {}, 'yml/.max-100-warnings.yml'); // should succeed
+
+    done();
+  });
+
+  it('should not raise error if no warnings even if `max-warnings` is zero', function (done) {
+    var results = lint.lintFiles('sass/success.scss', {});  // no warnings
+    lint.failOnError(results, {'max-warnings': 0}); // should still succceed
+    lint.failOnError(results, {}, 'yml/.max-0-warnings.yml'); // should still succeed
+
+    done();
+  });
+});

--- a/tests/sass/success.scss
+++ b/tests/sass/success.scss
@@ -1,0 +1,3 @@
+.one {
+  margin-top: 0;
+}

--- a/tests/yml/.indentation-error.yml
+++ b/tests/yml/.indentation-error.yml
@@ -1,0 +1,2 @@
+rules:
+  indentation: 2

--- a/tests/yml/.indentation-warn.yml
+++ b/tests/yml/.indentation-warn.yml
@@ -1,0 +1,2 @@
+rules:
+  indentation: 1

--- a/tests/yml/.max-0-warnings.yml
+++ b/tests/yml/.max-0-warnings.yml
@@ -1,0 +1,2 @@
+options:
+  max-warnings: 0

--- a/tests/yml/.max-10-warnings.yml
+++ b/tests/yml/.max-10-warnings.yml
@@ -1,0 +1,2 @@
+options:
+  max-warnings: 10

--- a/tests/yml/.max-100-warnings.yml
+++ b/tests/yml/.max-100-warnings.yml
@@ -1,0 +1,2 @@
+options:
+  max-warnings: 100


### PR DESCRIPTION
**What do the changes you have made achieve?**

This adds `max-warnings` as a proper option, including tests and documentation. This option can be set in the config file, passed straight through to `failOnError`, or set via the command-line.

See #856 for more detail.

**Are there any new warning messages?**

No.

There's a new error message:

```
MaxWarningsExceededError: Number of warnings (257) exceeds the allowed maximum of 20.
```

**Have you written tests?**

Yes. 

```
  failures
    ✓ should raise SassLintFailureError if indentation is set to error (595ms)
    ✓ should not raise SassLintFailureError if indentation is only set to warn
    ✓ should raise MaxWarningsExceededError if warnings exceed `max-warnings` setting (133ms)
    ✓ should not raise MaxWarningsExceededError if warnings do not exceed `max-warnings` setting
```

**Have you included relevant documentation**

Yes, in `docs/options/max-warnings.md`.

**Which issues does this resolve?**

Closes #856.

`<DCO 1.1 Signed-off-by: Robin Winslow robin@robinwinslow.co.uk>`