### PR TITLE
Fix cli error throws

### DIFF
--- a/docs/options/max-warnings.md
+++ b/docs/options/max-warnings.md
@@ -2,6 +2,8 @@
 
 An error will be thrown if the total number of warnings exceeds the `max-warnings` setting.
 
+> Please note, if you're using this option with the sass-lint CLI and you're specifying the `--no-exit / -q` option too, you will not see an error but an error code of 1 will still be thrown.
+
 ## Examples
 
 This can be set as a command-line option:
@@ -26,4 +28,3 @@ var sassLint = require('sass-lint'),
 results = sassLint.lintFiles('sass/**/*.scss', config)
 sassLint.failOnError(results, config);
 ```
-


### PR DESCRIPTION
With the introduction of the `max-warnings` option for config files in #857 an error was introduced where any errors detected by sass-lint would always throw an unhandled exception even if the `--no-exit` / `-q` option were specified.

This was unintended.

The following should now be true for all CLI instances

* If `-q` then all unhandled errors and exits should be quiet, an error code of 1 will still be present
* If max warnings fails and the CLI is 'quiet' then no errors will be thrown but an error code of 1 will be present
* If not quiet then any errors detected (i.e. rules set to 2) will throw an exception and exit the process on the first error detected.
* If not quiet and no errors are detected but the max-warnings option is exceeded then a max-warnings exception will be thrown

@nottrobin you may want to give this a once over too as it may affect your initial intentions with the PR you made. Unfortunately without a major version bump I don't think the exact implementation of yours would work, sorry that I missed this eventuality at the time.

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
