### PR TITLE
Fix space before bang within value node

### DIFF
--- a/lib/rules/space-before-bang.js
+++ b/lib/rules/space-before-bang.js
@@ -10,31 +10,65 @@ module.exports = {
   'detect': function (ast, parser) {
     var result = [];
 
-    ast.traverseByTypes(['important', 'default'], function (block, i, parent) {
+    ast.traverseByTypes(['important', 'default', 'value'], function (block, i, parent) {
       var previous = parent.content[i - 1];
-
-      if (!previous.is('space')) {
-        if (parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': block.start.line,
-            'column': block.start.column,
-            'message': 'Whitespace required before !important',
-            'severity': parser.severity
-          });
+      if (block.is('value') && block.contains('important')) {
+        if (block.content.length === 1 && block.first('important')) {
+          if (previous) {
+            if (!previous.is('space')) {
+              if (parser.options.include) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': block.first('important').start.line,
+                  'column': block.first('important').start.column,
+                  'message': 'Whitespace required before !important',
+                  'severity': parser.severity
+                });
+              }
+            }
+            else {
+              if (!parser.options.include) {
+                result = helpers.addUnique(result, {
+                  'ruleId': parser.rule.name,
+                  'line': block.first('important').start.line,
+                  'column': block.first('important').start.column,
+                  'message': 'Whitespace not allowed before !important',
+                  'severity': parser.severity
+                });
+              }
+            }
+          }
         }
       }
-      else {
-        if (!parser.options.include) {
-          result = helpers.addUnique(result, {
-            'ruleId': parser.rule.name,
-            'line': previous.start.line,
-            'column': previous.start.column,
-            'message': 'Whitespace not allowed before !important',
-            'severity': parser.severity
-          });
+      else
+      if (block.is('important') || block.is('default')) {
+        var blockString = block.is('important') ? '!important' : '!default';
+        if (previous) {
+          if (!previous.is('space')) {
+            if (parser.options.include) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': block.start.line,
+                'column': block.start.column,
+                'message': 'Whitespace required before ' + blockString,
+                'severity': parser.severity
+              });
+            }
+          }
+          else {
+            if (!parser.options.include) {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': previous.start.line,
+                'column': previous.start.column,
+                'message': 'Whitespace not allowed before ' + blockString,
+                'severity': parser.severity
+              });
+            }
+          }
         }
       }
+      return false;
     });
 
     return result;

--- a/tests/rules/space-after-bang.js
+++ b/tests/rules/space-after-bang.js
@@ -12,7 +12,7 @@ describe('space after bang - scss', function () {
     lint.test(file, {
       'space-after-bang': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('space after bang - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -42,7 +42,7 @@ describe('space after bang - sass', function () {
     lint.test(file, {
       'space-after-bang': 1
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space after bang - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(11, data.warningCount);
       done();
     });
   });

--- a/tests/rules/space-before-bang.js
+++ b/tests/rules/space-before-bang.js
@@ -12,7 +12,7 @@ describe('space before bang - scss', function () {
     lint.test(file, {
       'space-before-bang': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('space before bang - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -42,7 +42,7 @@ describe('space before bang - sass', function () {
     lint.test(file, {
       'space-before-bang': 1
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('space before bang - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(4, data.warningCount);
+      lint.assert.equal(8, data.warningCount);
       done();
     });
   });

--- a/tests/sass/space-after-bang.sass
+++ b/tests/sass/space-after-bang.sass
@@ -50,3 +50,35 @@ $qux: green ! global
 //
 // .qux
 //   @extend .notice! optional
+
+=testcase($important: null)
+  @if $important == true
+    $important: !important
+
+=testcaseFail($important: null)
+  @if $important == true
+    $important:!important
+
+=testcase($important: null)
+  @if $important == true
+    $important: ! important
+
+=testcaseFail($important: null)
+  @if $important == true
+    $important:! important
+
+=testcase($important: null)
+  @if $important == true
+    $color: red !default
+
+=testcaseFail($important: null)
+  @if $important == true
+    $color: red!default
+
+=testcaseFail($important: null)
+  @if $important == true
+    $color: red ! default
+
+=testcaseFail($important: null)
+  @if $important == true
+    $color: red! default

--- a/tests/sass/space-after-bang.scss
+++ b/tests/sass/space-after-bang.scss
@@ -54,3 +54,35 @@ $qux: red ! global;
 // .qux {
 //   @extend .notice! optional;
 // }
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$important: !important;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$important:!important;}
+}
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$important: ! important;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$important:! important;}
+}
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$color: red !default;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$color: red!default;}
+}
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$color: red ! default;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$color: red! default;}
+}

--- a/tests/sass/space-before-bang.sass
+++ b/tests/sass/space-before-bang.sass
@@ -25,3 +25,35 @@ $foo: orange !default
 $foo: blue! default
 
 $foo: green ! default
+
+=testcase($important: null)
+  @if $important == true
+    $important: !important
+
+=testcaseFail($important: null)
+  @if $important == true
+    $important:!important
+
+=testcase($important: null)
+  @if $important == true
+    $important: ! important
+
+=testcaseFail($important: null)
+  @if $important == true
+    $important:! important
+
+=testcase($important: null)
+  @if $important == true
+    $color: red !default
+
+=testcaseFail($important: null)
+  @if $important == true
+    $color: red!default
+
+=testcaseFail($important: null)
+  @if $important == true
+    $color: red ! default
+
+=testcaseFail($important: null)
+  @if $important == true
+    $color: red! default

--- a/tests/sass/space-before-bang.scss
+++ b/tests/sass/space-before-bang.scss
@@ -1,7 +1,7 @@
 // Important
 
 .foo {
-  color: red!important;
+  color:red!important;
 }
 
 .bar {
@@ -25,3 +25,35 @@ $foo: red !default;
 $foo: red! default;
 
 $foo: red ! default;
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$important: !important;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$important:!important;}
+}
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$important: ! important;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$important:! important;}
+}
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$color: red !default;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$color: red!default;}
+}
+
+@mixin testcase($important: null) {
+  @if ($important == true) {$color: red ! default;}
+}
+
+@mixin testcaseFail($important: null) {
+  @if ($important == true) {$color: red! default;}
+}


### PR DESCRIPTION
Fixes the space before bang rule for assigning `!important` to a variable / value node.

Adds the extra tests for space after bang too to be consistent.

Fixes #1099 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
