### PR TITLE
Fix no duplicate properties

### DIFF
--- a/lib/rules/no-duplicate-properties.js
+++ b/lib/rules/no-duplicate-properties.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var helpers = require('../helpers');
+var selectorHelpers = require('../selector-helpers');
 
 module.exports = {
   'name': 'no-duplicate-properties',
@@ -25,8 +26,12 @@ module.exports = {
         warnMessage = false;
 
         declaration.eachFor('property', function (item) {
-          var property = item.content[0].content;
-
+          var property = '';
+          item.content.forEach(function (subItem) {
+            // Although not a selector the method here helps us construct the proper property name
+            // taking into account any interpolation etc
+            property += selectorHelpers.constructSelector(subItem);
+          });
           if (properties.indexOf(property) !== -1 && properties.length >= 1) {
             if (parser.options.exclude.indexOf(property) !== -1 && properties[properties.length - 1] !== property) {
               warnMessage = 'Excluded duplicate properties must directly follow each other.';

--- a/tests/rules/no-duplicate-properties.js
+++ b/tests/rules/no-duplicate-properties.js
@@ -12,7 +12,7 @@ describe('no duplicate properties - scss', function () {
     lint.test(file, {
       'no-duplicate-properties': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no duplicate properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -45,7 +45,7 @@ describe('no duplicate properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });
@@ -61,7 +61,7 @@ describe('no duplicate properties - sass', function () {
     lint.test(file, {
       'no-duplicate-properties': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('no duplicate properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -94,7 +94,7 @@ describe('no duplicate properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(5, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-duplicate-properties.sass
+++ b/tests/sass/no-duplicate-properties.sass
@@ -30,3 +30,13 @@
   content: 'display'
   display: flex
   display: inline-block
+
+// issue #907 - interpolation/variable in property names
+$paint-border-1: top
+$paint-border-2: left
+
+.test
+  border: $size solid transparent
+  border-#{$paint-border-1}: $size solid $color
+  border-#{$paint-border-2}: $size solid $color
+  border-#{$paint-border-2}: $size solid $color

--- a/tests/sass/no-duplicate-properties.scss
+++ b/tests/sass/no-duplicate-properties.scss
@@ -37,3 +37,14 @@
   display: inline-block;
 
 }
+
+// issue #907 - interpolation/variable in property names
+$paint-border-1: top;
+$paint-border-2: left;
+
+.test {
+  border: $size solid transparent;
+  border-#{$paint-border-1}: $size solid $color;
+  border-#{$paint-border-2}: $size solid $color;
+  border-#{$paint-border-2}: $size solid $color;
+}


### PR DESCRIPTION
Fixes and issue where the no duplicate properties rule was ignoring interpolated properties.

Fixes #907 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
