### PR TITLE
Fix false positive in border-zero

### DIFF
--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -29,7 +29,7 @@ module.exports = {
             var node = item.content[0];
             if (node.type === 'number' || node.type === 'ident') {
               if (node.content === '0' || node.content === 'none') {
-                if (parser.options.convention !== node.content) {
+                if (('' + parser.options.convention) !== node.content) {
                   result = helpers.addUnique(result, {
                     'ruleId': parser.rule.name,
                     'line': node.start.line,


### PR DESCRIPTION
<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

**What do the changes you have made achieve?**
This fixes a false positive when `convention` is set to the integer `0` (as opposed to the string, which does work), by casting the `convention` to a string.

**Are there any new warning messages?**
No

**Have you written tests?**
No but I've tested it manually

**Have you included relevant documentation**
Not necessary

**Which issues does this resolve?**
#861

`<DCO 1.1 Signed-off-by: Richard de Wit henk.exe@gmail.com>`