### PR TITLE
Prevent checking is of undefined

### DIFF
--- a/lib/rules/space-before-colon.js
+++ b/lib/rules/space-before-colon.js
@@ -14,7 +14,7 @@ module.exports = {
       if (delimiter.content === ':') {
         var previous = parent.content[i - 1];
 
-        if (previous.is('space')) {
+        if (previous && previous.is('space')) {
           if (!parser.options.include) {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,


### PR DESCRIPTION
Fixes #878 

small update to prevent checking `is` of `null`

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

