### PR TITLE
Fix operators in variable names

### DIFF
--- a/lib/rules/variable-name-format.js
+++ b/lib/rules/variable-name-format.js
@@ -16,8 +16,7 @@ module.exports = {
     ast.traverseByType('variable', function (variable) {
       var strippedName,
           violationMessage = false,
-          // Gonzales would parse variable names with operators without this regex i.e. '$mobile-site-gutter*1'
-          name = variable.first().content.split(/(\*|\+|\/)/)[0];
+          name = variable.first().content;
 
 
       strippedName = name;

--- a/lib/rules/variable-name-format.js
+++ b/lib/rules/variable-name-format.js
@@ -16,7 +16,9 @@ module.exports = {
     ast.traverseByType('variable', function (variable) {
       var strippedName,
           violationMessage = false,
-          name = variable.first().content;
+          // Gonzales would parse variable names with operators without this regex i.e. '$mobile-site-gutter*1'
+          name = variable.first().content.split(/(\*|\+|\/)/)[0];
+
 
       strippedName = name;
 

--- a/tests/rules/variable-name-format.js
+++ b/tests/rules/variable-name-format.js
@@ -27,7 +27,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -41,7 +41,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -55,7 +55,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -98,7 +98,7 @@ describe('variable name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -143,7 +143,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      lint.assert.equal(16, data.warningCount);
       done();
     });
   });
@@ -157,7 +157,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -171,7 +171,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });
@@ -214,7 +214,7 @@ describe('variable name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      lint.assert.equal(17, data.warningCount);
       done();
     });
   });

--- a/tests/sass/variable-name-format.sass
+++ b/tests/sass/variable-name-format.sass
@@ -19,3 +19,7 @@ $_does_NOT-fitSTANDARD: 1
 
 .class
   width: $snake_case
+
+// Issue #901 - operators not recognized as separate tokens by gonzales-pe
+.content-main
+  padding: $mobile-site-gutter*1.5

--- a/tests/sass/variable-name-format.scss
+++ b/tests/sass/variable-name-format.scss
@@ -20,3 +20,8 @@ $_does_NOT-fitSTANDARD: 1;
 .class {
   width: $snake_case;
 }
+
+// Issue #901 - operators not recognized as separate tokens by gonzales-pe
+.content-main {
+  padding: $mobile-site-gutter*1.5;
+}


### PR DESCRIPTION
If you had a variable followed by an operator i.e. `$my-var*1.5` Gonzales would report the variable name as `$my-var*1` therefore I've added a small bit of regex to split the string on these occasions which will cover the majority of problems we'd see.

fixes #901 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

