### PR TITLE
Add sasslintrc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install sass-lint --save-dev
 
 ## Configuring
 
-Sass-lint can be configured from a `.sass-lint.yml` file in your project. If you don't have one in the root of your project or you would like all your projects to follow a standard config file then you can specify the path to one in your project's `package.json` file.
+Sass-lint can be configured from a `.sass-lint.yml` or `.sasslintrc` file in your project. The `.sasslintrc` file can be in either JSON format or YAML. Both formats are interchangeable easily using tools such as [json2yaml](https://www.json2yaml.com/). If you don't either file in the root of your project or you would like all your projects to follow a standard config file then you can specify the path to one in your project's `package.json` file with the `sasslintConfig` option.
 
 For example:
 ```javascript
@@ -32,7 +32,7 @@ For example:
 }
 ```
 
-Use the [Sample Config](https://github.com/sasstools/sass-lint/tree/master/docs/sass-lint.yml) as a guide to create your own `.sass-lint.yml` config file. The default configuration can be found [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml).
+Use the [Sample Config (YAML)](https://github.com/sasstools/sass-lint/tree/master/docs/sass-lint.yml) or [Sample Config (JSON)](https://github.com/sasstools/sass-lint/tree/master/docs/sasslintrc) as a guide to create your own config file. The default configuration can be found [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml).
 
 ### [Configuration Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/options)
 
@@ -47,7 +47,6 @@ The following are options that you can use to config the Sass Linter.
 * [formatter](https://github.com/sasstools/sass-lint/tree/master/docs/options/formatter.md) - Choose the format for any warnings/errors to be displayed
 * [merge-default-rules](https://github.com/sasstools/sass-lint/tree/master/docs/options/merge-default-rules.md) - Allows you to merge your rules with the default config file included with sass-lint
 * [output-file](https://github.com/sasstools/sass-lint/tree/master/docs/options/output-file.md) - Choose to write the linters output to a file
-
 
 #### Files
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,6 +52,10 @@ module.exports = function (options, configPath) {
     }
     else {
       configPath = confHelpers.findFile(false, '.sass-lint.yml');
+
+      if (!configPath) {
+        configPath = confHelpers.findFile(false, '.sasslintrc');
+      }
     }
   }
   else if (!pathIsAbsolute(configPath)) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -262,7 +262,7 @@ describe('cli', function () {
   });
 
   it('should return JSON from .sasslintrc', function (done) {
-    var command = 'sass-lint ../../cli/cli.scss --verbose';
+    var command = 'sass-lint ../../cli/cli.scss -c ".sasslintrc" --verbose';
 
     exec(command, { cwd: path.join(__dirname, 'yml', '.sasslintrc') }, function (err, stdout) {
       if (err) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -239,6 +239,48 @@ describe('cli', function () {
     });
   });
 
+  // Test default config files
+
+  it('should return JSON from .sass-lint.yml', function (done) {
+    var command = 'sass-lint ../../sass/cli.scss --verbose';
+
+    childProcess.exec(command, { cwd: path.join(__dirname, 'yml', '.sass-lint.yml') }, function (err, stdout) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        try {
+          JSON.parse(stdout);
+          return done();
+        }
+        catch (e) {
+          return done(new Error('Not JSON'));
+        }
+      }
+    });
+  });
+
+  it('should return JSON from .sasslintrc', function (done) {
+    var command = 'sass-lint ../../sass/cli.scss --verbose';
+
+    childProcess.exec(command, { cwd: path.join(__dirname, 'yml', '.sasslintrc') }, function (err, stdout) {
+
+      if (err) {
+        return done(err);
+      }
+      else {
+        try {
+          JSON.parse(stdout);
+          return done();
+        }
+        catch (e) {
+          return done(new Error('Not JSON'));
+        }
+      }
+    });
+  });
+
   // Test custom config path
 
   it('should return JSON from a custom config', function (done) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -242,7 +242,7 @@ describe('cli', function () {
   // Test default config files
 
   it('should return JSON from .sass-lint.yml', function (done) {
-    var command = 'sass-lint ../../cli/cli.scss --verbose';
+    var command = 'node ../../../bin/sass-lint ../../cli/cli.scss --verbose';
 
     exec(command, { cwd: path.join(__dirname, 'yml', '.sass-lint.yml') }, function (err, stdout) {
 
@@ -262,7 +262,7 @@ describe('cli', function () {
   });
 
   it('should return JSON from .sasslintrc', function (done) {
-    var command = 'sass-lint ../../cli/cli.scss -c ".sasslintrc" --verbose';
+    var command = 'node ../../../bin/sass-lint ../../cli/cli.scss -c ".sasslintrc" --verbose';
 
     exec(command, { cwd: path.join(__dirname, 'yml', '.sasslintrc') }, function (err, stdout) {
       if (err) {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -242,9 +242,9 @@ describe('cli', function () {
   // Test default config files
 
   it('should return JSON from .sass-lint.yml', function (done) {
-    var command = 'sass-lint ../../sass/cli.scss --verbose';
+    var command = 'sass-lint ../../cli/cli.scss --verbose';
 
-    childProcess.exec(command, { cwd: path.join(__dirname, 'yml', '.sass-lint.yml') }, function (err, stdout) {
+    exec(command, { cwd: path.join(__dirname, 'yml', '.sass-lint.yml') }, function (err, stdout) {
 
       if (err) {
         return done(err);
@@ -262,10 +262,9 @@ describe('cli', function () {
   });
 
   it('should return JSON from .sasslintrc', function (done) {
-    var command = 'sass-lint ../../sass/cli.scss --verbose';
+    var command = 'sass-lint ../../cli/cli.scss --verbose';
 
-    childProcess.exec(command, { cwd: path.join(__dirname, 'yml', '.sasslintrc') }, function (err, stdout) {
-
+    exec(command, { cwd: path.join(__dirname, 'yml', '.sasslintrc') }, function (err, stdout) {
       if (err) {
         return done(err);
       }

--- a/tests/yml/.sass-lint.yml/.sass-lint.yml
+++ b/tests/yml/.sass-lint.yml/.sass-lint.yml
@@ -1,1 +1,8 @@
-../.color-keyword-errors.yml
+options:
+  formatter: json
+  cache-config: false
+  merge-default-rules: false
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  no-color-keywords: 1

--- a/tests/yml/.sass-lint.yml/.sass-lint.yml
+++ b/tests/yml/.sass-lint.yml/.sass-lint.yml
@@ -1,0 +1,1 @@
+../.color-keyword-errors.yml

--- a/tests/yml/.sasslintrc/.sasslintrc
+++ b/tests/yml/.sasslintrc/.sasslintrc
@@ -1,1 +1,13 @@
-../.color-keyword-errors.yml
+{
+	"options": {
+		"formatter": "json",
+		"cache-config": false,
+    "merge-default-rules": false
+	},
+	"files": {
+		"include": "**/*.s+(a|c)ss"
+	},
+	"rules": {
+		"no-color-keywords": 1
+	}
+}

--- a/tests/yml/.sasslintrc/.sasslintrc
+++ b/tests/yml/.sasslintrc/.sasslintrc
@@ -1,0 +1,1 @@
+../.color-keyword-errors.yml


### PR DESCRIPTION
Reopened this PR to finally get the basics finished. We're going to need to go a bit deeper into the core config / engine rewrite soon.

The `.sasslintrc` can be either YAML or JSON format as yaml loader handles both anyway. 

** original PR text **

Adds support for a .sasslintrc config file. This will be work in progress but I'll continue from the work by @ngryman in #537

Fixes conflicts from #537

closes #533

`<DCO 1.1 Signed-off-by: Dan Purdy dan@danpurdy.co.uk>`
