### PR TITLE
Update hyphenated BEM regex pattern

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -178,7 +178,7 @@ helpers.isStrictBEM = function (str) {
  * @returns {boolean}     Whether str adheres to hyphenated-BEM format
  */
 helpers.isHyphenatedBEM = function (str) {
-  return !(/[A-Z]|-{3}|_{3}|[^_]_[^_]/.test(str));
+  return /^([a-z]*[-]?[a-z0-9\-]*)(\.[a-z0-9\-]*)?(__[a-z0-9]*[-]?[a-z0-9\-]*)?(--[a-z0-9]*[-]?[a-z0-9\-]*)?(\:[a-z]*)*$/.test(str);
 };
 
 helpers.isValidHex = function (str) {


### PR DESCRIPTION
related to #1051 

slight update to check for actual hyphenated BEM rather than just the characters that are allowed in the pattern. I've slightly modified what was suggested though as we don't need to look for `.` or `%` at the beginning of the name.

`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
