### PR TITLE
update quotes rule to support specific value for attribute selectors 

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,10 +1,12 @@
 # Quotes
 
 Rule `quotes` will enforce whether single quotes (`''`) or double quotes (`""`) should be used for all strings.
+You can specify a different value for attribute selectors.
 
 ## Options
 
 * `style`: `single`/`double` (defaults to `single`)
+* `attribute`: `single`/`double` (defaults to `single`)
 
 ## Examples
 
@@ -21,5 +23,21 @@ When `style: double`, the following are allowed. When `style: single`, the follo
 ```scss
 .foo {
   content: "bar";
+}
+```
+
+When `attribute: single`, the following are allowed. When `attribute: double`, the following are disallowed:
+
+```scss
+[class='foo'] {
+  color: red;
+}
+```
+
+When `attribute: double`, the following are allowed. When `attribute: single`, the following are disallowed:
+
+```scss
+[class="foo"] {
+  color: red;
 }
 ```

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -5,12 +5,13 @@ var helpers = require('../helpers');
 module.exports = {
   'name': 'quotes',
   'defaults': {
-    'style': 'single'
+    'style': 'single',
+    'attribute': 'single'
   },
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByType('string', function (node) {
+    ast.traverseByType('string', function (node, index, parent) {
       var firstQuote = node.content.charAt(0),
           lastQuote = node.content.charAt(node.content.length - 1);
 
@@ -24,7 +25,11 @@ module.exports = {
         });
       }
 
-      if (parser.options.style === 'single' && firstQuote !== '\'') {
+      var quotesStyle = (parent.type === 'attributeValue') ?
+        parser.options.attribute :
+        parser.options.style;
+
+      if (quotesStyle === 'single' && firstQuote !== '\'') {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': node.start.line,
@@ -33,7 +38,7 @@ module.exports = {
           'severity': parser.severity
         });
       }
-      else if (parser.options.style === 'double' && firstQuote !== '"') {
+      else if (quotesStyle === 'double' && firstQuote !== '"') {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
           'line': node.start.line,

--- a/tests/rules/quotes.js
+++ b/tests/rules/quotes.js
@@ -8,16 +8,16 @@ var lint = require('./_lint');
 describe('quotes - scss', function () {
   var file = lint.file('quotes.scss');
 
-  it('[style: single]', function (done) {
+  it('[style: single, attribute: single]', function (done) {
     lint.test(file, {
       'quotes': 1
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
 
-  it('[style: double]', function (done) {
+  it('[style: double, attribute: double]', function (done) {
     lint.test(file, {
       'quotes': [
         1,
@@ -26,7 +26,36 @@ describe('quotes - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: single, attribute: double]', function (done) {
+    lint.test(file, {
+      'quotes': [
+        1,
+        {
+          'attribute': 'double'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: double, attribute: single]', function (done) {
+    lint.test(file, {
+      'quotes': [
+        1,
+        {
+          'style': 'double',
+          'attribute': 'single'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
@@ -38,16 +67,16 @@ describe('quotes - scss', function () {
 describe('quotes - sass', function () {
   var file = lint.file('quotes.sass');
 
-  it('[style: single]', function (done) {
+  it('[style: single, attribute: single]', function (done) {
     lint.test(file, {
       'quotes': 1
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });
 
-  it('[style: double]', function (done) {
+  it('[style: double, attribute: double]', function (done) {
     lint.test(file, {
       'quotes': [
         1,
@@ -56,7 +85,36 @@ describe('quotes - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(2, data.warningCount);
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: single, attribute: double]', function (done) {
+    lint.test(file, {
+      'quotes': [
+        1,
+        {
+          'attribute': 'double'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
+      done();
+    });
+  });
+
+  it('[style: double, attribute: single]', function (done) {
+    lint.test(file, {
+      'quotes': [
+        1,
+        {
+          'style': 'double',
+          'attribute': 'single'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(6, data.warningCount);
       done();
     });
   });

--- a/tests/sass/quotes.sass
+++ b/tests/sass/quotes.sass
@@ -12,3 +12,15 @@
 
 .qux
   background-image: url("/foo/img.png")
+
+[foo='foo']
+  content: 'hello'
+
+[bar="bar"]
+  content: "hello"
+
+[baz="baz"]
+  content: 'hello'
+
+[qux='qux']
+  content: "hello"

--- a/tests/sass/quotes.scss
+++ b/tests/sass/quotes.scss
@@ -13,3 +13,19 @@
 .qux {
   background-image: url("/foo/img.png");
 }
+
+[foo='foo'] {
+  content: 'hello';
+}
+
+[bar="bar"] {
+  content: "hello";
+}
+
+[baz="baz"] {
+  content: 'hello';
+}
+
+[qux='qux'] {
+  content: "hello";
+}


### PR DESCRIPTION
Closes #1017

Single quotes is a best practice.
But, for attribute selectors, it would be nice to be able to use double quotes.

I added a new `attribute` property with `single` as default value (to keep backward compatibility despite I think that `double` would have been better).

- **Are there any new warning messages?**: no
- **Have you written tests?**: yes
- **Have you included relevant documentation**: yes
- **Which issues does this resolve?**: #1017

`<DCO 1.1 Signed-off-by: Thierry Michel thmichel@gmail.com>`
