### PR TITLE
mixin-name-format should not warn on @include

### DIFF
--- a/docs/rules/mixin-name-format.md
+++ b/docs/rules/mixin-name-format.md
@@ -25,11 +25,6 @@ When enabled, the following are allowed:
 @mixin _leading-underscore() {
   content: '';
 }
-
-.foo {
-  @include hyphenated-lowercase();
-}
-
 ```
 
 When enabled, the following are disallowed:
@@ -41,10 +36,6 @@ When enabled, the following are disallowed:
 
 @mixin _camelCaseWithLeadingUnderscore() {
   content: '';
-}
-
-.foo {
-  @include snake_case();
 }
 ```
 
@@ -60,10 +51,6 @@ When enabled, the following are allowed:
 @mixin camelCase() {
   content: '';
 }
-
-.foo {
-  @include anotherCamelCase();
-}
 ```
 
 When enabled, the following are disallowed:
@@ -75,10 +62,6 @@ When enabled, the following are disallowed:
 
 @mixin _camelCaseWithLeadingUnderscore() {
   content: '';
-}
-
-.foo {
-  @include snake_case();
 }
 ```
 
@@ -94,10 +77,6 @@ When enabled, the following are allowed:
 @mixin PascalCase() {
   content: '';
 }
-
-.foo {
-  @include AnotherPascalCase();
-}
 ```
 
 When enabled, the following are disallowed:
@@ -109,10 +88,6 @@ When enabled, the following are disallowed:
 
 @mixin _camelCaseWithLeadingUnderscore() {
   content: '';
-}
-
-.foo {
-  @include snake_case();
 }
 ```
 
@@ -128,10 +103,6 @@ When enabled, the following are allowed:
 @mixin snake_case() {
   content: '';
 }
-
-.foo {
-  @include another_snake_case();
-}
 ```
 
 When enabled, the following are disallowed:
@@ -143,10 +114,6 @@ When enabled, the following are disallowed:
 
 @mixin _snake_case_with_leading_underscore() {
   content: '';
-}
-
-.foo {
-  @include camelCase();
 }
 ```
 
@@ -177,10 +144,6 @@ When enabled, the following are disallowed:
 @mixin HYPHENATED-UPPERCASE {
   content: '';
 }
-
-.foo {
-  @include camelCase();
-}
 ```
 
 ## Example 6
@@ -210,10 +173,6 @@ When enabled, the following are disallowed:
 @mixin HYPHENATED-UPPERCASE {
   content: '';
 }
-
-.foo {
-  @include camelCase();
-}
 ```
 
 
@@ -230,10 +189,6 @@ When enabled, the following are allowed:
 @mixin SCREAMING_SNAKE_CASE() {
   content: '';
 }
-
-.foo {
-  @include _LEADING_UNDERSCORE();
-}
 ```
 
 When enabled, the following are disallowed:
@@ -247,9 +202,5 @@ When enabled, the following are disallowed:
 
 @mixin _snake_case_with_leading_underscore() {
   content: '';
-}
-
-.foo {
-  @include camelCase();
 }
 ```

--- a/lib/rules/mixin-name-format.js
+++ b/lib/rules/mixin-name-format.js
@@ -12,29 +12,13 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByTypes(['mixin', 'include'], function (node) {
+    ast.traverseByType('mixin', function (node) {
       var name,
           strippedName,
           violationMessage = false;
 
-      if (node.is('mixin')) {
-        if (node.contains('ident')) {
-          name = node.first('ident').content;
-        }
-      }
-      else {
-        // We're not linting extends here
-        if (node.contains('atkeyword')) {
-          if (node.first('atkeyword').contains('ident')) {
-            if (node.first('atkeyword').first('ident').content === 'extend') {
-              return false;
-            }
-          }
-        }
-
-        if (node.contains('ident')) {
-          name = node.first('ident').content;
-        }
+      if (node.contains('ident')) {
+        name = node.first('ident').content;
       }
 
       if (name) {

--- a/tests/rules/mixin-name-format.js
+++ b/tests/rules/mixin-name-format.js
@@ -2,6 +2,51 @@
 
 var lint = require('./_lint');
 
+var SCSS_MIXIN_LINES = [1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61, 65];
+var SASS_MIXIN_LINES = [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 40, 43, 46, 49];
+
+var remove = function (arr, what) {
+  var index = arr.indexOf(what);
+
+  if (index > -1) {
+    arr.splice(index, 1);
+  }
+};
+
+var expectWarningOnlyOnLines = function (lines, data) {
+  var actualLines;
+
+  lint.assert(data.warningCount <= lines.length, 'There are more warnings (' + data.warningCount + ') than expected (' + lines.length + ')');
+
+  actualLines = data.messages.map(function (message) {
+    return message.line;
+  });
+
+  actualLines.forEach(function (line) {
+    remove(lines, line);
+  });
+
+  lint.assert(lines.length === 0, 'Expected warnings on lines ' + lines.join(', ') + '. Warnings were on lines ' + actualLines.join(', '));
+};
+
+var mixinLinesExcept = function (TYPE, exceptions) {
+  var lines = TYPE.slice(0);
+
+  exceptions.forEach(function (exception) {
+    remove(lines, exception);
+  });
+
+  return lines;
+};
+
+var scssMixinLinesExcept = function (exceptions) {
+  return mixinLinesExcept(SCSS_MIXIN_LINES, exceptions);
+};
+
+var sassMixinLinesExcept = function (exceptions) {
+  return mixinLinesExcept(SASS_MIXIN_LINES, exceptions);
+};
+
 describe('mixin name format - scss', function () {
   var file = lint.file('mixin-name-format.scss');
 
@@ -9,7 +54,7 @@ describe('mixin name format - scss', function () {
     lint.test(file, {
       'mixin-name-format': 1
     }, function (data) {
-      lint.assert.equal(14, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([1, 25, 29, 49]), data);
       done();
     });
   });
@@ -23,7 +68,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([9, 29]), data);
       done();
     });
   });
@@ -37,7 +82,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(17, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([13]), data);
       done();
     });
   });
@@ -51,7 +96,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([5, 29, 33, 37, 41, 45, 53]), data);
       done();
     });
   });
@@ -65,7 +110,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([1, 5, 25, 29, 33, 37, 41, 53]), data);
       done();
     });
   });
@@ -79,7 +124,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([1, 25, 29, 37, 49, 53, 57, 61]), data);
       done();
     });
   });
@@ -94,7 +139,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(17, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([21]), data);
       done();
     });
   });
@@ -108,7 +153,7 @@ describe('mixin name format - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      expectWarningOnlyOnLines(scssMixinLinesExcept([1, 29, 49]), data);
       done();
     });
   });
@@ -121,7 +166,7 @@ describe('mixin name format - sass', function () {
     lint.test(file, {
       'mixin-name-format': 1
     }, function (data) {
-      lint.assert.equal(14, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([1, 19, 22, 37]), data);
       done();
     });
   });
@@ -135,7 +180,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(16, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([7, 22]), data);
       done();
     });
   });
@@ -149,7 +194,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([4, 22, 25, 28, 31, 34, 40]), data);
       done();
     });
   });
@@ -163,7 +208,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(17, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([10]), data);
       done();
     });
   });
@@ -177,7 +222,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([1, 4, 19, 22, 25, 28, 31, 40]), data);
       done();
     });
   });
@@ -191,7 +236,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(10, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([1, 19, 22, 28, 37, 40, 43, 46]), data);
       done();
     });
   });
@@ -206,7 +251,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(17, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([16]), data);
       done();
     });
   });
@@ -220,7 +265,7 @@ describe('mixin name format - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(15, data.warningCount);
+      expectWarningOnlyOnLines(sassMixinLinesExcept([1, 22, 37]), data);
       done();
     });
   });


### PR DESCRIPTION
fixes #739

DCO 1.1 Signed-off-by: Wayne Warner <wawjr3d@gmail.com>

<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

**What do the changes you have made achieve?**
The mixin-name-format rule should only apply to mixin definition so that you can use mixins, which don't follow your team's convention, from third party libraries (e.g. compass).

**Are there any new warning messages?**
No?

**Have you written tests?**
Yes

**Have you included relevant documentation**
Yes

**Which issues does this resolve?**
#739

`<DCO 1.1 Signed-off-by: Wayne Warner wawjr3d@gmail.com>`