### PR TITLE
updated concentric rules to match the newest property sort order list…

### DIFF
--- a/lib/config/property-sort-orders/concentric.yml
+++ b/lib/config/property-sort-orders/concentric.yml
@@ -11,6 +11,19 @@ order:
   - 'bottom'
   - 'left'
 
+  - 'flex'
+  - 'flex-basis'
+  - 'flex-direction'
+  - 'flex-flow'
+  - 'flex-grow'
+  - 'flex-shrink'
+  - 'flex-wrap'
+  - 'align-content'
+  - 'align-items'
+  - 'align-self'
+  - 'justify-content'
+  - 'order'
+
   - 'columns'
   - 'column-gap'
   - 'column-fill'
@@ -46,6 +59,10 @@ order:
   - 'margin-left'
 
   - 'outline'
+  - 'outline-offset'
+  - 'outline-width'
+  - 'outline-style'
+  - 'outline-color'
 
   - 'border'
   - 'border-top'
@@ -79,6 +96,8 @@ order:
   - 'box-shadow'
 
   - 'background'
+  - 'background-attachment'
+  - 'background-clip'
   - 'background-color'
   - 'background-image'
   - 'background-repeat'


### PR DESCRIPTION
**What do the changes you have made achieve?**
I updated the concentric.yml to match the newest version so we can get rid of the error messages regarding flexbox properties or background-clip.

**Are there any new warning messages?**
Nope.

**Have you written tests?**
Nope.

**Have you included relevant documentation**
No, because it is jut an update of the concentric.yml

**Which issues does this resolve?**
#921

`<DCO 1.1 Signed-off-by: Lucas Jahn lucas@ludwig-jahn.com>`
