### PR TITLE
:bug: Add missing .sasslintrc JSON example file and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For example:
 }
 ```
 
-Use the [Sample Config (YAML)](https://github.com/sasstools/sass-lint/tree/master/docs/sass-lint.yml) or [Sample Config (JSON)](https://github.com/sasstools/sass-lint/tree/master/docs/sasslintrc) as a guide to create your own config file. The default configuration can be found [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml).
+Use the [Sample Config (YAML)](https://github.com/sasstools/sass-lint/tree/master/docs/sass-lint.yml) or [Sample Config (JSON)](https://github.com/sasstools/sass-lint/tree/master/docs/.sasslintrc) as a guide to create your own config file. The default configuration can be found [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml).
 
 ### [Configuration Documentation](https://github.com/sasstools/sass-lint/tree/master/docs/options)
 

--- a/docs/.sasslintrc
+++ b/docs/.sasslintrc
@@ -1,0 +1,63 @@
+{
+  "options": {
+    "merge-default-rules": false,
+    "formatter": "html",
+    "output-file": "linters/sass-lint.html",
+    "max-warnings": 50
+  },
+  "files": {
+    "include": "sass/**/*.s+(a|c)ss",
+    "ignore": [
+      "sass/vendor/**/*.*"
+    ]
+  },
+  "rules": {
+    "extends-before-mixins": 2,
+    "extends-before-declarations": 2,
+    "placeholder-in-extend": 2,
+    "mixins-before-declarations": [
+      2,
+      {
+        "exclude": [
+          "breakpoint",
+          "mq"
+        ]
+      }
+    ],
+    "no-warn": 1,
+    "no-debug": 1,
+    "no-ids": 2,
+    "no-important": 2,
+    "hex-notation": [
+      2,
+      {
+        "style": "uppercase"
+      }
+    ],
+    "indentation": [
+      2,
+      {
+        "size": 2
+      }
+    ],
+    "property-sort-order": [
+      1,
+      {
+        "order": [
+          "display",
+          "margin"
+        ],
+        "ignore-custom-properties": true
+      }
+    ],
+    "variable-for-property": [
+      2,
+      {
+        "properties": [
+          "margin",
+          "content"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**What do the changes you have made achieve?**
Help other developers who want to use the .sasslintrc file in JSON format with their projects
**Are there any new warning messages?**
No
**Have you written tests?**
No
**Have you included relevant documentation**
Yes
**Which issues does this resolve?**
This fixes issue #1168

`<DCO 1.1 Signed-off-by: Samuel R. Sheldon samuelrsheldon@gmail.com>`
