### PR TITLE
New rule: calc-without-interpolation

### DIFF
--- a/docs/rules/calc-without-interpolation.md
+++ b/docs/rules/calc-without-interpolation.md
@@ -1,0 +1,29 @@
+# Calc Without Interpolation
+
+Rule `calc-without-interpolation` will enforce that variables are interpolated inside `calc()` expressions.
+
+## Examples
+
+When enabled, the following uses of `calc()` are disallowed:
+
+```scss
+.foo {
+  margin: calc( $foo + $bar );
+}
+
+.foo {
+  margin: calc( $foo * $bar );
+}
+```
+
+The rules above need to be rewritten to the following in order to pass the validation:
+
+```scss
+.foo {
+  margin: calc( #{$foo} + #{$bar} );
+}
+
+.foo {
+  margin: calc( #{$foo} * #{$bar} );
+}
+```

--- a/lib/config/sass-lint.yml
+++ b/lib/config/sass-lint.yml
@@ -63,6 +63,7 @@ rules:
   bem-depth: 0
   border-zero: 1
   brace-style: 1
+  calc-without-interpolation: 1
   clean-import-paths: 1
   empty-args: 1
   hex-length: 1

--- a/lib/rules/calc-without-interpolation.js
+++ b/lib/rules/calc-without-interpolation.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var helpers = require('../helpers');
+
+module.exports = {
+  'name': 'calc-without-interpolation',
+  'defaults': {},
+  'detect': function (ast, parser) {
+    var result = [];
+
+    ast.traverseByType('function', function (node) {
+      if (node.content[0].content === 'calc') {
+        var isVariable = function (argument) {
+          return argument.type === 'variable';
+        };
+        var hasNonInterpolated = node.content[1].content.some(isVariable);
+
+        if (hasNonInterpolated) {
+          result = helpers.addUnique(result, {
+            'ruleId': parser.rule.name,
+            'line': node.start.line,
+            'column': node.start.column,
+            'message': 'Calc expression \'' + node.content + '\' will be calculated at compile time. Use interpolation ( #{$var} ) to calculate it in the browser.',
+            'severity': parser.severity
+          });
+        }
+      }
+    });
+
+    return result;
+  }
+};
+

--- a/tests/rules/calc-without-interpolation.js
+++ b/tests/rules/calc-without-interpolation.js
@@ -1,0 +1,36 @@
+
+'use strict';
+
+var lint = require('./_lint');
+
+//////////////////////////////
+// SCSS syntax tests
+//////////////////////////////
+describe('calc without interpolation - scss', function () {
+  var file = lint.file('calc-without-interpolation.scss');
+
+  it('[default]', function (done) {
+    lint.test(file, {
+      'calc-without-interpolation': 1
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+});
+
+//////////////////////////////
+// Sass syntax tests
+//////////////////////////////
+describe('calc without interpolation - sass', function () {
+  var file = lint.file('calc-without-interpolation.sass');
+
+  it('[default]', function (done) {
+    lint.test(file, {
+      'calc-without-interpolation': 1
+    }, function (data) {
+      lint.assert.equal(1, data.warningCount);
+      done();
+    });
+  });
+});

--- a/tests/sass/calc-without-interpolation.sass
+++ b/tests/sass/calc-without-interpolation.sass
@@ -1,0 +1,15 @@
+$foo: 1px
+$bar: 2px
+
+@function my-fn()
+  @return '2px'
+
+.foo
+  width: calc( #{$foo} + #{$bar} )
+
+.bar
+  width: calc( my-fn() + #{$foo} )
+
+// values are added at compile time
+.baz
+  width: calc( $foo + $bar )

--- a/tests/sass/calc-without-interpolation.scss
+++ b/tests/sass/calc-without-interpolation.scss
@@ -1,0 +1,20 @@
+$foo: 1px;
+$bar: 2px;
+
+@function my-fn() {
+  @return '2px';
+}
+
+.foo {
+  width: calc( #{$foo} + #{$bar} );
+}
+
+.bar {
+  width: calc( my-fn() + #{$foo} );
+}
+
+
+// values are added at compile time
+.baz {
+  width: calc( $foo + $bar );
+}


### PR DESCRIPTION
This rule prevents unintentional errors in generated output by prohibiting uses of `calc()` without interpolated variables. See the tests and the referenced issue for more information about the problem.

Fixes #1005.

`<DCO 1.1 Signed-off-by: Alex Gyoshev alex@gyoshev.net>`