### PR TITLE
Check for custom properties in no-color-keywords

### DIFF
--- a/lib/rules/no-color-keywords.js
+++ b/lib/rules/no-color-keywords.js
@@ -16,7 +16,7 @@ var cssColors = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data',
  */
 var checkValidParentType = function (node) {
   if (node) {
-    return node.type === 'function' || node.type === 'variable';
+    return node.type === 'function' || node.type === 'variable' || node.type === 'customProperty';
   }
 
   return false;

--- a/lib/rules/no-color-keywords.js
+++ b/lib/rules/no-color-keywords.js
@@ -15,11 +15,11 @@ var cssColors = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data',
  * @returns {boolean} Whether the node is a valid type or not
  */
 var checkValidParentType = function (node) {
-  if (node) {
-    return node.type === 'function' || node.type === 'variable' || node.type === 'customProperty';
+  if (node && (node.is('function') || node.is('variable') || node.is('customProperty'))) {
+    return false;
   }
 
-  return false;
+  return true;
 };
 
 module.exports = {
@@ -30,7 +30,7 @@ module.exports = {
 
     ast.traverseByType('value', function (node) {
       node.traverse(function (elem, i, parent) {
-        if (elem.type === 'ident' && !checkValidParentType(parent)) {
+        if (elem.type === 'ident' && checkValidParentType(parent)) {
           var index = cssColors.indexOf(elem.content.toLowerCase());
 
           if (index !== -1) {

--- a/tests/sass/no-color-keywords.sass
+++ b/tests/sass/no-color-keywords.sass
@@ -31,3 +31,5 @@ $other: rgba($blue, 0.3)
 
 // Issue #717 - rule trips over Sass color function names
 $colors: ( 'red': red($color), 'green': green($color), 'blue': blue($color) )
+
+$badge-bg: var(--red)

--- a/tests/sass/no-color-keywords.scss
+++ b/tests/sass/no-color-keywords.scss
@@ -42,3 +42,5 @@ $colors: (
   'green': green($color),
   'blue': blue($color)
 );
+
+$badge-bg: var(--red);


### PR DESCRIPTION
Fixes #1120

Checks for custom properties when looking at color-keywords. I.e. the custom property is named `--red`.

`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
