### PR TITLE
Update Gonzales-pe parser to v4.1.1

### DIFF
--- a/lib/rules/no-mergeable-selectors.js
+++ b/lib/rules/no-mergeable-selectors.js
@@ -8,8 +8,7 @@ var mergeableNodes = ['atrule', 'include', 'ruleset'],
     curLevel = 0,
     curSelector = [],
     parentSelector = [],
-    selectorList = [],
-    syntax = '';
+    selectorList = [];
 
 
 /**
@@ -89,7 +88,6 @@ var checkAtRule = function (atRule) {
 
 /**
  * Checks an atRule to see if if it's part of our mergeable at rule list.
- * It also checks for Sass syntax as gonzales currently has issues with the syntax
  *
  * @param {object} node - The current node / atRule part of our selector
  * @returns {boolean} Whether this atRule should be merged or not
@@ -99,7 +97,7 @@ var isMergeableAtRule = function (node) {
   node.forEach(function (item) {
     // TODO Check back when Gonzales updates to fix this
     // Gonzales has issues with nest levels in media queries :(
-    if (item.is('atkeyword') && validAtRules.indexOf(item.first('ident').content) !== -1 && syntax !== 'sass') {
+    if (item.is('atkeyword') && validAtRules.indexOf(item.first('ident').content) !== -1) {
       isMergeable = true;
     }
   });
@@ -181,7 +179,6 @@ module.exports = {
     curSelector = [];
     parentSelector = [];
     selectorList = [];
-    syntax = ast.syntax;
     ast.traverseByType('stylesheet', function (styleSheet) {
       traverseBlock(styleSheet, traverseNode);
     });

--- a/lib/rules/no-universal-selectors.js
+++ b/lib/rules/no-universal-selectors.js
@@ -8,17 +8,13 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('typeSelector', function (typeSelector) {
-      typeSelector.traverse(function (item) {
-        if (item.is('ident') && item.content === '*') {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': item.start.line,
-            'column': item.start.column,
-            'message': '* (universal) selectors are not allowed',
-            'severity': parser.severity
-          });
-        }
+    ast.traverseByType('universalSelector', function (node) {
+      result = helpers.addUnique(result, {
+        'ruleId': parser.rule.name,
+        'line': node.start.line,
+        'column': node.start.column,
+        'message': '* (universal) selectors are not allowed',
+        'severity': parser.severity
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "^3.0.1",
     "glob": "^7.0.0",
     "globule": "^1.0.0",
-    "gonzales-pe": "3.4.7",
+    "gonzales-pe": "^4.1.1",
     "js-yaml": "^3.5.4",
     "lodash.capitalize": "^4.1.0",
     "lodash.kebabcase": "^4.0.0",

--- a/tests/rules/attribute-quotes.js
+++ b/tests/rules/attribute-quotes.js
@@ -12,7 +12,7 @@ describe('attribute-quotes - scss', function () {
     lint.test(file, {
       'attribute-quotes': 1
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('attribute-quotes - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -42,7 +42,7 @@ describe('attribute-quotes - sass', function () {
     lint.test(file, {
       'attribute-quotes': 1
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('attribute-quotes - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });

--- a/tests/rules/force-pseudo-nesting.js
+++ b/tests/rules/force-pseudo-nesting.js
@@ -28,8 +28,7 @@ describe('force pseudo nesting - sass', function () {
     lint.test(file, {
       'force-pseudo-nesting': 1
     }, function (data) {
-      // Should be 6 once the gonzales parse error is fixed see https://github.com/sasstools/sass-lint/issues/271
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });

--- a/tests/rules/no-attribute-selectors.js
+++ b/tests/rules/no-attribute-selectors.js
@@ -12,7 +12,7 @@ describe('no attribute selectors - scss', function () {
     lint.test(file, {
       'no-attribute-selectors': 1
     }, function (data) {
-      lint.assert.equal(18, data.warningCount);
+      lint.assert.equal(21, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no attribute selectors - sass', function () {
     lint.test(file, {
       'no-attribute-selectors': 1
     }, function (data) {
-      lint.assert.equal(18, data.warningCount);
+      lint.assert.equal(21, data.warningCount);
       done();
     });
   });

--- a/tests/rules/no-mergeable-selectors.js
+++ b/tests/rules/no-mergeable-selectors.js
@@ -32,7 +32,6 @@ describe('no mergeable selectors - scss', function () {
 
 });
 
-// 1 less warning than scss syntax as we dont attempt to merge media queries
 describe('no mergeable selectors - sass', function () {
   var file = lint.file('no-mergeable-selectors.sass');
 
@@ -40,12 +39,11 @@ describe('no mergeable selectors - sass', function () {
     lint.test(file, {
       'no-mergeable-selectors': 1
     }, function (data) {
-      lint.assert.equal(21, data.warningCount);
+      lint.assert.equal(22, data.warningCount);
       done();
     });
   });
 
-  // 1 less warning than scss syntax as we dont attempt to merge media queries
   it('[whitelist: div p]', function (done) {
     lint.test(file, {
       'no-mergeable-selectors': [
@@ -57,7 +55,7 @@ describe('no mergeable selectors - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(20, data.warningCount);
+      lint.assert.equal(21, data.warningCount);
       done();
     });
   });

--- a/tests/rules/space-around-operator.js
+++ b/tests/rules/space-around-operator.js
@@ -42,7 +42,7 @@ describe('space around operator - sass', function () {
     lint.test(file, {
       'space-around-operator': 1
     }, function (data) {
-      lint.assert.equal(88, data.warningCount);
+      lint.assert.equal(92, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space around operator - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(88, data.warningCount);
+      lint.assert.equal(94, data.warningCount);
       done();
     });
   });

--- a/tests/rules/url-quotes.js
+++ b/tests/rules/url-quotes.js
@@ -12,7 +12,7 @@ describe('url quotes - scss', function () {
     lint.test(file, {
       'url-quotes': 1
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(1, data.warningCount);
       done();
     });
   });

--- a/tests/sass/attribute-quotes.sass
+++ b/tests/sass/attribute-quotes.sass
@@ -11,18 +11,17 @@ span[lang=pt]
 span[lang~=en-us]
   color: blue
 
-// TODO currently a parse error in gonzales-pe
-// span[lang|="zh"] {color: red;}
-
-// TODO currently a parse error in gonzales-pe
-// a[href^=#] {
-//   background-color: gold;
-// }
+span[lang|=zh]
+  color: red
 
 span[class^=main]
   background-color: yellow
 
-// TODO currently a parse error in gonzales-pe
+// Invalid CSS - must be ident or string
+// a[href^=#] {
+//   background-color: gold;
+// }
+//
 // a[href$=.cn] {
 //   color: red;
 // }
@@ -43,14 +42,14 @@ span[lang="pt"]
 span[lang~="en-us"]
   color: blue
 
-// TODO currently a parse error in gonzales-pe
-// span[lang|="zh"] {color: red;}
-
-a[href^="#"]
-  background-color: gold
+span[lang|="zh"]
+  color: red
 
 span[class^="main"]
   background-color: yellow
+
+a[href^="#"]
+  background-color: gold
 
 a[href$=".cn"]
   color: red

--- a/tests/sass/attribute-quotes.scss
+++ b/tests/sass/attribute-quotes.scss
@@ -14,19 +14,19 @@ span[lang~=en-us] {
   color: blue;
 }
 
-// TODO currently a parse error in gonzales-pe
-// span[lang|="zh"] {color: red;}
-
-// TODO currently a parse error in gonzales-pe
-// a[href^=#] {
-//   background-color: gold;
-// }
+span[lang|=zh] {
+  color: red;
+}
 
 span[class^=main] {
   background-color: yellow;
 }
 
-// TODO currently a parse error in gonzales-pe
+// Invalid CSS - must be ident or string
+// a[href^=#] {
+//   background-color: gold;
+// }
+//
 // a[href$=.cn] {
 //   color: red;
 // }
@@ -51,15 +51,16 @@ span[lang~="en-us"] {
   color: blue;
 }
 
-// TODO currently a parse error in gonzales-pe
-// span[lang|="zh"] {color: red;}
-
-a[href^="#"] {
-  background-color: gold;
+span[lang|="zh"] {
+  color: red;
 }
 
 span[class^="main"] {
   background-color: yellow;
+}
+
+a[href^="#"] {
+  background-color: gold;
 }
 
 a[href$=".cn"] {

--- a/tests/sass/extends-before-mixins.sass
+++ b/tests/sass/extends-before-mixins.sass
@@ -12,4 +12,3 @@
   @extend %waldo
   +foo
   @extend %qux
-

--- a/tests/sass/force-pseudo-nesting.sass
+++ b/tests/sass/force-pseudo-nesting.sass
@@ -23,11 +23,10 @@ p::first-line
   color: #ff0000
   font-variant: small-caps
 
-// FIXME parsing issue in Gonzales-Pe see https://github.com/sasstools/sass-lint/issues/271
-// .parent
-//   .child
-//     p::first-line
-//       color: #ff0000
+.parent
+  .child
+    p::first-line
+      color: #ff0000
 
 .parent
   .child

--- a/tests/sass/indentation/indentation-spaces.sass
+++ b/tests/sass/indentation/indentation-spaces.sass
@@ -33,9 +33,10 @@ $foo: ('foo': 'bar', 'bar': ('foo': 'bze'))
     @if (1 == 1)
         content: 'foo'
 
-=bar
-    content: 'bar'
-	content: 'baz'
+// TODO: Considered invalid Sass - re-evaluate
+// =bar
+//     content: 'bar'
+// 	content: 'baz'
 
 .color
   color: rgba(255, 255, 255, 0.3)
@@ -100,8 +101,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
       #unit
         margin: 16px
 
-// Gonzales issue with media queries
-// .test
-//   @media (max-width: 800px), (max-height: 600px)
-//         #unit
-//           margin: 16px
+.test
+  @media (max-width: 800px), (max-height: 600px)
+        #unit
+          margin: 16px

--- a/tests/sass/indentation/indentation-tabs.sass
+++ b/tests/sass/indentation/indentation-tabs.sass
@@ -33,9 +33,10 @@ $foo: ('foo': 'bar', 'bar': ('foo': 'bze'))
 		@if (1 == 1)
 				content: 'foo'
 
-=bar
-		content: 'bar'
-  content: 'baz'
+// TODO: Considered invalid Sass - re-evaluate
+// =bar
+// 		content: 'bar'
+//   content: 'baz'
 
 .color
 	color: rgba(255, 255, 255, 0.3)
@@ -100,8 +101,7 @@ $colors: (base: (red: #fff, blue: #fff), text: (default: #fff, light: (brap: #98
 			#unit
 				margin: 16px
 
-// Gonzales issue with media queries
-// .test
-// 	@media (max-width: 800px), (max-height: 600px)
-// 			#unit
-// 				margin: 16px
+.test
+	@media (max-width: 800px), (max-height: 600px)
+				#unit
+					margin: 16px

--- a/tests/sass/mixins-before-declarations.sass
+++ b/tests/sass/mixins-before-declarations.sass
@@ -56,14 +56,13 @@
 
 // added from issue #227 https://github.com/sasstools/sass-lint/issues/227
 
-// FIXME: Currently causes a parse error with gonzales. Ok if mixin is within
-// class
+@include hello
 
-// @media (min-width: 50em)
-//   +hello
-//
-// @supports (display: flex)
-//   +hello
-//
-// @at-root
-//   +hello
+@media (min-width: 50em)
+  +hello
+
+@supports (display: flex)
+  +hello
+
+@at-root
+  +hello

--- a/tests/sass/no-attribute-selectors.sass
+++ b/tests/sass/no-attribute-selectors.sass
@@ -10,10 +10,8 @@
 [attr~=value]
   content: 'baz'
 
-// TODO: Uncomment once gonzale-pe issue fixed
-// https://github.com/tonyganch/gonzales-pe/issues/174
-// [attr|=value]
-//   content: 'qux'
+[attr|=value]
+  content: 'qux'
 
 [attr^=value]
   content: 'norf'
@@ -36,10 +34,8 @@
 .foo [attr~=value]
   content: 'baz'
 
-// TODO: Uncomment once gonzale-pe issue fixed
-// https://github.com/tonyganch/gonzales-pe/issues/174
-// .foo [attr|=value]
-//   content: 'qux'
+.foo [attr|=value]
+  content: 'qux'
 
 .foo [attr^=value]
   content: 'norf'
@@ -62,10 +58,8 @@
 .foo[attr~=value]
   content: 'baz'
 
-// TODO: Uncomment once gonzale-pe issue fixed
-// https://github.com/tonyganch/gonzales-pe/issues/174
-// .foo[attr|=value]
-//   content: 'qux'
+.foo[attr|=value]
+  content: 'qux'
 
 .foo[attr^=value]
   content: 'norf'

--- a/tests/sass/no-attribute-selectors.scss
+++ b/tests/sass/no-attribute-selectors.scss
@@ -13,11 +13,9 @@
   content: 'baz';
 }
 
-// TODO: Uncomment once gonzale-pe issue fixed
-// https://github.com/tonyganch/gonzales-pe/issues/174
-// [attr|=value] {
-//   content: 'qux';
-// }
+[attr|=value] {
+  content: 'qux';
+}
 
 [attr^=value] {
   content: 'norf';
@@ -46,11 +44,9 @@
   content: 'baz';
 }
 
-// TODO: Uncomment once gonzale-pe issue fixed
-// https://github.com/tonyganch/gonzales-pe/issues/174
-// .foo [attr|=value] {
-//   content: 'qux';
-// }
+.foo [attr|=value] {
+  content: 'qux';
+}
 
 .foo [attr^=value] {
   content: 'norf';
@@ -79,11 +75,9 @@
   content: 'baz';
 }
 
-// TODO: Uncomment once gonzale-pe issue fixed
-// https://github.com/tonyganch/gonzales-pe/issues/174
-// .foo[attr|=value] {
-//   content: 'qux';
-// }
+.foo[attr|=value] {
+  content: 'qux';
+}
 
 .foo[attr^=value] {
   content: 'norf';

--- a/tests/sass/no-mergeable-selectors.sass
+++ b/tests/sass/no-mergeable-selectors.sass
@@ -170,10 +170,10 @@ ul ~ p
   .bar
     color: red
 
-// // make sure a selector inside a supports query is not marked as mergable
-// @supports (display: flex)
-//   .bar
-//     display: flex
+// make sure a selector inside a supports query is not marked as mergable
+@supports (display: flex)
+  .bar
+    display: flex
 
 //make sure a low level selector doesn't flag with a nested selector above
 .bar
@@ -197,11 +197,6 @@ ul ~ p
 .bar
   @media (max-width: 40em) and (min-width: 20em) and (orientation: landscape)
     content: ''
-
-// //////////////////////////////////////////////////////////////////////////////////////////////////
-// THE FOLLOWING WILL BE MANUALLY IGNORED BY THE RULE DUE TO GONZALES ISSUE WITH MEDIA QUERY NESTING
-// /////////////////////////////////////////////////////////////////////////////////////////////////
-
 
 // shouldn't merge with the previous bar above
 %bar
@@ -228,26 +223,23 @@ ul ~ p
   .bar
     content: ''
 
-// CRASHES GONZALES
-// // Adds keyframes blocks
-// =keyframes($name)
-//   @keyframes #{$name}
-//     @content
+// Adds keyframes blocks
+=keyframes($name)
+  @keyframes #{$name}
+    @content
 
 // keyframes should be ignored completely
-// +keyframes(fade-in)
-//   0%
-//     opacity: 0
-//
-//   100%
-//     opacity: 1
-//
-//
-// +keyframes(fade-out)
-//   0%
-//     opacity: 1
-//
-//   100%
-//     opacity: 1
++keyframes(fade-in)
+  0%
+    opacity: 0
 
-// Issue #703 - Interpolation in selector - ignored in Sass syntax for now due to gonzales issue
+  100%
+    opacity: 1
+
+
++keyframes(fade-out)
+  0%
+    opacity: 1
+
+  100%
+    opacity: 1

--- a/tests/sass/space-around-operator.sass
+++ b/tests/sass/space-around-operator.sass
@@ -41,7 +41,7 @@ $foo: 1 +1
 $bar: 2 -1
 $baz: 1 /2
 $qux: 2 *1
-// $norf: 5 %2 FIXME: Gonzales - FIXED IN BETA
+$norf: 5 %2
 
 
 // No space before
@@ -59,7 +59,7 @@ $foo: 1     +    1
 $bar: 2 +   1
 $baz: 1     + 2
 $qux: 2  +1
-// $norf: 5  %    2 FIXME: Gonzales - FIXED IN BETA
+$norf: 5  %    2
 
 // No space with parens
 
@@ -76,7 +76,7 @@ $foo: (1 +1)
 $bar: (2 -1)
 $baz: (1 /2)
 $qux: (2 *1)
-// $norf: (5 %2) FIXME: Gonzales - FIXED IN BETA
+$norf: (5 %2)
 
 
 // No space before with parens
@@ -94,7 +94,7 @@ $foo: (1     +    1)
 $bar: (2 +   1)
 $baz: (1     + 2)
 $qux: (2  +1)
-// $norf: (5   %   2) FIXME: Gonzales - FIXED IN BETA
+$norf: (5   %   2)
 
 
 
@@ -400,7 +400,7 @@ $foo: 1 + 1
 $bar: 2 - 1
 $baz: 1 / 2
 $qux: 2 * 1
-// $norf: 5 % 2 FIXME: Gonzales - FIXED IN BETA
+$norf: 5 % 2
 
 // Values with parens
 
@@ -408,7 +408,7 @@ $foo: (1 + 1)
 $bar: (2 - 1)
 $baz: (1 / 2)
 $qux: (2 * 1)
-// $norf: (5 % 2) FIXME: Gonzales - FIXED IN BETA
+$norf: (5 % 2)
 
 // Space with no parens
 

--- a/tests/sass/url-quotes.sass
+++ b/tests/sass/url-quotes.sass
@@ -12,9 +12,5 @@ $foo: 'foo.png'
   background-image: url($foo)
 
 
-// FIXME: Issue with Gonzales parser
-// .qux
-//   background-image: url('bar/' + $foo)
-//
-// .norf
-//   background-image: url(bar/ + $foo)
+.qux
+  background-image: url('bar/' + $foo)

--- a/tests/sass/url-quotes.scss
+++ b/tests/sass/url-quotes.scss
@@ -15,7 +15,3 @@ $foo: 'foo.png';
 .qux {
   background-image: url('bar/' + $foo);
 }
-
-.norf {
-  background-image: url(bar/ + $foo);
-}


### PR DESCRIPTION
~~This PR is a placeholder for updating to Gonzales v4 as there are still a few new bugs introduced on the parser side.~~

### Update

This PR is finally good to go. Many bugs have been fixed within the gonzales-pe parser and all sass-lint tests are now working.

Changes:
- Update package dependancy to `gonzales-pe@v4.1.1`
- Uncomment previously broken tests
- Refactor rules for breaking changes

`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`