### PR TITLE
Fix custom properties in declarations

### DIFF
--- a/lib/rules/no-misspelled-properties.js
+++ b/lib/rules/no-misspelled-properties.js
@@ -43,7 +43,7 @@ var buildPartialProperty = function (valBlock, currentProperty) {
       var value = node.first('value');
       skipProps++;
 
-      if (prop.first().is('ident')) {
+      if (prop && prop.first().is('ident')) {
         if (value.contains('block')) {
           propList = propList.concat(
             buildPartialProperty(value.first('block'),
@@ -77,7 +77,10 @@ module.exports = {
 
     ast.traverseByType('declaration', function (node) {
       var prop = node.first('property');
-      var containsInterp = prop.contains('interpolation');
+      // declaration may include custom properties etc, check that prop is defined here
+      if (!prop) {
+        return false;
+      }
       // If we've already checked declarations in a multiline we can skip those decs here
       if (skipProps) {
         skipProps -= 1;
@@ -123,7 +126,7 @@ module.exports = {
          * If our property name contains interpolation we need to make a best guess by using a
          * partial string match as we can't be 100% on the context
          */
-        if (containsInterp) {
+        if (prop.contains('interpolation')) {
           if (!helpers.isPartialStringMatch(curProperty, propertyList)) {
             result = helpers.addUnique(result, {
               'ruleId': parser.rule.name,

--- a/tests/sass/no-misspelled-properties.sass
+++ b/tests/sass/no-misspelled-properties.sass
@@ -77,3 +77,6 @@ $red: #ff0000
     color: red
   background-colr: blue
   font-size: 12rem
+
+.element
+  --main-bg-color: brown

--- a/tests/sass/no-misspelled-properties.scss
+++ b/tests/sass/no-misspelled-properties.scss
@@ -104,3 +104,7 @@ $red: #ff0000;
   background-colr: blue; // 14
   font-size: 12rem;
 }
+
+.element {
+  --main-bg-color: brown;
+}


### PR DESCRIPTION
Fixes an unreported issue to do with custom properties in the no-misspelled-properties rule. A custom property can be found within a declaration but it won't be classed as a straight up property. I failed to check for that previously.

`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
