### PR TITLE
Clearer readme for configuring a rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ For all [rules](https://github.com/sasstools/sass-lint/tree/master/docs/rules), 
 
 If you want to configure options, set the rule to an array, where the first item in the array is the severity, and the second item in the array is an object including the options you would like to set.
 
-An example configuration of a rule with options look like the following:
+Here an is example configuration of a rule, where we are specifying that breaking the [indentation rule](https://github.com/sasstools/sass-lint/blob/master/docs/rules/indentation.md) should be treated as an error (its severity set to two), and setting the `size` option of the rule to 2 spaces:  
 
 ```yml
-indentation:
-  - 2
-  -
-    size: 2
+rules: 
+  indentation:
+    - 2
+    -
+      size: 2
 ```
 
 ### [Rules Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/rules)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For all [rules](https://github.com/sasstools/sass-lint/tree/master/docs/rules), 
 
 If you want to configure options, set the rule to an array, where the first item in the array is the severity, and the second item in the array is an object including the options you would like to set.
 
-Here an is example configuration of a rule, where we are specifying that breaking the [indentation rule](https://github.com/sasstools/sass-lint/blob/master/docs/rules/indentation.md) should be treated as an error (its severity set to two), and setting the `size` option of the rule to 2 spaces:  
+Here is an example configuration of a rule, where we are specifying that breaking the [indentation rule](https://github.com/sasstools/sass-lint/blob/master/docs/rules/indentation.md) should be treated as an error (its severity set to two), and setting the `size` option of the rule to 2 spaces:  
 
 ```yml
 rules: 


### PR DESCRIPTION
It took me a few minutes to figure out how to configure a rule, given that there are no complete examples of a `sass-lint.yml` (something that perhaps should be addressed?).

In particular, it wasn't clear to me that the rule configuration needs to be nested under `rules:`, or what the example config shown was doing. I've clarified both of these in this updated readme.

Hope it helps, thanks for the great project. 

DCO 1.1 Signed-off-by: James Riley <webdevjamesriley@gmail.com>
