### PR TITLE
Fix a crash from empty-line-between-blocks

### DIFF
--- a/lib/rules/empty-line-between-blocks.js
+++ b/lib/rules/empty-line-between-blocks.js
@@ -52,7 +52,7 @@ var findNearestReturnSCSS = function (parent, i) {
 var findNearestReturnSass = function (parent, i) {
   var previous;
 
-  if (parent.content[i - 1]) {
+  if (parent.content[i - 1] && typeof parent.content[i - 1] === 'object') {
     previous = parent.content[i - 1];
 
     if (counter === 2) {

--- a/tests/rules/empty-line-between-blocks.js
+++ b/tests/rules/empty-line-between-blocks.js
@@ -263,4 +263,18 @@ describe('empty line between blocks - sass', function () {
       done();
     });
   });
+
+  it('does not throw an error when missing a space', function (done) {
+    var file = lint.file('empty-line-adjacent-to-include.sass');
+
+    var test = function () {
+      lint.test(file, {
+        'empty-line-between-blocks': [1]
+      }, function () {
+        done();
+      });
+    };
+
+    lint.assert.doesNotThrow(test);
+  });
 });

--- a/tests/sass/empty-line-adjacent-to-include.sass
+++ b/tests/sass/empty-line-adjacent-to-include.sass
@@ -1,0 +1,14 @@
+#pages-terms
+  #terms
+    @include white-box
+    ul, ol
+      margin-left: 20px
+
+    ol
+      ol
+        list-style: upper-roman
+
+.foo
+  @include clearfix
+  .bar
+    width: 32%


### PR DESCRIPTION
The tree traversal code that was checking for space between blocks in
`.sass` files was a little too lenient when checking where it should
traverse and was actually moving into the content of an `ident` node
when there wasn't an empty line after an `@include`. This looks like:

```sass
.item
  @include my-mixin
  color: blue
```

The tree traversal is looking for a `space` node and accidentally walks
into the `ident` node for `my-mixin`.

To prevent this, we now check to see if the parent is a node before
walking into it. If the parent isn't a node, then we should halt
execution and return a violation.

I have checked whether this problem happens in `.scss` files as well and
it appears it does not due to the presence of the braces for the blocks.
This leads me to believe that the problem is purely due to relying on
whitespace for delineate blocks.

Fixes #729
Fixes #793

`<DCO 1.1 Signed-off-by: Michael Herold michael@michaeljherold.com>`