### PR TITLE
Skip all front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ For further information you can visit our CLI documentation linked below.
 
 ---
 
+## Front matter
+
+Certain static site generators such as [Jekyll](http://jekyllrb.com/docs/frontmatter/) include the YAML front matter block at the top of their scss file. Sass-lint by default checks a file for this block and attempts to parse your Sass without this front matter. You can see an example of a front matter block below.
+
+```scss
+
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+.test {
+  color: red;
+}
+
+```
+
+---
+
 ## Contributions
 
 We welcome all contributions to this project but please do read our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/master/CONTRIBUTING.md) first, especially before opening a pull request. It would also be good to read our [code of conduct](https://github.com/sasstools/sass-lint/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/groot.js
+++ b/lib/groot.js
@@ -3,13 +3,19 @@
 //////////////////////////////
 'use strict';
 
-var gonzales = require('gonzales-pe');
+var gonzales = require('gonzales-pe'),
+    fm = require('front-matter');
 
 module.exports = function (text, syntax, filename) {
   var tree;
 
   // Run `.toString()` to allow Buffers to be passed in
   text = text.toString();
+
+  // if we're skipping front matter do it here, fall back to just our text in case it fails
+  if (fm.test(text)) {
+    text = fm(text).body || text;
+  }
 
   try {
     tree = gonzales.parse(text, {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "eslint": "^2.7.0",
+    "front-matter": "2.1.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.0",
     "globule": "^1.0.0",

--- a/tests/main.js
+++ b/tests/main.js
@@ -160,6 +160,18 @@ describe('sass lint', function () {
     });
 
     // ==============================================================================
+    //  Parse files with YAML front matter
+    // ==============================================================================
+
+    it('should parse a file with front matter correctly and without parse error', function (done) {
+      lintFile('front-matter/front-matter.scss', function (data) {
+        assert.equal(0, data.errorCount);
+        assert.equal(2, data.warningCount);
+        done();
+      });
+    });
+
+    // ==============================================================================
     //  Parse Errors should return as lint errors
     // ==============================================================================
 

--- a/tests/sass/front-matter/front-matter.scss
+++ b/tests/sass/front-matter/front-matter.scss
@@ -1,0 +1,7 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+.test {
+  color: red;
+}


### PR DESCRIPTION
Any front matter blocks such as those introduced into scss files by Jekyll will cause a Gonzales-pe parse error understandably as they aren't valid syntax. This PR tests each file and parses just the body of the file rather than the front matter block

Closes #542 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

