### PR TITLE
Fix boolean strictbem modifiers

### DIFF
--- a/docs/rules/class-name-format.md
+++ b/docs/rules/class-name-format.md
@@ -191,6 +191,10 @@ When enabled, the following are allowed:
 .owner-name_mod-name_mod-val {
   content: '';
 }
+
+.block-name__elem-name_mod-bool {
+  content: '';
+}
 ```
 
 When enabled, the following are disallowed:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -169,7 +169,7 @@ helpers.isSnakeCase = function (str) {
  * @returns {boolean}     Whether str adheres to strict-BEM format
  */
 helpers.isStrictBEM = function (str) {
-  return /^[a-z](\-?[a-z0-9]+)*(__[a-z0-9](\-?[a-z0-9]+)*)?((_[a-z0-9](\-?[a-z0-9]+)*){2})?$/.test(str);
+  return /^[a-z](\-?[a-z0-9]+)*(__[a-z0-9](\-?[a-z0-9]+)*)?((_[a-z0-9](\-?[a-z0-9]+)*){0,2})?$/.test(str);
 };
 
 /**

--- a/tests/helpers/isStrictBEM.js
+++ b/tests/helpers/isStrictBEM.js
@@ -89,11 +89,11 @@ describe('helpers - isStrictBEM', function () {
     done();
   });
 
-  it('isStrictBEM - [\'abc_def\' - false]', function (done) {
+  it('isStrictBEM - [\'abc_def\' - true]', function (done) {
 
     var result = helpers.isStrictBEM('abc_def');
 
-    assert.equal(false, result);
+    assert.equal(true, result);
     done();
   });
 

--- a/tests/rules/class-name-format.js
+++ b/tests/rules/class-name-format.js
@@ -12,7 +12,7 @@ describe('class name format - scss', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(27, data.warningCount);
+      lint.assert.equal(31, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(26, data.warningCount);
+      lint.assert.equal(30, data.warningCount);
       done();
     });
   });
@@ -40,7 +40,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(36, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(36, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });
@@ -68,7 +68,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(32, data.warningCount);
+      lint.assert.equal(36, data.warningCount);
       done();
     });
   });
@@ -82,7 +82,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(22, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -96,7 +96,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(20, data.warningCount);
+      lint.assert.equal(24, data.warningCount);
       done();
     });
   });
@@ -110,7 +110,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(38, data.warningCount);
+      lint.assert.equal(42, data.warningCount);
       done();
     });
   });
@@ -126,7 +126,7 @@ describe('class name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(34, data.warningCount);
+      lint.assert.equal(38, data.warningCount);
       lint.assert.equal(data.messages[0].message, message);
       done();
     });
@@ -143,7 +143,7 @@ describe('class name format - sass', function () {
     lint.test(file, {
       'class-name-format': 1
     }, function (data) {
-      lint.assert.equal(27, data.warningCount);
+      lint.assert.equal(31, data.warningCount);
       done();
     });
   });
@@ -157,7 +157,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(26, data.warningCount);
+      lint.assert.equal(30, data.warningCount);
       done();
     });
   });
@@ -171,7 +171,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(36, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });
@@ -185,7 +185,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(36, data.warningCount);
+      lint.assert.equal(40, data.warningCount);
       done();
     });
   });
@@ -199,7 +199,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(32, data.warningCount);
+      lint.assert.equal(36, data.warningCount);
       done();
     });
   });
@@ -213,7 +213,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(22, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -227,7 +227,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(20, data.warningCount);
+      lint.assert.equal(24, data.warningCount);
       done();
     });
   });
@@ -241,7 +241,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(38, data.warningCount);
+      lint.assert.equal(42, data.warningCount);
       done();
     });
   });
@@ -257,7 +257,7 @@ describe('class name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(34, data.warningCount);
+      lint.assert.equal(38, data.warningCount);
       lint.assert.equal(data.messages[0].message, message);
       done();
     });

--- a/tests/rules/function-name-format.js
+++ b/tests/rules/function-name-format.js
@@ -65,7 +65,7 @@ describe('function name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });
@@ -177,7 +177,7 @@ describe('function name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(10, data.warningCount);
       done();
     });
   });

--- a/tests/rules/mixin-name-format.js
+++ b/tests/rules/mixin-name-format.js
@@ -65,7 +65,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -177,7 +177,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });

--- a/tests/rules/placeholder-name-format.js
+++ b/tests/rules/placeholder-name-format.js
@@ -69,7 +69,7 @@ describe('placeholder name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -185,7 +185,7 @@ describe('placeholder name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(13, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -69,7 +69,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -185,7 +185,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });

--- a/tests/sass/class-name-format.sass
+++ b/tests/sass/class-name-format.sass
@@ -81,3 +81,16 @@
   .APascalCase
     .camelCase
       color: red
+
+// Issue #872 - incorrect strict bem regex
+.strict-bem__elem_bool
+  color: red
+
+.strict-bem__elem_bool-modifier
+  color: red
+
+.strict-bem__elem_key-val
+  color: red
+
+.strict-bem__elem_key--fail
+  color: red

--- a/tests/sass/class-name-format.scss
+++ b/tests/sass/class-name-format.scss
@@ -116,3 +116,20 @@
     }
   }
 }
+
+// Issue #872 - incorrect strict bem regex
+.strict-bem__elem_bool {
+  color: red;
+}
+
+.strict-bem__elem_bool-modifier {
+  color: red;
+}
+
+.strict-bem__elem_key-val {
+  color: red;
+}
+
+.strict-bem__elem_key--fail {
+  color: red;
+}


### PR DESCRIPTION
In strict BEM there are two types of modifiers signified by a single underscore character

a key value pair
```scss
.block_{key_val}
```
or a boolean
```scss
.block_{bool}
```

In all our name value rules we were only checking for the key value pair and completely ignoring the boolean type which was flagging a lot of false positives it seems, even in our own tests. 

This PR rectifies this.

fixes #872 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

