### PR TITLE
fix multiline mispelled properties

### DIFF
--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -2,7 +2,8 @@
 
 var helpers = require('../helpers');
 var properties = require('known-css-properties').all;
-
+// Keep track of our properties we need to skip from the gonzales loop
+var skipProps = 0;
 /**
  * Combine the valid property array and the array of extras into a new array
  *
@@ -33,14 +34,14 @@ var generateName = function (baseName, name) {
  * @param {Number} propsCounted - The number of properties encountered in our multiline so far
  * @returns {Array} Array of objects containing our property and line/col info etc
  */
-var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
+var buildPartialProperty = function (valBlock, currentProperty) {
   var propList = [];
-  var propsEncountered = propsCounted;
+
   if (valBlock.contains('declaration')) {
     valBlock.forEach('declaration', function (node) {
       var prop = node.first('property');
       var value = node.first('value');
-      propsEncountered++;
+      skipProps++;
 
       if (prop.first().is('ident')) {
         if (value.contains('block')) {
@@ -48,8 +49,7 @@ var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
             buildPartialProperty(value.first('block'),
               {
                 name: generateName(currentProperty.name, prop.first('ident').content)
-              },
-              propsEncountered
+              }
             )
           );
         }
@@ -57,8 +57,7 @@ var buildPartialProperty = function (valBlock, currentProperty, propsCounted) {
           propList.push({
             name: generateName(currentProperty.name, prop.first('ident').content),
             line: prop.first().start.line,
-            col: prop.first().start.column,
-            propsEncountered: propsEncountered
+            col: prop.first().start.column
           });
         }
       }
@@ -74,16 +73,15 @@ module.exports = {
   },
   'detect': function (ast, parser) {
     var result = [];
-    var toSkip = 0;
     var propertyList = getCombinedList(properties, parser.options['extra-properties']);
 
     ast.traverseByType('declaration', function (node) {
       var prop = node.first('property');
       var containsInterp = prop.contains('interpolation');
       // If we've already checked declarations in a multiline we can skip those decs here
-      if (toSkip) {
-        toSkip--;
-        return !toSkip;
+      if (skipProps) {
+        skipProps -= 1;
+        return !skipProps;
       }
       // make sure our first node within our property is an ident
       if (!prop.first() || !prop.first().is('ident')) {
@@ -102,15 +100,12 @@ module.exports = {
             name: curProperty,
             line: prop.first('ident').start.line,
             col: prop.first('ident').start.column
-          },
-          0
+          }
         );
       }
       // If we have multiline properties
       if (fullProperties.length) {
         fullProperties.forEach(function (constrProp) {
-          // Add the number of property declarations we've already checked here so we can skip them
-          toSkip += constrProp.propsEncountered;
           // Check if the property exists in our list
           if (propertyList.indexOf(constrProp.name) === -1) {
             result = helpers.addUnique(result, {

--- a/tests/rules/no-misspelled-properties.js
+++ b/tests/rules/no-misspelled-properties.js
@@ -12,7 +12,7 @@ describe('no misspelled properties - scss', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });
@@ -45,7 +45,7 @@ describe('no misspelled properties - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });
@@ -61,7 +61,7 @@ describe('no misspelled properties - sass', function () {
     lint.test(file, {
       'no-misspelled-properties': 1
     }, function (data) {
-      lint.assert.equal(9, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(8, data.warningCount);
+      lint.assert.equal(13, data.warningCount);
       done();
     });
   });
@@ -94,7 +94,7 @@ describe('no misspelled properties - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(7, data.warningCount);
+      lint.assert.equal(12, data.warningCount);
       done();
     });
   });

--- a/tests/sass/no-misspelled-properties.sass
+++ b/tests/sass/no-misspelled-properties.sass
@@ -1,14 +1,15 @@
 $red: #ff0000
 
 .test-failure
-  @include test
+  +test
   -webkit-transit1on: width 2s
   background-sizer: contain
   colors: $red
   transit1on: width 2s
 
 .test-correct
-  @include test
+  +test
+
   -webkit-transition: width 2s
   background-size: contain
   color: $red
@@ -20,7 +21,6 @@ $red: #ff0000
 // https://github.com/sasstools/sass-lint/issues/606
 .test-vendor
   -moz-osx-font-smoothing: auto
-
 
 .foo
   font:
@@ -46,3 +46,34 @@ $red: #ff0000
 
 .foo
   margin-#{$property-y}: -2 * $hint-arrow-width
+
+// https://github.com/sasstools/sass-lint/issues/1112
+=font-test1
+  font:
+    family: Arial, sans-serif
+    style: normal
+    weight: 300
+
+=font-test2
+  font:
+    family: Arial, sans-serif
+    style: normal
+    weight: 400
+
+=font-test2
+  font:
+    fazily: Arial, sans-serif
+    style: normal
+    weght: 400
+  border:
+    top:
+      left:
+        radius: 5px
+    right: 6px solid #fff
+    botom:
+      right:
+        radiu: 5px
+  background:
+    color: red
+  background-colr: blue
+  font-size: 12rem

--- a/tests/sass/no-misspelled-properties.scss
+++ b/tests/sass/no-misspelled-properties.scss
@@ -2,10 +2,10 @@ $red: #ff0000;
 
 .test-failure {
   @include test;
-  -webkit-transit1on: width 2s;
-  background-sizer: contain;
-  colors: $red;
-  transit1on: width 2s;
+  -webkit-transit1on: width 2s; // 1
+  background-sizer: contain; // 2
+  colors: $red; // 3
+  transit1on: width 2s; // 4
 }
 
 .test-correct {
@@ -33,9 +33,9 @@ $red: #ff0000;
   }
   border: {
     top: {
-      right: 1px solid #fff;
+      right: 1px solid #fff; // 5
       left: {
-        color: red;
+        color: red; // 6
       }
     }
     left: 2px solid #000;
@@ -44,20 +44,63 @@ $red: #ff0000;
 
 .bar {
   font: {
-    famizy: fantasy;
+    famizy: fantasy; // 7
     size: 12px;
   }
   boder: {
     top: {
-      rigt: 1px solid #fff;
+      rigt: 1px solid #fff; // 8
       left: {
-        color: red;
+        color: red; // 9
       }
     }
-    left: 2px solid #000;
+    left: 2px solid #000; // 10
   }
 }
 
 .foo {
   margin-#{$property-y}: -2 * $hint-arrow-width;
+}
+
+// https://github.com/sasstools/sass-lint/issues/1112
+@mixin font-test1 {
+  font: {
+    family: Arial, sans-serif;
+    style: normal;
+    weight: 300;
+  }
+}
+
+@mixin font-test2 {
+  font: {
+    family: Arial, sans-serif;
+    style: normal;
+    weight: 400;
+  }
+}
+
+@mixin font-test2 {
+  font: {
+    fazily: Arial, sans-serif; // 11
+    style: normal;
+    weght: 400; // 12
+  }
+  border: {
+    top: {
+      left: {
+        radius: 5px;
+      }
+    }
+    right: 6px solid #fff;
+    botom: {
+      right: {
+        radiu: 5px; // 13
+      }
+    }
+  }
+  background: {
+    color: red;
+  }
+  background-colr: blue; // 14
+  font-size: 12rem;
 }


### PR DESCRIPTION
It seems I was being a little bit stupid when counting properties to skip in this one. Updated to fix any multiline properties.

Fixes #1112 

`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
