### PR TITLE
More comprehensive property sort order error messages

### DIFF
--- a/docs/rules/property-sort-order.md
+++ b/docs/rules/property-sort-order.md
@@ -6,6 +6,7 @@ Rule `property-sort-order` will enforce the order in which declarations are writ
 
 * `order`: `'alphabetical'`, [`'concentric'`](http://rhodesmill.org/brandon/2011/concentric-css/), [`'recess'`](http://twitter.github.io/recess/), [`'smacss'`](http://smacss.com/book/formatting), or `[array of properties]` (defaults to `alphabetical`. Unknown properties are sorted alphabetically)
 * `ignore-custom-properties`: `true`/`false` (defaults to `false`)
+* `display-mode`: `lines`/`blocks` (defaults to `lines`)
 
 Property orders: https://github.com/sasstools/sass-lint/tree/develop/lib/config/property-sort-orders
 
@@ -99,3 +100,64 @@ When `ignore-custom-properties: true` (assume `order: 'alphabetical'`) the follo
   display: block;
 }
 ```
+
+### Display Mode
+When `display-mode: lines` every property is reported in separate message.
+
+```scss
+.foo {
+  height: 100vh;
+  display: block;
+  width: 100vw;
+  border: 1px;
+}
+```
+
+```yaml
+property-sort-order:
+  - 1
+  -
+    order:
+      - height
+      - width
+      - display
+      - color
+    display-mode: lines
+```
+
+Results:
+```
+Expected `width`, found `display`
+Expected `display`, found `width`
+```
+
+When `display-mode: blocks` linter tries to detect and report whole block.
+
+Example:
+
+```scss
+.foo {
+  height: 100vh;
+  display: block;
+  width: 100vw;
+  border: 1px;
+}
+```
+
+```yaml
+property-sort-order:
+  - 1
+  -
+    order:
+      - height
+      - width
+      - display
+      - color
+    display-mode: blocks
+```
+
+Results:
+```
+Expected order `width, display`, found `display, width`
+```
+

--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -86,11 +86,29 @@ var sortProperties = function (obj, order) {
   return sorted;
 };
 
+var addBlockMismatch = function (parser, result, blockMismatch) {
+  var message;
+  if (blockMismatch.expected.length === 1) {
+    message = 'Expected `' + blockMismatch.expected[0] + '`, found `' + blockMismatch.actual[0] + '`';
+  }
+  else {
+    message = 'Expected order `' + blockMismatch.expected.join(', ') + '`, found `' + blockMismatch.actual.join(', ') + '`';
+  }
+  return helpers.addUnique(result, {
+    'ruleId': parser.rule.name,
+    'line': blockMismatch.first.start.line,
+    'column': blockMismatch.first.start.column,
+    'message': message,
+    'severity': parser.severity
+  });
+};
+
 module.exports = {
   'name': 'property-sort-order',
   'defaults': {
     'order': 'alphabetical',
-    'ignore-custom-properties': false
+    'ignore-custom-properties': false,
+    'display-mode': 'lines'
   },
   'detect': function (ast, parser) {
     var result = [],
@@ -124,21 +142,49 @@ module.exports = {
         pKeys = Object.keys(properties);
         sKeys = Object.keys(sorted);
 
+        var blockMismatch = null;
+
         sKeys.every(function (e, i) {
           var pKey = pKeys[i],
               prop = properties[pKey];
 
           if (e !== pKey) {
-            result = helpers.addUnique(result, {
-              'ruleId': parser.rule.name,
-              'line': prop.start.line,
-              'column': prop.start.column,
-              'message': 'Expected `' + e + '`, found `' + pKey + '`',
-              'severity': parser.severity
-            });
+            if (parser.options['display-mode'] === 'lines') {
+              result = helpers.addUnique(result, {
+                'ruleId': parser.rule.name,
+                'line': prop.start.line,
+                'column': prop.start.column,
+                'message': 'Expected `' + e + '`, found `' + pKey + '`',
+                'severity': parser.severity
+              });
+            }
+            if (blockMismatch) {
+              blockMismatch.expected.push(e);
+              blockMismatch.actual.push(pKey);
+            }
+            else {
+              blockMismatch = {
+                first: prop,
+                expected: [e],
+                actual: [pKey]
+              };
+            }
+          }
+          else {
+            if (blockMismatch) {
+              if (parser.options['display-mode'] === 'blocks') {
+                result = addBlockMismatch(parser, result, blockMismatch);
+              }
+              blockMismatch = null;
+            }
           }
           return true;
         });
+        if (blockMismatch) {
+          if (parser.options['display-mode'] === 'blocks') {
+            result = addBlockMismatch(parser, result, blockMismatch);
+          }
+        }
       }
     });
 

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -50,6 +50,26 @@ describe('property sort order - scss', function () {
     });
   });
 
+  it('[order: custom, display-mode: blocks]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'height',
+            'width',
+            'display',
+            'color'
+          ],
+          'display-mode': 'blocks'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(4, data.warningCount);
+      done();
+    });
+  });
+
   it('[order: custom + composes, ignore-custom-properties: false]', function (done) {
     lint.test(file, {
       'property-sort-order': [
@@ -178,6 +198,26 @@ describe('property sort order - sass', function () {
       ]
     }, function (data) {
       lint.assert.equal(8, data.warningCount);
+      done();
+    });
+  });
+
+  it('[order: custom, display-mode: blocks]', function (done) {
+    lint.test(file, {
+      'property-sort-order': [
+        1,
+        {
+          'order': [
+            'height',
+            'width',
+            'display',
+            'color'
+          ],
+          'display-mode': 'blocks'
+        }
+      ]
+    }, function (data) {
+      lint.assert.equal(4, data.warningCount);
       done();
     });
   });


### PR DESCRIPTION
<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

**What do the changes you have made achieve?**
This PR introduces new option for property-sort-order rule: display-mode: lines/blocks.
Display Mode"lines" (default) works as before. Display mode "blocks" tries to agregate wrongly sorted properties in longer blocks and displays one message per detected block instead of per single line. Message for block contains expected and actual order of properties in block.
There is naive algorithm used for block detection, may not support correctly some corner cases but in general should give better (or at least not worse) advices that original.

**Are there any new warning messages?**
Yes, introduces messages like: 
"Expected order `width, display`, found `display, width`"
instead of
"Expected `width`, found `display`"
"Expected `display`, found `width`"
for detected blocks (single element blocks are reported as before).

**Have you written tests?**
Yes, single test in both scss and sass suites.

**Have you included relevant documentation**
Yes

**Which issues does this resolve?**
Closes #416

`<DCO 1.1 Signed-off-by: Rafal Witczak raf_w87@wp.pl>`
