### PR TITLE
Fix BOM markers causing parse issues

### DIFF
--- a/lib/groot.js
+++ b/lib/groot.js
@@ -5,13 +5,13 @@
 
 var gonzales = require('gonzales-pe');
 var fm = require('front-matter');
-var stripBom = require('strip-bom');
+var helpers = require('./helpers');
 
 module.exports = function (text, syntax, filename) {
   var tree;
 
   // Run `.toString()` to allow Buffers to be passed in
-  text = stripBom(text.toString());
+  text = helpers.stripBom(text.toString());
 
   // if we're skipping front matter do it here, fall back to just our text in case it fails
   if (fm.test(text)) {

--- a/lib/groot.js
+++ b/lib/groot.js
@@ -3,14 +3,15 @@
 //////////////////////////////
 'use strict';
 
-var gonzales = require('gonzales-pe'),
-    fm = require('front-matter');
+var gonzales = require('gonzales-pe');
+var fm = require('front-matter');
+var stripBom = require('strip-bom');
 
 module.exports = function (text, syntax, filename) {
   var tree;
 
   // Run `.toString()` to allow Buffers to be passed in
-  text = text.toString();
+  text = stripBom(text.toString());
 
   // if we're skipping front matter do it here, fall back to just our text in case it fails
   if (fm.test(text)) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -394,4 +394,24 @@ helpers.isPartialStringMatch = function (needle, haystack) {
   return false;
 };
 
+/**
+ *  A copy of the the stripBom module from https://github.com/sindresorhus/strip-bom/blob/master/index.js
+ *  The module requires node > 4 whereas we support earlier versions.
+ *  This function strips the BOM marker from the beginning of a file
+ *
+ * @param {string} str - The string we wish to strip the BOM marker from
+ * @returns {string} The string without a BOM marker
+ */
+helpers.stripBom = function (str) {
+  if (typeof str !== 'string') {
+    throw new TypeError('Expected a string, got ' + typeof str);
+  }
+
+  if (str.charCodeAt(0) === 0xFEFF) {
+    return str.slice(1);
+  }
+
+  return str;
+};
+
 module.exports = helpers;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "lodash.kebabcase": "^4.0.0",
     "merge": "^1.2.0",
     "path-is-absolute": "^1.0.0",
-    "strip-bom": "^3.0.0",
     "util": "^0.10.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lodash.kebabcase": "^4.0.0",
     "merge": "^1.2.0",
     "path-is-absolute": "^1.0.0",
+    "strip-bom": "^3.0.0",
     "util": "^0.10.3"
   },
   "devDependencies": {

--- a/tests/bom-utf8/starts-with-mixin-utf8-bom.scss
+++ b/tests/bom-utf8/starts-with-mixin-utf8-bom.scss
@@ -1,0 +1,5 @@
+﻿@mixin foo(
+  $param: 'def'
+) {
+  color: red;
+}

--- a/tests/bom-utf8/var-utf8-bom.scss
+++ b/tests/bom-utf8/var-utf8-bom.scss
@@ -1,0 +1,5 @@
+﻿$my-color: red;
+
+body {
+  color: $my-color;
+}

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -486,7 +486,7 @@ describe('Reading files with UTF-8 BOM', function () {
   });
 
   it('should not throw a parse error from file containing a BOM', function (done) {
-    var command = 'sass-lint -v tests/bom-utf8/starts-with-mixin-utf8-bom.scss --format json';
+    var command = 'node bin/sass-lint -v tests/bom-utf8/starts-with-mixin-utf8-bom.scss --format json';
 
     exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0];
@@ -499,7 +499,7 @@ describe('Reading files with UTF-8 BOM', function () {
   });
 
   it('should return the correct amount of warnings from a file containing BOM markers', function (done) {
-    var command = 'sass-lint -v tests/bom-utf8/var-utf8-bom.scss --format json';
+    var command = 'node bin/sass-lint -v tests/bom-utf8/var-utf8-bom.scss --format json';
 
     exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0];

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -491,7 +491,7 @@ describe('Reading files with UTF-8 BOM', function () {
     exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
       var result = JSON.parse(stdout)[0];
 
-      // Files with BOM markers that start with a mixing throw a fatal error
+      // Files with BOM markers that start with a mixin throw a fatal error
       // https://github.com/sasstools/sass-lint/issues/880
       assert.equal(result.errorCount, 0);
       done();

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -472,3 +472,43 @@ describe('cli', function () {
     });
   });
 });
+
+// ==============================================================================
+//  UTF-8 BOM
+// ==============================================================================
+
+describe('Reading files with UTF-8 BOM', function () {
+  before(function () {
+    var testText = fs.readFileSync('tests/bom-utf8/starts-with-mixin-utf8-bom.scss').toString();
+    if (testText.charCodeAt(0) !== 0xFEFF) {
+      throw new Error('BOM test files have no BOM markers');
+    }
+  });
+
+  it('should not throw a parse error from file containing a BOM', function (done) {
+    var command = 'sass-lint -v tests/bom-utf8/starts-with-mixin-utf8-bom.scss --format json';
+
+    exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
+      var result = JSON.parse(stdout)[0];
+
+      // Files with BOM markers that start with a mixing throw a fatal error
+      // https://github.com/sasstools/sass-lint/issues/880
+      assert.equal(result.errorCount, 0);
+      done();
+    });
+  });
+
+  it('should return the correct amount of warnings from a file containing BOM markers', function (done) {
+    var command = 'sass-lint -v tests/bom-utf8/var-utf8-bom.scss --format json';
+
+    exec(command, function (err, stdout) { // eslint-disable-line handle-callback-err
+      var result = JSON.parse(stdout)[0];
+
+      // Files starting with variables threw extra errors
+      // see https://github.com/sasstools/sass-lint/issues/880
+      assert.equal(result.errorCount, 0);
+      assert.equal(result.warningCount, 2);
+      done();
+    });
+  });
+});

--- a/tests/helpers/stripBom.js
+++ b/tests/helpers/stripBom.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var assert = require('assert'),
+    helpers = require('../../lib/helpers'),
+    fs = require('fs');
+
+describe('helpers - stripBom', function () {
+
+  //////////////////////////////
+  // Strip BOM
+  //////////////////////////////
+
+  it('should remove the BOM marker', function (done) {
+    var file = fs.readFileSync('tests/bom-utf8/starts-with-mixin-utf8-bom.scss').toString();
+    assert.equal(file.charCodeAt(0), 0xFEFF);
+    assert.notEqual(helpers.stripBom(file).charCodeAt(0), 0xFEFF);
+    done();
+  });
+
+  it('should throw an error if not passed a string', function (done) {
+    assert.throws(
+      function () {
+        helpers.stripBom(8);
+      }, Error
+    );
+    done();
+  });
+});


### PR DESCRIPTION
As discussed in #880 BOM markers in files were causing issues with the way gonzales is parsing the files we send it. This change strips any BOM markers from the files text before it is parsed.

Fixes #880 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

