### PR TITLE
Whitelist files published to npmjs - Closes #986.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
   "bin": {
     "sass-lint": "./bin/sass-lint.js"
   },
+  "files": [
+    "src",
+    "bin",
+    "data",
+    "lib",
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/sasstools/sass-lint.git"


### PR DESCRIPTION
Closes #986

**What do the changes you have made achieve?**
Limits the files published to npmjs to only those required to run `sass-lint`, not the ones needed to develop `sass-lint`.

**Are there any new warning messages?**
None have been added.

**Have you written tests?**
No tests have been added.

**Have you included relevant documentation**
Not sure what documentation would need to be updated.

**Which issues does this resolve?**
This reduces the size on `sass-lint` on npmjs from 15MB to 13MB. The majority of the size comes from:
```
 4.8M	node_modules/lodash
4.9M	node_modules/globule
```

`<DCO 1.1 Signed-off-by: jake champion me@jakechampion.name>`
