### PR TITLE
Handle multiline properties & update css list

### DIFF
--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -1,12 +1,8 @@
 'use strict';
 
-var helpers = require('../helpers'),
-    yaml = require('js-yaml'),
-    fs = require('fs'),
-    path = require('path');
-
-var properties = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' ');
-
+var helpers = require('../helpers');
+var properties = require('known-css-properties').all;
+var PROP_DIVIDER = '-';
 /**
  * Combine the valid property array and the array of extras into a new array
  *
@@ -18,6 +14,40 @@ var getCombinedList = function (props, extras) {
   return props.concat(extras);
 };
 
+var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
+  var propList = [];
+  var propsEncountered = propsCounted;
+  if (valBlock.contains('declaration')) {
+    valBlock.forEach('declaration', function (node) {
+      var prop = node.first('property');
+      var value = node.first('value');
+      propsEncountered++;
+
+      if (prop.first().is('ident')) {
+        if (value.contains('block')) {
+          propList = propList.concat(
+            buildPartialProperty(value.first('block'),
+              {
+                name: currentProperty.name + PROP_DIVIDER + prop.first('ident').content
+              },
+              propsEncountered
+            )
+          );
+        }
+        else {
+          propList.push({
+            name: currentProperty.name + PROP_DIVIDER + prop.first('ident').content,
+            line: prop.first().start.line,
+            col: prop.first().start.column,
+            propsEncountered: propsEncountered
+          });
+        }
+      }
+    });
+  }
+  return propList;
+};
+
 module.exports = {
   'name': 'no-misspelled-properties',
   'defaults': {
@@ -25,34 +55,77 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
+    var toSkip = 0;
+    var propertyList = getCombinedList(properties, parser.options['extra-properties']);
 
-    ast.traverseByType('property', function (node) {
-      if (node.first().is('ident')) {
-        var curProperty = node.first().content,
-            propertyList = getCombinedList(properties, parser.options['extra-properties']);
-
-        if (curProperty.charAt(0) === '-') {
-          curProperty = helpers.stripPrefix(curProperty);
-        }
-
-        if (helpers.isPartialStringMatch(curProperty, propertyList)) {
+    ast.traverseByType('declaration', function (node) {
+      var prop = node.first('property');
+      var containsInterp = prop.contains('interpolation');
+      if (toSkip) {
+        toSkip--;
+        if (toSkip) {
           return false;
         }
+      }
+      if (!prop.first() || !prop.first().is('ident')) {
+        return false;
+      }
+      var curProperty = prop.first() && prop.first().is('ident') && prop.first('ident').content;
+      var value = node.first('value');
+      var fullProperties = [];
 
-        if (curProperty.length > 0) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': node.start.line,
-            'column': node.start.column,
-            'message': 'Property `' + curProperty + '` appears to be spelled incorrectly',
-            'severity': parser.severity
-          });
-        }
+      if (value.contains('block')) {
+        fullProperties = buildPartialProperty(
+          value.first('block'),
+          {
+            name: curProperty,
+            line: prop.first('ident').start.line,
+            col: prop.first('ident').start.column
+          },
+          0
+        );
       }
 
+      if (fullProperties.length) {
+        fullProperties.forEach(function (constrProp) {
+          toSkip += constrProp.propsEncountered;
+          if (propertyList.indexOf(constrProp.name) === -1) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': constrProp.line,
+              'column': constrProp.col,
+              'message': 'Property `' + constrProp.name + '` appears to be spelled incorrectly',
+              'severity': parser.severity
+            });
+          }
+        });
+      }
+      else {
+        if (curProperty.length > 0) {
+          if (containsInterp) {
+            if (!helpers.isPartialStringMatch(curProperty, propertyList)) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': node.start.line,
+                'column': node.start.column,
+                'message': 'Property `' + curProperty + '` appears to be spelled incorrectly',
+                'severity': parser.severity
+              });
+            }
+          }
+          else if (propertyList.indexOf(curProperty) === -1) {
+            result = helpers.addUnique(result, {
+              'ruleId': parser.rule.name,
+              'line': node.start.line,
+              'column': node.start.column,
+              'message': 'Property `' + curProperty + '` appears to be spelled incorrectly',
+              'severity': parser.severity
+            });
+          }
+        }
+      }
       return false;
     });
-
     return result;
   }
 };

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -3,6 +3,7 @@
 var helpers = require('../helpers');
 var properties = require('known-css-properties').all;
 var PROP_DIVIDER = '-';
+
 /**
  * Combine the valid property array and the array of extras into a new array
  *
@@ -14,6 +15,14 @@ var getCombinedList = function (props, extras) {
   return props.concat(extras);
 };
 
+/**
+ * Recursive function to build up an array of property names when encountering multiline properties
+ *
+ * @param {Object} valBlock - The current block node from within our value
+ * @param {Object} currentProperty - The current base property name i.e. border-
+ * @param {Number} propsCounted - The number of properties encountered in our multiline so far
+ * @returns {Array} Array of objects containing our property and line/col info etc
+ */
 var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
   var propList = [];
   var propsEncountered = propsCounted;
@@ -61,20 +70,22 @@ module.exports = {
     ast.traverseByType('declaration', function (node) {
       var prop = node.first('property');
       var containsInterp = prop.contains('interpolation');
+      // If we've already checked declarations in a multiline we can skip those decs here
       if (toSkip) {
         toSkip--;
-        if (toSkip) {
-          return false;
-        }
+        return !toSkip;
       }
+      // make sure our first node within our property is an ident
       if (!prop.first() || !prop.first().is('ident')) {
         return false;
       }
+
       var curProperty = prop.first() && prop.first().is('ident') && prop.first('ident').content;
       var value = node.first('value');
       var fullProperties = [];
 
       if (value.contains('block')) {
+        // encountered a multiline property, we should build the property list here
         fullProperties = buildPartialProperty(
           value.first('block'),
           {
@@ -85,10 +96,12 @@ module.exports = {
           0
         );
       }
-
+      // If we have multiline properties
       if (fullProperties.length) {
         fullProperties.forEach(function (constrProp) {
+          // Add the number of propertiy declarations we've already checked here so we can skip them
           toSkip += constrProp.propsEncountered;
+          // Check if the property exists in our list
           if (propertyList.indexOf(constrProp.name) === -1) {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,
@@ -102,6 +115,10 @@ module.exports = {
       }
       else {
         if (curProperty.length > 0) {
+          /*
+           * If our property name contains interpolation we need to make a best guess by using a
+           * partial string match as we can't be 100% on the context
+           */
           if (containsInterp) {
             if (!helpers.isPartialStringMatch(curProperty, propertyList)) {
               result = helpers.addUnique(result, {
@@ -113,6 +130,7 @@ module.exports = {
               });
             }
           }
+          // Otherwise it's just a normal string property name, lets check it here
           else if (propertyList.indexOf(curProperty) === -1) {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,
@@ -126,6 +144,7 @@ module.exports = {
       }
       return false;
     });
+
     return result;
   }
 };

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -114,7 +114,7 @@ module.exports = {
         });
       }
       else {
-        if (curProperty.length > 0) {
+        if (curProperty && curProperty.length > 0) {
           /*
            * If our property name contains interpolation we need to make a best guess by using a
            * partial string match as we can't be 100% on the context

--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -2,7 +2,6 @@
 
 var helpers = require('../helpers');
 var properties = require('known-css-properties').all;
-var PROP_DIVIDER = '-';
 
 /**
  * Combine the valid property array and the array of extras into a new array
@@ -13,6 +12,17 @@ var PROP_DIVIDER = '-';
  */
 var getCombinedList = function (props, extras) {
   return props.concat(extras);
+};
+
+/**
+ * Combines the base property name with the current property name to correct a full property name
+ *
+ * @param {String} baseName - The base property name
+ * @param {String} name - The property name to append to our base property name
+ * @returns {String} The constructed property name
+ */
+var generateName = function (baseName, name) {
+  return baseName + '-' + name;
 };
 
 /**
@@ -37,7 +47,7 @@ var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
           propList = propList.concat(
             buildPartialProperty(value.first('block'),
               {
-                name: currentProperty.name + PROP_DIVIDER + prop.first('ident').content
+                name: generateName(currentProperty.name, prop.first('ident').content)
               },
               propsEncountered
             )
@@ -45,7 +55,7 @@ var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
         }
         else {
           propList.push({
-            name: currentProperty.name + PROP_DIVIDER + prop.first('ident').content,
+            name: generateName(currentProperty.name, prop.first('ident').content),
             line: prop.first().start.line,
             col: prop.first().start.column,
             propsEncountered: propsEncountered
@@ -99,7 +109,7 @@ module.exports = {
       // If we have multiline properties
       if (fullProperties.length) {
         fullProperties.forEach(function (constrProp) {
-          // Add the number of propertiy declarations we've already checked here so we can skip them
+          // Add the number of property declarations we've already checked here so we can skip them
           toSkip += constrProp.propsEncountered;
           // Check if the property exists in our list
           if (propertyList.indexOf(constrProp.name) === -1) {
@@ -113,25 +123,13 @@ module.exports = {
           }
         });
       }
-      else {
-        if (curProperty && curProperty.length > 0) {
-          /*
-           * If our property name contains interpolation we need to make a best guess by using a
-           * partial string match as we can't be 100% on the context
-           */
-          if (containsInterp) {
-            if (!helpers.isPartialStringMatch(curProperty, propertyList)) {
-              result = helpers.addUnique(result, {
-                'ruleId': parser.rule.name,
-                'line': node.start.line,
-                'column': node.start.column,
-                'message': 'Property `' + curProperty + '` appears to be spelled incorrectly',
-                'severity': parser.severity
-              });
-            }
-          }
-          // Otherwise it's just a normal string property name, lets check it here
-          else if (propertyList.indexOf(curProperty) === -1) {
+      else if (curProperty && curProperty.length) {
+        /*
+         * If our property name contains interpolation we need to make a best guess by using a
+         * partial string match as we can't be 100% on the context
+         */
+        if (containsInterp) {
+          if (!helpers.isPartialStringMatch(curProperty, propertyList)) {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,
               'line': node.start.line,
@@ -140,6 +138,16 @@ module.exports = {
               'severity': parser.severity
             });
           }
+        }
+        // Otherwise it's just a normal string property name, lets check it here
+        else if (propertyList.indexOf(curProperty) === -1) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': 'Property `' + curProperty + '` appears to be spelled incorrectly',
+            'severity': parser.severity
+          });
         }
       }
       return false;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "globule": "^1.0.0",
     "gonzales-pe": "^4.1.1",
     "js-yaml": "^3.5.4",
+    "known-css-properties": "^0.3.0",
     "lodash.capitalize": "^4.1.0",
     "lodash.kebabcase": "^4.0.0",
     "merge": "^1.2.0",

--- a/tests/rules/no-misspelled-properties.js
+++ b/tests/rules/no-misspelled-properties.js
@@ -12,7 +12,7 @@ describe('no misspelled properties - scss', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -45,7 +45,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });
@@ -61,7 +61,7 @@ describe('no misspelled properties - sass', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(9, data.warningCount);
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(5, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -94,7 +94,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(7, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-misspelled-properties.scss
+++ b/tests/sass/no-misspelled-properties.scss
@@ -6,7 +6,6 @@ $red: #ff0000;
   background-sizer: contain;
   colors: $red;
   transit1on: width 2s;
-
 }
 
 .test-correct {
@@ -15,7 +14,6 @@ $red: #ff0000;
   background-size: contain;
   color: $red;
   transition: width 2s;
-
 }
 
 .test-interp {


### PR DESCRIPTION
Fixes issues with the `no-misspelled-properties` rule. It currently doesn't work very well with multiline properties and only does partial string matches without trying to understand the context which in turn means it would let spelling errors through.

e.g.
```
.foo {
  colors: ... // would pass because of -moz-border-bottom-COLORS being a real property
}
```

I've also moved away from our own maintained list of properties to a more coherent, full and more importantly maintained list [known-css-properties](https://www.npmjs.com/package/known-css-properties). Any properties that aren't featured there can either be requested to be added there OR added to the extra properties setting of this rule. This will lead to a lot less frustration with our poorly maintained list.

fixes #1101 
fixes #1024
fixes #1045
fixes #951
fixes #805 
fixes #720 
closes #1062 
closes #767 

I'll update the vendor prefixes rule on top of this too and then we can removed our properties file.
`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
