### PR TITLE
Check before calling is method

### DIFF
--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -52,7 +52,7 @@ var findNearestReturnSCSS = function (parent, i) {
 var findNearestReturnSass = function (parent, i) {
   var previous;
 
-  if (parent.content[i - 1]) {
+  if (!parent.is('ident') && parent.content[i - 1]) {
     previous = parent.content[i - 1];
 
     if (counter === 2) {


### PR DESCRIPTION
Checks that `parent` node isn't an ident before calling `is` method on a child.

Fixes https://github.com/sasstools/sass-lint/issues/887 and closes https://github.com/sasstools/sass-lint/pull/888
 
`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`
