### PR TITLE
Fix false positives on variable declarations

### DIFF
--- a/lib/rules/declarations-before-nesting.js
+++ b/lib/rules/declarations-before-nesting.js
@@ -22,6 +22,14 @@ module.exports = {
           }
 
           if (item.is('declaration')) {
+            var property = item.content[0];
+
+            if (property && property.is('property')) {
+              if (property.content[0] && property.content[0].is('variable')) {
+                return;
+              }
+            }
+
             declarationIndex = j;
             declaration = item;
           }

--- a/lib/rules/no-duplicate-properties.js
+++ b/lib/rules/no-duplicate-properties.js
@@ -27,11 +27,18 @@ module.exports = {
 
         declaration.eachFor('property', function (item) {
           var property = '';
-          item.content.forEach(function (subItem) {
+
+          // Check if declaration is actually a variable declaration
+          if (item.content[0] && item.content[0].is('variable')) {
+            return;
+          }
+
+          item.forEach(function (subItem) {
             // Although not a selector the method here helps us construct the proper property name
             // taking into account any interpolation etc
             property += selectorHelpers.constructSelector(subItem);
           });
+
           if (properties.indexOf(property) !== -1 && properties.length >= 1) {
             if (parser.options.exclude.indexOf(property) !== -1 && properties[properties.length - 1] !== property) {
               warnMessage = 'Excluded duplicate properties must directly follow each other.';

--- a/tests/sass/declarations-before-nesting.sass
+++ b/tests/sass/declarations-before-nesting.sass
@@ -25,3 +25,10 @@
     content: 'baz'
 
   content: 'baz'
+
+// issue #935 - ignore variables
++foo
+  #{$bar}
+    content: 'foobar'
+
+  $baz: 'qux'

--- a/tests/sass/declarations-before-nesting.scss
+++ b/tests/sass/declarations-before-nesting.scss
@@ -33,3 +33,12 @@
 
   content: 'baz';
 }
+
+// issue #935 - ignore variables
+@mixin foo {
+  #{$bar} {
+    content: 'foobar';
+  }
+
+  $baz: 'qux';
+}

--- a/tests/sass/no-duplicate-properties.sass
+++ b/tests/sass/no-duplicate-properties.sass
@@ -40,3 +40,8 @@ $paint-border-2: left
   border-#{$paint-border-1}: $size solid $color
   border-#{$paint-border-2}: $size solid $color
   border-#{$paint-border-2}: $size solid $color
+
+// issue #935 - ignore variables
++foo
+  $i: 0
+  $i: 1

--- a/tests/sass/no-duplicate-properties.scss
+++ b/tests/sass/no-duplicate-properties.scss
@@ -48,3 +48,9 @@ $paint-border-2: left;
   border-#{$paint-border-2}: $size solid $color;
   border-#{$paint-border-2}: $size solid $color;
 }
+
+// issue #935 - ignore variables
+@mixin foo {
+  $i: 0;
+  $i: 1;
+}


### PR DESCRIPTION
This PR fixes #935 - false positives on variable declarations that were being taken as property declarations.

Fixed in both `no-duplicate-properties` and `declarations-before-nesting` rules.

`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`