### PR TITLE
feature(auto-fix): Implementation of --fix flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ rules:
       size: 2
 ```
 
+##### Adding Fix to Rules
+
+Within `lib/rules/*.js`, for any file you can just add a `fix` hook to `module.exports` like so:
+
+ex.
+
+```js
+module.exports.fix = function (ast, parser) {
+  /** ... **/
+};
+```
+
+The `ast` parameter represents the gonzales-pe abstract syntax tree.
+Any manipulations to `ast` are reflected in the code after `.fix` finishes.
+
+The changes will be reflected in any files with detected faults.
+
+`parser` represents the configuration file for the rule.
+
+To run the code fixer, simply use the CLI flag as seen below:
+
+`sass-lint --fix`
+
+`sass-lint` can also be run from `bin/sass-lint`
+
+#### Rules Implementing Fix
+- [x] `border-zero`
+- [ ] `no-color-keywords`
+- [x] `no-css-comments`
+- [x] `property-sort-order`
+- [ ] `space-before-colon`
+- [ ] `space-after-colon`
+
 ### [Rules Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/rules)
 
 ---

--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -42,6 +42,7 @@ program
   .option('-f, --format [format]', 'pass one of the available eslint formats')
   .option('-o, --output [output]', 'the path and filename where you would like output to be written')
   .option('-s, --syntax [syntax]', 'syntax to evaluate the file(s) with (either sass or scss)')
+  .option('--fix', 'Automatically fixes formatting issues with code.')
   .option('--max-warnings [integer]', 'Number of warnings to trigger nonzero exit code')
   .parse(process.argv);
 
@@ -51,7 +52,6 @@ configOptions.options = configOptions.options || {};
 if (program.config && program.config !== true) {
   configPath = program.config;
 }
-
 if (program.ignore && program.ignore !== true) {
   configOptions.files.ignore = program.ignore.split(', ');
 }
@@ -66,6 +66,12 @@ if (program.format && program.format !== true) {
 
 if (program.output && program.output !== true) {
   configOptions.options['output-file'] = program.output;
+}
+if (program.fix) {
+  configOptions.fix = program.fix;
+}
+if (program.verbose) {
+  configOptions.verbose = program.verbose;
 }
 
 if (program.maxWarnings && program.maxWarnings !== true) {

--- a/docs/cli/readme.md
+++ b/docs/cli/readme.md
@@ -22,5 +22,6 @@ Command Line Flag        | Description
 `-s`,`--syntax`           | Syntax to evaluate the given file(s) with, either sass or scss. Use with care: overrides filename extension-based syntax detection.
 `-v`,`--verbose`          | Verbose output (fully formatted output)
 `-V`,`--version`          | Outputs the version number of Sass Lint
+`--fix`                   | Automatically fixes formatting issues with code.
 
 To see more on how to use the CLI you can view the examples included within sass-lint's [readme](https://github.com/sasstools/sass-lint/blob/develop/README.md#cli)

--- a/docs/rules/attribute-quotes.md
+++ b/docs/rules/attribute-quotes.md
@@ -1,6 +1,6 @@
 # Attribute Quotes
 
-Rule `attribute-quotes` will enforce the use of the use of quotes in attribute values.
+Rule `attribute-quotes` will enforce the use of quotes in attribute values.
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -116,7 +116,6 @@ sassLint.lintText = function (file, options, configPath) {
   catch (e) {
     var line = e.line || 1;
     errors++;
-
     results = [{
       ruleId: 'Fatal',
       line: line,
@@ -133,6 +132,17 @@ sassLint.lintText = function (file, options, configPath) {
     rules.forEach(function (rule) {
       detects = rule.rule.detect(ast, rule)
         .filter(isEnabledFilter);
+
+      if (detects && options.fix && rule.rule.fix) {
+        if (options.verbose) {
+          helpers.log('[' + rule.rule.name + '] on [' + file.filename + ']');
+        }
+        rule.rule.fix(ast, rule);
+        detects = rule.rule.detect(ast, rule)
+          .filter(isEnabledFilter);
+
+      }
+
       results = results.concat(detects);
       if (detects.length) {
         if (rule.severity === 1) {
@@ -143,6 +153,10 @@ sassLint.lintText = function (file, options, configPath) {
         }
       }
     });
+    if (options.fix) {
+      var filename = file.path || file.filename;
+      fs.writeFileSync(filename, ast.toString());
+    }
   }
 
   results.sort(helpers.sortDetects);

--- a/lib/rules/attribute-quotes.js
+++ b/lib/rules/attribute-quotes.js
@@ -1,6 +1,11 @@
 'use strict';
 
 var helpers = require('../helpers');
+var traverse = function (ast, parser, callback) {
+  ast.traverseByType('attributeValue', function (item) {
+    callback(item);
+  });
+};
 
 module.exports = {
   'name': 'attribute-quotes',
@@ -9,8 +14,7 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
-
-    ast.traverseByType('attributeValue', function (item) {
+    traverse(ast, parser, function (item) {
       if (item.content[0].is('string') && !parser.options.include) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
@@ -30,7 +34,17 @@ module.exports = {
         });
       }
     });
-
     return result;
   }
+};
+
+module.exports.fix = function (ast, parser) {
+  traverse(ast, parser, function (item) {
+    if (item.content[0].is('string') && !parser.options.include) {
+      item.content[0].content = item.content[0].content.replace(/(\"|\')((?:\\.|[^"\\])*)(\"|\')/, '$2');
+    }
+    else if (item.content[0].is('ident') && parser.options.include) {
+      item.content[0].content = item.content[0].content.replace(/(.*)/, '"$1"');
+    }
+  });
 };

--- a/lib/rules/border-zero.js
+++ b/lib/rules/border-zero.js
@@ -5,6 +5,33 @@ var helpers = require('../helpers');
 var borders = ['border', 'border-top', 'border-right', 'border-bottom', 'border-left'];
 var allowedConventions = ['0', 'none'];
 
+var traverse = function (ast, parser, callback) {
+  ast.traverseByType('declaration', function (declaration) {
+    var isBorder = false;
+
+    declaration.traverse(function (item) {
+      if (item.type === 'property') {
+        item.traverse(function (child) {
+          if (borders.indexOf(child.content) !== -1) {
+            isBorder = true;
+          }
+        });
+      }
+
+      if (isBorder) {
+        if (item.type === 'value') {
+          var node = item.content[0];
+          if (node.type === 'number' || node.type === 'ident') {
+            if (node.content === '0' || node.content === 'none') {
+              return callback(node);
+            }
+          }
+        }
+      }
+      return item;
+    });
+  });
+};
 module.exports = {
   'name': 'border-zero',
   'defaults': {
@@ -60,7 +87,12 @@ module.exports = {
         }
       });
     });
-
     return result;
   }
+};
+
+module.exports.fix = function (ast, parser) {
+  traverse(ast, parser, function (node) {
+    node.content = parser.options.convention;
+  });
 };

--- a/lib/rules/hex-length.js
+++ b/lib/rules/hex-length.js
@@ -5,11 +5,18 @@ var lengths = {
   short: 3,
   long: 6
 };
+
 var canShorten = function (hex) {
   return hex.length === lengths.long &&
           hex[0] === hex[1] &&
           hex[2] === hex[3] &&
           hex[4] === hex[5];
+};
+
+var traverse = function (ast, callback) {
+  ast.traverseByType('color', function (node) {
+    return callback(node);
+  });
 };
 
 module.exports = {
@@ -19,30 +26,38 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
-
-    ast.traverseByType('color', function (value) {
-      if (parser.options.style === 'short' && canShorten(value.content)) {
+    traverse(ast, function (node) {
+      if (parser.options.style === 'short' && canShorten(node.content)) {
         result = helpers.addUnique(result, {
           'ruleId': parser.rule.name,
-          'line': value.start.line,
-          'column': value.start.column,
+          'line': node.start.line,
+          'column': node.start.column,
           'message': 'Hex values should use the shorthand format - 3 characters where possible',
           'severity': parser.severity
         });
       }
       else if (parser.options.style === 'long') {
-        if (value.content.length !== lengths.long) {
+        if (node.content.length !== lengths.long) {
           result = helpers.addUnique(result, {
             'ruleId': parser.rule.name,
-            'line': value.start.line,
-            'column': value.start.column,
+            'line': node.start.line,
+            'column': node.start.column,
             'message': 'Hex values should use the long-form format - 6 characters',
             'severity': parser.severity
           });
         }
       }
     });
-
     return result;
   }
+};
+
+module.exports.fix = function (ast, parser) {
+  traverse(ast, function (node) {
+    if (parser.options.style === 'short' && canShorten(node.content)) {
+      node.content = [0, 2, 4].reduce(function (e, r) {
+        return e + node.content[r];
+      }, '');
+    }
+  });
 };

--- a/lib/rules/no-color-keywords.js
+++ b/lib/rules/no-color-keywords.js
@@ -27,7 +27,6 @@ module.exports = {
   'defaults': {},
   'detect': function (ast, parser) {
     var result = [];
-
     ast.traverseByType('value', function (node) {
       node.traverse(function (elem, i, parent) {
         if (elem.type === 'ident' && !checkValidParentType(parent)) {
@@ -48,4 +47,17 @@ module.exports = {
     });
     return result;
   }
+};
+
+module.exports.fix = function (ast) {
+  ast.traverseByType('value', function (n) {
+    n.traverseByTypes('ident', function (_n, _i, _p) {
+      if (!_p.is('variable')) {
+        var j = cssColors.indexOf(_n.content.toLowerCase());
+        if (j !== -1) {
+          _n.content = _n.content.replace(new RegExp('(' + cssColors.join('|') + ')'), '#' + cssColors[j + 1]);
+        }
+      }
+    });
+  });
 };

--- a/lib/rules/no-css-comments.js
+++ b/lib/rules/no-css-comments.js
@@ -22,3 +22,11 @@ module.exports = {
     return result;
   }
 };
+
+module.exports.fix = function (ast) {
+  ast.traverseByType('multilineComment', function (node, i, parent) {
+    if (node.content.charAt(0) !== '!') {
+      parent.removeChild(i);
+    }
+  });
+};

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -16,13 +16,11 @@ var orderPresets = {
 var getOrderConfig = function (order) {
   if (typeof order === 'string') {
     if (orderPresets.hasOwnProperty(order)) {
-      var filename = orderPresets[order],
-          orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
-
+      var filename = orderPresets[order];
+      var orderConfig = helpers.loadConfigFile('property-sort-orders/' + filename);
       return orderConfig.order;
     }
   }
-
   return false;
 };
 
@@ -95,13 +93,11 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [],
         order = getOrderConfig(parser.options.order) || parser.options.order;
-
     ast.traverseByType('block', function (block) {
       var properties = {},
           sorted,
           pKeys,
           sKeys;
-
       if (block) {
         block.forEach('declaration', function (dec) {
           var prop = dec.first('property'),
@@ -120,7 +116,6 @@ module.exports = {
         });
 
         sorted = sortProperties(properties, order);
-
         pKeys = Object.keys(properties);
         sKeys = Object.keys(sorted);
 
@@ -144,4 +139,44 @@ module.exports = {
 
     return result;
   }
+};
+
+module.exports.fix = function (ast, parser) {
+  ast.traverseByType('block', function (block) {
+    var res = [];
+    var indexes = [];
+    block.forEach('declaration', function (declaration, index) {
+      var prop = declaration.first('property');
+      var name = prop.first('ident') || prop.first('variable').first('ident');
+      if (name) {
+        res.push({
+          name: name.toString(),
+          node: declaration
+        });
+        indexes.push(index);
+      }
+    });
+    if (parser.options.order === 'alphabetical') {
+      res.sort(function (p, c) {
+        return p.name.localeCompare(c.name);
+      });
+    }
+    else {
+      res.sort(function (p, c) {
+        var order = parser.options.order;
+        var priorities = getOrderConfig(order) || order || [];
+        if (priorities.indexOf(p.name) === -1) {
+          return 1;
+        }
+        if (priorities.indexOf(c.name) === -1) {
+          return -1;
+        }
+        return priorities.indexOf(p.name) - priorities.indexOf(c.name);
+      });
+    }
+    res.forEach(function (e) {
+      block.content[indexes.shift()] = e.node;
+    });
+  });
+
 };

--- a/lib/rules/space-after-colon.js
+++ b/lib/rules/space-after-colon.js
@@ -2,6 +2,12 @@
 
 var helpers = require('../helpers');
 
+var traverse = function (ast, callback) {
+  ast.traverseByTypes(['propertyDelimiter', 'operator'], function (delimiter, i, parent) {
+    return callback(delimiter, i, parent);
+  });
+};
+
 module.exports = {
   'name': 'space-after-colon',
   'defaults': {
@@ -9,9 +15,9 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
-
-    ast.traverseByTypes(['propertyDelimiter', 'operator'], function (delimiter, i, parent) {
+    traverse(ast, function (delimiter, i, parent) {
       if (delimiter.content === ':') {
+
         var next = parent.content[i + 1];
 
         if (next && next.is('space')) {
@@ -38,7 +44,23 @@ module.exports = {
         }
       }
     });
-
     return result;
   }
+};
+
+module.exports.fix = function (ast, parser) {
+  traverse(ast, function (delimiter, i, parent) {
+    if (delimiter.content === ':') {
+      var next = parent.content[i + 1];
+      var include = parser.options.include;
+      if (next && next.is('space')) {
+        if (!include) {
+          parent.content = parent.content.splice(i + 1, 1);
+        }
+      }
+      else if (parser.options.include) {
+        delimiter.content += ' ';
+      }
+    }
+  });
 };

--- a/lib/rules/space-before-colon.js
+++ b/lib/rules/space-before-colon.js
@@ -1,7 +1,11 @@
 'use strict';
 
 var helpers = require('../helpers');
-
+var traverse = function (ast, callback) {
+  ast.traverseByTypes(['propertyDelimiter', 'operator'], function (delimiter, i, parent) {
+    return callback(delimiter, i, parent);
+  });
+};
 module.exports = {
   'name': 'space-before-colon',
   'defaults': {
@@ -9,8 +13,7 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
-
-    ast.traverseByTypes(['propertyDelimiter', 'operator'], function (delimiter, i, parent) {
+    traverse(ast, function (delimiter, i, parent) {
       if (delimiter.content === ':') {
         var previous = parent.content[i - 1];
 
@@ -38,7 +41,23 @@ module.exports = {
         }
       }
     });
-
     return result;
   }
+};
+
+module.exports.fix = function (ast, parser) {
+  var include = parser.options.include;
+  traverse(ast, function (delimiter, i, parent) {
+    if (delimiter.content === ':') {
+      var previous = parent.content[i - 1];
+      if (previous.is('space')) {
+        if (!include) { // no space allowed
+          parent.content.splice(i - 1, 1);
+        }
+      }
+      else if (include) {
+        previous.content += ' ';
+      }
+    }
+  });
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "eslint": "^2.7.0",
-    "front-matter": "2.1.1",
+    "front-matter": "2.1.2",
     "fs-extra": "^1.0.0",
     "glob": "^7.0.0",
     "globule": "^1.0.0",

--- a/tests/rules/border-zero.js
+++ b/tests/rules/border-zero.js
@@ -8,55 +8,89 @@ var lint = require('./_lint');
 describe('border zero - scss', function () {
   var file = lint.file('border-zero.scss');
 
-  it('[convention: 0]', function (done) {
-    lint.test(file, {
+  describe('[convention: 0]', function () {
+    var config = {
       'border-zero': [
         1,
         {
           'convention': 0
         }
       ]
-    }, function (data) {
-      lint.assert.equal(3, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(3, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[convention: \'0\']', function (done) {
-    lint.test(file, {
+  describe('[convention: \'0\']', function () {
+    var config = {
       'border-zero': 1
-    }, function (data) {
-      lint.assert.equal(3, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(3, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[convention: \'none\']', function (done) {
-    lint.test(file, {
+  describe('[convention: \'none\']', function () {
+    var config = {
       'border-zero': [
         1,
         {
           'convention': 'none'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(2, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(2, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 
-  it('invalid convention [convention: \'zero\']', function (done) {
+  describe('invalid convention [convention: \'zero\']', function () {
     // defaults to convention 0
-    lint.test(file, {
+    var config = {
       'border-zero': [
         1,
         {
           'convention': 'zero'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(4, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(4, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 });
@@ -67,55 +101,93 @@ describe('border zero - scss', function () {
 describe('border zero - sass', function () {
   var file = lint.file('border-zero.sass');
 
-  it('[convention: 0]', function (done) {
-    lint.test(file, {
+  describe('[convention: 0]', function () {
+    var config = {
       'border-zero': [
         1,
         {
           'convention': 0
         }
       ]
-    }, function (data) {
-      lint.assert.equal(3, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(3, data.warningCount);
+        done();
+      });
     });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
+    });
+
   });
 
-  it('[convention: \'0\']', function (done) {
-    lint.test(file, {
+  describe('[convention: \'0\']', function () {
+    var config = {
       'border-zero': 1
-    }, function (data) {
-      lint.assert.equal(3, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(3, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 
-  it('[convention: \'none\']', function (done) {
-    lint.test(file, {
+  describe('[convention: \'none\']', function () {
+    var config = {
       'border-zero': [
         1,
         {
           'convention': 'none'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(2, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(2, data.warningCount);
+        done();
+      });
     });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
+    });
+
   });
 
-  it('invalid convention [convention: \'zero\']', function (done) {
+  describe('invalid convention [convention: \'zero\']', function () {
     // defaults to convention 0
-    lint.test(file, {
+    var config = {
       'border-zero': [
         1,
         {
           'convention': 'zero'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(4, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(4, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 });

--- a/tests/rules/no-css-comments.js
+++ b/tests/rules/no-css-comments.js
@@ -2,34 +2,44 @@
 
 var lint = require('./_lint');
 
-//////////////////////////////
-// SCSS syntax tests
-//////////////////////////////
-describe('no css comments - scss', function () {
-  var file = lint.file('no-css-comments.scss');
-
-  it('enforce', function (done) {
-    lint.test(file, {
-      'no-css-comments': 1
-    }, function (data) {
-      lint.assert.equal(4, data.warningCount);
-      done();
+describe('no css comments', function () {
+  var config = {
+    'no-css-comments': 1
+  };
+  //////////////////////////////
+  // SCSS syntax tests
+  //////////////////////////////
+  describe('scss', function () {
+    var file = lint.file('no-css-comments.scss');
+    it('enforce', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(4, data.warningCount);
+        done();
+      });
+    });
+    it('corrects', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-});
-
-//////////////////////////////
-// Sass syntax tests
-//////////////////////////////
-describe('no css comments - sass', function () {
-  var file = lint.file('no-css-comments.sass');
-
-  it('enforce', function (done) {
-    lint.test(file, {
-      'no-css-comments': 1
-    }, function (data) {
-      lint.assert.equal(4, data.warningCount);
-      done();
+  //////////////////////////////
+  // Sass syntax tests
+  //////////////////////////////
+  describe('sass', function () {
+    var file = lint.file('no-css-comments.sass');
+    it('enforce', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(4, data.warningCount);
+        done();
+      });
+    });
+    it('corrects', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 });

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -1,38 +1,52 @@
 'use strict';
 
 var lint = require('./_lint');
-
 //////////////////////////////
 // SCSS syntax tests
 //////////////////////////////
 describe('property sort order - scss', function () {
   var file = lint.file('property-sort-order.scss');
-
-  it('[order: alphabetical]', function (done) {
-    lint.test(file, {
+  describe('[order: alphabetical]', function () {
+    var config = {
       'property-sort-order': 1
-    }, function (data) {
-      lint.assert.equal(15, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(15, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: alphabetical, ignore-custom-properties: true]', function (done) {
-    lint.test(file, {
+  describe('[order: alphabetical, ignore-custom-properties: true]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'ignore-custom-properties': true
         }
       ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(12, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: custom]', function (done) {
-    lint.test(file, {
+  describe('[order: custom]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
@@ -44,14 +58,22 @@ describe('property sort order - scss', function () {
           ]
         }
       ]
-    }, function (data) {
-      lint.assert.equal(8, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(8, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: custom + composes, ignore-custom-properties: false]', function (done) {
-    lint.test(file, {
+  describe('[order: custom + composes, ignore-custom-properties: false]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
@@ -65,14 +87,22 @@ describe('property sort order - scss', function () {
           'ignore-custom-properties': false
         }
       ]
-    }, function (data) {
-      lint.assert.equal(10, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(10, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: custom + composes, ignore-custom-properties: true]', function (done) {
-    lint.test(file, {
+  describe('[order: custom + composes, ignore-custom-properties: true]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
@@ -85,51 +115,85 @@ describe('property sort order - scss', function () {
           'ignore-custom-properties': true
         }
       ]
-    }, function (data) {
-      lint.assert.equal(8, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(8, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: recess]', function (done) {
-    lint.test(file, {
+  describe('[order: recess]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'order': 'recess'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(12, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: smacss]', function (done) {
-    lint.test(file, {
+  describe('[order: smacss]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'order': 'smacss'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(12, data.warningCount);
+        done();
+      });
     });
-  });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
+    });
 
-  it('[order: concentric]', function (done) {
-    lint.test(file, {
+  });
+  describe('[order: concentric]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'order': 'concentric'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(14, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(14, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 });
@@ -140,31 +204,47 @@ describe('property sort order - scss', function () {
 describe('property sort order - sass', function () {
   var file = lint.file('property-sort-order.sass');
 
-  it('[order: alphabetical]', function (done) {
-    lint.test(file, {
+  describe('[order: alphabetical]', function () {
+    var config = {
       'property-sort-order': 1
-    }, function (data) {
-      lint.assert.equal(15, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(15, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: alphabetical, ignore-custom-properties: true]', function (done) {
-    lint.test(file, {
+  describe('[order: alphabetical, ignore-custom-properties: true]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'ignore-custom-properties': true
         }
       ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(12, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: custom]', function (done) {
-    lint.test(file, {
+  describe('[order: custom]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
@@ -176,14 +256,22 @@ describe('property sort order - sass', function () {
           ]
         }
       ]
-    }, function (data) {
-      lint.assert.equal(8, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(8, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: custom + composes, ignore-custom-properties: false]', function (done) {
-    lint.test(file, {
+  describe('[order: custom + composes, ignore-custom-properties: false]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
@@ -197,14 +285,22 @@ describe('property sort order - sass', function () {
           'ignore-custom-properties': false
         }
       ]
-    }, function (data) {
-      lint.assert.equal(10, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(10, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
-
-  it('[order: custom + composes, ignore-custom-properties: true]', function (done) {
-    lint.test(file, {
+  describe('[order: custom + composes, ignore-custom-properties: true]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
@@ -217,51 +313,87 @@ describe('property sort order - sass', function () {
           'ignore-custom-properties': true
         }
       ]
-    }, function (data) {
-      lint.assert.equal(8, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(8, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 
-  it('[order: recess]', function (done) {
-    lint.test(file, {
+  describe('[order: recess]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'order': 'recess'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(12, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 
-  it('[order: smacss]', function (done) {
-    lint.test(file, {
+  describe('[order: smacss]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'order': 'smacss'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(12, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(12, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 
-  it('[order: concentric]', function (done) {
-    lint.test(file, {
+  describe('[order: concentric]', function () {
+    var config = {
       'property-sort-order': [
         1,
         {
           'order': 'concentric'
         }
       ]
-    }, function (data) {
-      lint.assert.equal(14, data.warningCount);
-      done();
+    };
+    it('detects faults', function (done) {
+      lint.test(file, config, function (data) {
+        lint.assert.equal(14, data.warningCount);
+        done();
+      });
+    });
+    it('corrects faults', function (done) {
+      lint.fix(file, config, function (data) {
+        lint.assert.equal(0, data.warningCount);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
**What do the changes you have made achieve?**
- Base implementation of --fix
- Tests
    - Maintain coverage %
    - Test `fix`'s already implemented as demonstration of PR capabilities
        - [x] `border-zero`
        - [x] `no-css-comments`
        - [x] `property-sort-order`

**Are there any new warning messages?**

No, `fix` will only run if given `fix` config option.
If fix is run, the only difference is it will rebuild the parsed ast correctly, and write the new one into that file.

**Have you written tests?**

Partially, yes. Currently in the process of writing more tests.

**Have you included relevant documentation**

Yes, have added some explanation on how to run `fix`, and how to add your own rule fixes.

**Which issues does this resolve?**
#904
`<DCO 1.1 Signed-off-by: SEENA ROWHANI seenarowhani95@gmail.com>`

Let me know of any concerns or questions. I understand this PR can be risky from your perspective, so I'll do my best to address any comments.

Also, side-note, help adding rules / testing them would be really helpful. So if anyone wants to contribute, feel free to PR my fork 🔥 

Closing #997 in favour of this.