### PR TITLE
Fix/space around operator condition

### DIFF
--- a/lib/rules/space-around-operator.js
+++ b/lib/rules/space-around-operator.js
@@ -35,8 +35,20 @@ var isNegativeNumber = function (operator, next, previous, doublePrevious) {
 
     // Catch the following:
     // $foo: -20;
-    if (!previous && next && !next.is('space')) {
-      return true;
+    // $foo: -#{$foo}
+    // $foo: -($foo * 2)
+    // $foo: -$foo
+    if (next) {
+      if (!previous || (previous.is('space') && doublePrevious && !doublePrevious.is('number'))) {
+        if (
+          next.is('number') ||
+          next.is('interpolation') ||
+          next.is('variable') ||
+          next.is('parentheses')
+        ) {
+          return true;
+        }
+      }
     }
 
     // Catch the following:

--- a/tests/rules/space-around-operator.js
+++ b/tests/rules/space-around-operator.js
@@ -26,7 +26,7 @@ describe('space around operator - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(92, data.warningCount);
+      lint.assert.equal(94, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space around operator - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(86, data.warningCount);
+      lint.assert.equal(88, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -477,9 +477,8 @@ h1
     unicode-range: U+26
     unicode-range: U+0-7F
     unicode-range: U+0025-00FF
-    // TODO: Wildcard currently causes gonzales to fail
-    // unicode-range: U+4??;
-    // unicode-range: U+0025-00FF, U+4??;
+    unicode-range: U+4??
+    unicode-range: U+0025-00FF, U+4??
 
 // Negative numbers
 .foo
@@ -487,3 +486,27 @@ h1
 
 // Imports
 @import bar/foo
+
+@if -1
+  $bar: 1
+
+@if -$foo
+  $bar: 1
+
+@if -#{$foo}
+  $bar: 1
+
+@if -($foo * 2)
+  $bar: 1
+
+@for $i from 0 through -1
+  $bar: 1
+
+@for $i from 0 through -$foo
+  $bar: 1
+
+@for $i from 0 through -#{$foo}
+  $bar: 1
+
+@for $i from 0 through -($foo * 2)
+  $bar: 1

--- a/tests/sass/space-around-operator.scss
+++ b/tests/sass/space-around-operator.scss
@@ -495,9 +495,8 @@ $norf: (5 % 2);
   unicode-range: U+26;
   unicode-range: U+0-7F;
   unicode-range: U+0025-00FF;
-  // TODO: Wildcard currently causes gonzales to fail
-  // unicode-range: U+4??;
-  // unicode-range: U+0025-00FF, U+4??;
+  unicode-range: U+4??;
+  unicode-range: U+0025-00FF, U+4??;
 }
 
 // Negative numbers
@@ -507,3 +506,35 @@ $norf: (5 % 2);
 
 // Imports
 @import 'bar/foo';
+
+@if -1 {
+  $bar: 1;
+}
+
+@if -$foo {
+  $bar: 1;
+}
+
+@if -#{$foo} {
+  $bar: 1;
+}
+
+@if -($foo * 2) {
+  $bar: 1;
+}
+
+@for $i from 0 through -1 {
+  $bar: 1;
+}
+
+@for $i from 0 through -$foo {
+  $bar: 1;
+}
+
+@for $i from 0 through -#{$foo} {
+  $bar: 1;
+}
+
+@for $i from 0 through -($foo * 2) {
+  $bar: 1;
+}


### PR DESCRIPTION
This PR fixes #941 - an issue with negative numbers and `space-around-operator` rule.
`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`