### PR TITLE
:bug: Remove font-smoothing from list of standard properties

### DIFF
--- a/data/properties.yml
+++ b/data/properties.yml
@@ -208,7 +208,6 @@ font-language-override
 font-size
 font-size-adjust
 font-size-delta
-font-smoothing
 font-stretch
 font-style
 font-synthesis

--- a/tests/rules/no-misspelled-properties.js
+++ b/tests/rules/no-misspelled-properties.js
@@ -12,7 +12,7 @@ describe('no misspelled properties - scss', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -45,7 +45,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });
@@ -61,7 +61,7 @@ describe('no misspelled properties - sass', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -94,7 +94,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });


### PR DESCRIPTION
Removed font-smoothing from list of standard properties

Closes #824 

`<DCO 1.1 Signed-off-by: Piotr Niziniecki pniziniecki@gmail.com>`
