### PR TITLE
Add an exception for partial ident in the space-around-operator rule

### DIFF
--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -144,12 +144,13 @@ var isImport = function (operator, parent) {
  * Determine if operator is part an ident
  *
  * @param {string} operator - The operator
+ * @param {Object} next - The next node
  * @param {Object} previous - The previous node
  * @returns {bool} true / false
  */
-var isPartialIdent = function (operator, previous) {
+var isPartialIdent = function (operator, next, previous) {
   if (operator === '-') {
-    return previous && previous.is('interpolation');
+    return next && previous && previous.is('interpolation');
   }
   return false;
 };
@@ -183,7 +184,7 @@ var isException = function (operator, parent, i) {
     return true;
   }
 
-  if (isPartialIdent(operator, previous)) {
+  if (isPartialIdent(operator, next, previous)) {
     return true;
   }
 

--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -35,7 +35,7 @@ var isNegativeNumber = function (operator, next, previous, doublePrevious) {
 
     // Catch the following:
     // $foo: -20;
-    if (!previous && !next.is('space')) {
+    if (!previous && next && !next.is('space')) {
       return true;
     }
 
@@ -43,7 +43,7 @@ var isNegativeNumber = function (operator, next, previous, doublePrevious) {
     // .foo {
     //   property: -16px;
     // }
-    if (next.is('dimension') || next.is('percentage')) {
+    if (next && (next.is('dimension') || next.is('percentage'))) {
       return true;
     }
 
@@ -106,7 +106,7 @@ var isUnicode = function (operator, previous) {
     // @font-face {
     //   unicode-range: U+26;
     // }
-    if (previous.is('ident') && previous.content === 'U') {
+    if (previous && previous.is('ident') && previous.content === 'U') {
       return true;
     }
   }
@@ -124,7 +124,7 @@ var isUnicode = function (operator, previous) {
 var isImport = function (operator, parent) {
   if (operator === '/') {
 
-    if (parent.is('atrule') && parent.contains('atkeyword')) {
+    if (parent && parent.is('atrule') && parent.contains('atkeyword')) {
       var keyword = parent.first('atkeyword');
 
       if (keyword.contains('ident')) {

--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -141,6 +141,18 @@ var isImport = function (operator, parent) {
 };
 
 /**
+ * Determine if operator is part an ident
+ *
+ * @param {string} operator - The operator
+ * @param {Object} next - The next node
+ * @param {Object} previous - The previous node
+ * @returns {bool} true / false
+ */
+var isPartialIdent = function (operator, next, previous) {
+  return next.is('interpolation') && previous.is('interpolation');
+};
+
+/**
  * Determine if operator is exception
  *
  * @param {string} operator - The operator
@@ -166,6 +178,10 @@ var isException = function (operator, parent, i) {
   }
 
   if (isImport(operator, parent)) {
+    return true;
+  }
+
+  if (isPartialIdent(operator, next, previous)) {
     return true;
   }
 

--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -144,12 +144,14 @@ var isImport = function (operator, parent) {
  * Determine if operator is part an ident
  *
  * @param {string} operator - The operator
- * @param {Object} next - The next node
  * @param {Object} previous - The previous node
  * @returns {bool} true / false
  */
-var isPartialIdent = function (operator, next, previous) {
-  return next.is('interpolation') && previous.is('interpolation');
+var isPartialIdent = function (operator, previous) {
+  if (operator === '-') {
+    return previous && previous.is('interpolation');
+  }
+  return false;
 };
 
 /**
@@ -181,7 +183,7 @@ var isException = function (operator, parent, i) {
     return true;
   }
 
-  if (isPartialIdent(operator, next, previous)) {
+  if (isPartialIdent(operator, previous)) {
     return true;
   }
 

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -333,6 +333,8 @@ $qux: (2  +1)
 
 $foo: scale-color($foo, $lightness: -14%)
 
+$foobar: #{$foo}-#{$bar}
+
 .foo
   top: -10px
 

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -334,6 +334,7 @@ $qux: (2  +1)
 $foo: scale-color($foo, $lightness: -14%)
 
 $foobar: #{$foo}-#{$bar}
+$foobar: #{$foo}-4
 
 .foo
   top: -10px

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -345,6 +345,8 @@ $norf: (5   %   2);
 
 $foo: scale-color($foo, $lightness: -14%);
 
+$foobar: #{$foo}-#{$bar};
+
 .foo {
   top: -10px;
 }

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -346,6 +346,7 @@ $norf: (5   %   2);
 $foo: scale-color($foo, $lightness: -14%);
 
 $foobar: #{$foo}-#{$bar};
+$foobar: #{$foo}-4;
 
 .foo {
   top: -10px;


### PR DESCRIPTION
This PR fixes #929 which was giving a false positive when a hyphen was used in-between two interpolations. Since this hyphen `-` is a partial ident, an exception has been added to the rule.

```scss
$foo: #{$a}-#{$b};
```

`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`