### PR TITLE
Don't ignore comments in no-empty-rulesets

### DIFF
--- a/lib/rules/no-empty-rulesets.js
+++ b/lib/rules/no-empty-rulesets.js
@@ -18,7 +18,9 @@ module.exports = {
       else {
         block.traverse(function (item) {
           if (!helpers.isEqual(block, item)) {
-            if (item.type !== 'space') {
+            if (item.type !== 'space' &&
+                item.type !== 'singlelineComment' &&
+                item.type !== 'multilineComment') {
               nonSpaceCount++;
             }
           }

--- a/tests/rules/no-empty-rulesets.js
+++ b/tests/rules/no-empty-rulesets.js
@@ -12,7 +12,7 @@ describe('no empty rulesets - scss', function () {
     lint.test(file, {
       'no-empty-rulesets': 1
     }, function (data) {
-      lint.assert.equal(3, data.warningCount);
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-empty-rulesets.scss
+++ b/tests/sass/no-empty-rulesets.scss
@@ -9,3 +9,10 @@
 }
 
 .bar{}
+
+.baz {
+	// a comment
+	/* and
+	   yet
+	   another */
+}


### PR DESCRIPTION
This commit makes the `no-empty-rulesets` rule trigger when a ruleset
contains only comments.

Closes #968.

`DCO 1.1 Signed-off-by: Joe Einertson <jeinerts@umm>`