### PR TITLE
Remove stray console.log

### DIFF
--- a/tests/rules/declarations-before-nesting.js
+++ b/tests/rules/declarations-before-nesting.js
@@ -12,7 +12,6 @@ describe('declarations before nesting - scss', function () {
     lint.test(file, {
       'declarations-before-nesting': 1
     }, function (data) {
-      console.log(data);
       lint.assert.equal(4, data.warningCount);
       done();
     });


### PR DESCRIPTION
A stray console.log managed to get through with the declarations before nesting rule this morning. this corrects it.

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`

