### PR TITLE
Npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+.github
+coverage
+docs
+tests
+.editorconfig
+.eslintrc
+.gitignore
+.npmignore
+.npmrc
+.travis.yml
+.nvmrc
+appveyor.yml
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md


### PR DESCRIPTION
fixes #986 

Removes all files and directories not required to run sass-lint to minimise the install size.

To test you can checkout this branch and run `npm pack` it should create a tar file then do `tar -tf THE_FILE_NAME` to get a list of all the files that would be created when installing from NPM

See also https://docs.npmjs.com/misc/developers

`<DCO 1.1 Signed-off-by: Dan Purdy dan@dpurdy.me>`
