### PR TITLE
Fix Enhanced trailing semicolon to lint double semicolons

### DIFF
--- a/lib/rules/trailing-semicolon.js
+++ b/lib/rules/trailing-semicolon.js
@@ -10,6 +10,21 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
+    var hasDoubleSemiColon = function (tree) {
+
+      tree.traverseByType('declarationDelimiter', function (node, index, parent) {
+        if (parent.content[index + 1].is('declarationDelimiter')) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'severity': parser.severity,
+            'line': parent.content[index + 1].start.line,
+            'column': parent.content[index + 1].start.column,
+            'message': 'No double semicolons allowed'
+          });
+        }
+      });
+    };
+
     if (ast.syntax !== 'sass') {
       ast.traverseByType('block', function (block) {
         var last,
@@ -53,6 +68,7 @@ module.exports = {
                       });
                     }
                   }
+                  hasDoubleSemiColon(parent);
                 }
               }
             }

--- a/tests/rules/trailing-semicolon.js
+++ b/tests/rules/trailing-semicolon.js
@@ -12,7 +12,7 @@ describe('trailing semicolon - scss', function () {
     lint.test(file, {
       'trailing-semicolon': 1
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('trailing semicolon - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(1, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/trailing-semicolon.scss
+++ b/tests/sass/trailing-semicolon.scss
@@ -3,10 +3,11 @@
 }
 
 .bar {
-  content: 'qux';
+  content: 'qux';;
   padding: 0
 
   .qux {
+    float: left;;
     content: 'waldo'
   }
 }
@@ -21,7 +22,7 @@
 
 .baz {
   font: {
-    family: 'Arial';
+    family: 'Arial';;
     weight: bold;
     size: 2rem
   }
@@ -30,7 +31,7 @@
 .norf {
   border: {
     top: {
-      color: red;
+      color: red;;
 
       left: {
         radius: 5px


### PR DESCRIPTION
<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

Enhanced 'trailing-semicolon' rule to lint double semicolons.

e.g
`.foo { 
background: red;;
 }` 

**Are there any new warning messages?**
No.

**Have you written tests?**
No. I increased the asserted number of errors in the existing 'trailing-semicolon' test, after including test examples for double semicolons inside the trailing-semicolon.scss file.

**Have you included relevant documentation**
No. None was needed (please let me know if otherwise).

**Which issues does this resolve?**
#852

`<DCO 1.1 Signed-off-by: Jordan Dustin Disch jordanddisch@gmail.com>`
