### PR TITLE
remove text-fill-color from properties

### DIFF
--- a/data/properties.yml
+++ b/data/properties.yml
@@ -516,7 +516,6 @@ text-emphasis
 text-emphasis-color
 text-emphasis-position
 text-emphasis-style
-text-fill-color
 text-height
 text-indent
 text-justify


### PR DESCRIPTION
It is not a standard property, and autoprefixer does not treat it as such, and it does not get prefixed, thus the no-vendor-prefixes rule fails.
https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-fill-color

<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

**What do the changes you have made achieve?**

**Are there any new warning messages?**

**Have you written tests?**

**Have you included relevant documentation**

**Which issues does this resolve?**

`<DCO 1.1 Signed-off-by: YOUR_FULL_NAME YOUR_EMAIL>`
