### PR TITLE
Throw error if loadConfig cannot find file by path

### DIFF
--- a/lib/config-helpers.js
+++ b/lib/config-helpers.js
@@ -56,6 +56,9 @@ var loadConfig = function (cPath) {
     if (fs.existsSync(configPath)) {
       resolvedConfig = yaml.safeLoad(fs.readFileSync(configPath, 'utf8')) || {};
     }
+    else {
+      throw new Error('Cannot find configPath ' + configPath);
+    }
   }
 
   return {

--- a/tests/config-helpers.js
+++ b/tests/config-helpers.js
@@ -78,8 +78,8 @@ describe('config-helpers', function () {
       done();
     });
 
-    it('should return an empty config when an incorrect path is provided', function (done) {
-      var testConfig = configHelpers.loadConfig('tests/yml/non-existant.yml');
+    it('should return an empty config when no path is provided', function (done) {
+      var testConfig = configHelpers.loadConfig('');
 
       assert(equal(emptyConfig, testConfig, {
         'strict': true
@@ -93,6 +93,16 @@ describe('config-helpers', function () {
       assert(equal(emptyConfig, testConfig, {
         'strict': true
       }));
+      done();
+    });
+
+    it('should throw an error when an incorrect path is provided', function (done) {
+      assert.throws(
+        function () {
+          configHelpers.loadConfig('tests/yml/non-existant.yml');
+        },
+        'Cannot find configPath tests/yml/non-existant.yml'
+      );
       done();
     });
   });

--- a/tests/failures.js
+++ b/tests/failures.js
@@ -27,7 +27,7 @@ describe('failures', function () {
   it('should not raise error if indentation is only set to warn', function (done) {
     // These should produce 55 warnings and 0 errors
     var directResults = lint.lintFiles('sass/indentation/indentation-spaces.scss', {rules: {indentation: 1}});
-    var configResults = lint.lintFiles('sass/indentation/indentation-spaces.scss', {}, 'yml/.indentation-warn.yml');
+    var configResults = lint.lintFiles('sass/indentation/indentation-spaces.scss', {}, 'tests/yml/.indentation-warn.yml');
     lint.failOnError(directResults);
     lint.failOnError(configResults);
 
@@ -75,7 +75,7 @@ describe('failures', function () {
   it('should not raise error if warnings do not exceed `max-warnings` setting', function (done) {
     var results = lint.lintFiles('sass/indentation/indentation-spaces.scss', {});  // 55 warnings
     lint.failOnError(results, {'max-warnings': 100}); // should succceed
-    lint.failOnError(results, {}, 'yml/.max-100-warnings.yml'); // should succeed
+    lint.failOnError(results, {}, 'tests/yml/.max-100-warnings.yml'); // should succeed
 
     done();
   });
@@ -83,7 +83,7 @@ describe('failures', function () {
   it('should not raise error if no warnings even if `max-warnings` is zero', function (done) {
     var results = lint.lintFiles('sass/success.scss', {});  // no warnings
     lint.failOnError(results, {'max-warnings': 0}); // should still succceed
-    lint.failOnError(results, {}, 'yml/.max-0-warnings.yml'); // should still succeed
+    lint.failOnError(results, {}, 'tests/yml/.max-0-warnings.yml'); // should still succeed
 
     done();
   });


### PR DESCRIPTION
If given a path to a file that doesn't exist, sass-lint should throw an
error to let the user know it cannot find the config file. Otherwise the
user will have no idea that the default config is being used and theirs
is being ignored.

When not given a config path, continue as usual: return an empty config.

This also fixes relative path issues in the failures test suite.

<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

---

**What do the changes you have made achieve?**

They let the user know if the given path to a config file does not exist instead of silently returning an empty config.

**Are there any new warning messages?**

Yes: 1 new `Error` thrown.

```
> confHelpers.loadConfig('notexist.yml')
Error: Cannot find configPath notexist.yml
    at [stack trace...]
```

**Have you written tests?**

Yes, and fixed the config file paths in `tests/failures.js`.

**Have you included relevant documentation**

No: I think the error thrown should be the natural result of giving an incorrect filepath, rather than a "new feature".

**Which issues does this resolve?**

Fixes #1006

`<DCO 1.1 Signed-off-by: Henry Blyth <blyth.henry@gmail.com>`
