### PR TITLE
Fix issue with non-string border zero convention value

### DIFF
--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -29,7 +29,7 @@ module.exports = {
             var node = item.content[0];
             if (node.type === 'number' || node.type === 'ident') {
               if (node.content === '0' || node.content === 'none') {
-                if (parser.options.convention !== node.content) {
+                if (('' + parser.options.convention) !== node.content) {
                   result = helpers.addUnique(result, {
                     'ruleId': parser.rule.name,
                     'line': node.start.line,

--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -29,7 +29,7 @@ module.exports = {
             var node = item.content[0];
             if (node.type === 'number' || node.type === 'ident') {
               if (node.content === '0' || node.content === 'none') {
-                if (('' + parser.options.convention) !== node.content) {
+                if (parser.options.convention.toString() !== node.content) {
                   result = helpers.addUnique(result, {
                     'ruleId': parser.rule.name,
                     'line': node.start.line,

--- a/tests/rules/border-zero.js
+++ b/tests/rules/border-zero.js
@@ -10,6 +10,20 @@ describe('border zero - scss', function () {
 
   it('[convention: 0]', function (done) {
     lint.test(file, {
+      'border-zero': [
+        1,
+        {
+          'convention': 0
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: \'0\']', function (done) {
+    lint.test(file, {
       'border-zero': 1
     }, function (data) {
       lint.assert.equal(3, data.warningCount);
@@ -39,6 +53,20 @@ describe('border zero - sass', function () {
   var file = lint.file('border-zero.sass');
 
   it('[convention: 0]', function (done) {
+    lint.test(file, {
+      'border-zero': [
+        1,
+        {
+          'convention': 0
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(3, data.warningCount);
+      done();
+    });
+  });
+
+  it('[convention: \'0\']', function (done) {
     lint.test(file, {
       'border-zero': 1
     }, function (data) {


### PR DESCRIPTION
This PR is a continuation of the fix (https://github.com/sasstools/sass-lint/pull/890) by @richarddewit for issue #861.

Closes #861 

`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`
