### PR TITLE
Selectors must be placed on single lines

### DIFF
--- a/docs/rules/single-line-per-selector.md
+++ b/docs/rules/single-line-per-selector.md
@@ -1,6 +1,6 @@
 # Single Line Per Selector
 
-Rule `single-line-per-selector` will enforce whether selectors should be placed on a new line.
+Rule `single-line-per-selector` will enforce whether selectors should be placed on a single new line.
 
 ## Examples
 
@@ -17,6 +17,11 @@ When enabled, the following are disallowed:
 
 ```scss
 .foo, .bar {
+  content: 'baz';
+}
+
+.foo
+.bar {
   content: 'baz';
 }
 ```

--- a/lib/rules/single-line-per-selector.js
+++ b/lib/rules/single-line-per-selector.js
@@ -27,6 +27,23 @@ var checkLineForSelector = function (ruleset, index) {
   return false;
 };
 
+/**
+ * Check a selector for EOL characters.
+ *
+ * @param {Object} selector - The selector node
+ * @returns {Object|boolean} Either the space node or false
+ */
+var checkSelectorForNewline = function (selector) {
+  for (var index = 0; index < selector.content.length; index++) {
+    var node = selector.content[index];
+    if (node.type === 'space' && helpers.hasEOL(node)) {
+      return node;
+    }
+  }
+
+  return false;
+};
+
 module.exports = {
   'name': 'single-line-per-selector',
   'defaults': {},
@@ -43,6 +60,20 @@ module.exports = {
             'line': next.start.line,
             'column': next.start.column,
             'message': 'Selectors must be placed on new lines',
+            'severity': parser.severity
+          });
+        }
+      });
+
+      ruleset.forEach('selector', function (selector) {
+        var node = checkSelectorForNewline(selector);
+
+        if (node) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': 'Selectors must be placed on single lines',
             'severity': parser.severity
           });
         }

--- a/tests/rules/single-line-per-selector.js
+++ b/tests/rules/single-line-per-selector.js
@@ -12,7 +12,7 @@ describe('single line per selector - scss', function () {
     lint.test(file, {
       'single-line-per-selector': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('single line per selector - sass', function () {
     lint.test(file, {
       'single-line-per-selector': 1
     }, function (data) {
-      lint.assert.equal(6, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });

--- a/tests/sass/single-line-per-selector.sass
+++ b/tests/sass/single-line-per-selector.sass
@@ -19,6 +19,11 @@
   content: 'foo'
 
 
+.foo
+.boo
+  content: 'foo'
+
+
 .foo > a,.bar
   content: 'baz'
 

--- a/tests/sass/single-line-per-selector.scss
+++ b/tests/sass/single-line-per-selector.scss
@@ -19,6 +19,11 @@
   content: 'foo';
 }
 
+.foo
+.boo {
+  content: 'foo';
+}
+
 .foo > a,.bar {
   content: 'baz';
 }


### PR DESCRIPTION
**What do the changes you have made achieve?**

Each individual selector occupy only a single line.

**Are there any new warning messages?**

No

**Have you written tests?**

Yes

**Have you included relevant documentation**

Yes

**Which issues does this resolve?**

Forgotten trailing commas are reported when single-line-per-selector is enabled.
