### PR TITLE
Fix issue with no-vendor-prefix rule & non-standard props

### DIFF
--- a/lib/rules/no-vendor-prefixes.js
+++ b/lib/rules/no-vendor-prefixes.js
@@ -1,12 +1,8 @@
 'use strict';
 
-var helpers = require('../helpers'),
-    yaml = require('js-yaml'),
-    fs = require('fs'),
-    path = require('path');
-
-var properties = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../data', 'properties.yml'), 'utf8')).split(' '),
-    prefixes = ['webkit', 'moz', 'ms'];
+var helpers = require('../helpers');
+var properties = require('known-css-properties').all;
+var prefixes = ['webkit', 'moz', 'ms'];
 
 /**
  * Returns a copy of the prefixes array so that it can be safely modified


### PR DESCRIPTION
This PR references the `known-css-properties` list to check against standard properties only when `ignore-non-standard` config setting is `false`.

```yml
no-vendor-prefixes:
    - 2
    -
      ignore-non-standard: true
```

Closes https://github.com/sasstools/sass-lint/issues/824
`<DCO 1.1 Signed-off-by: Ben Griffith gt11687@gmail.com>`
