### PR TITLE
Update smacss property order

### DIFF
--- a/lib/config/property-sort-orders/smacss.yml
+++ b/lib/config/property-sort-orders/smacss.yml
@@ -5,14 +5,49 @@
 
 order:
 
+  # Heading
+  
+  - 'content'
+  - 'quotes'
+
   # Box
 
   - 'display'
+  - 'visibility'
+  
   - 'position'
+  - 'z-index'
   - 'top'
   - 'right'
   - 'bottom'
   - 'left'
+  
+  - 'box-sizing'
+  
+  - 'grid'
+  - 'grid-after'
+  - 'grid-area'
+  - 'grid-auto-columns'
+  - 'grid-auto-flow'
+  - 'grid-auto-rows'
+  - 'grid-before'
+  - 'grid-column'
+  - 'grid-column-end'
+  - 'grid-column-gap'
+  - 'grid-column-start'
+  - 'grid-columns'
+  - 'grid-end'
+  - 'grid-gap'
+  - 'grid-row'
+  - 'grid-row-end'
+  - 'grid-row-gap'
+  - 'grid-row-start'
+  - 'grid-rows'
+  - 'grid-start'
+  - 'grid-template'
+  - 'grid-template-areas'
+  - 'grid-template-columns'
+  - 'grid-template-rows'
 
   - 'flex'
   - 'flex-basis'
@@ -30,7 +65,6 @@ order:
   - 'width'
   - 'min-width'
   - 'max-width'
-
   - 'height'
   - 'min-height'
   - 'max-height'
@@ -49,6 +83,13 @@ order:
 
   - 'float'
   - 'clear'
+  
+  - 'overflow'
+  - 'overflow-x'
+  - 'overflow-y'
+  
+  - 'clip'
+  - 'zoom'
 
   - 'columns'
   - 'column-gap'
@@ -57,17 +98,41 @@ order:
   - 'column-span'
   - 'column-count'
   - 'column-width'
+  
+  - 'table-layout'
+  - 'empty-cells'
+  - 'caption-side'
+  - 'border-spacing'
+  - 'border-collapse'
+  - 'list-style'
+  - 'list-style-position'
+  - 'list-style-type'
+  - 'list-style-image'
+  
+  # Animation
 
   - 'transform'
-  - 'transform-box'
   - 'transform-origin'
   - 'transform-style'
+  - 'transform-box'
+  - 'backface-visibility'
+  - 'perspective'
+  - 'perspective-origin'
   
   - 'transition'
-  - 'transition-delay'
-  - 'transition-duration'
   - 'transition-property'
+  - 'transition-duration'
   - 'transition-timing-function'
+  - 'transition-delay'
+  
+  - 'animation'
+  - 'animation-name'
+  - 'animation-duration'
+  - 'animation-play-state'
+  - 'animation-timing-function'
+  - 'animation-delay'
+  - 'animation-iteration-count'
+  - 'animation-direction'
 
   # Border
 
@@ -105,8 +170,16 @@ order:
   - 'outline-offset'
   - 'outline-style'
   - 'outline-width'
+  
+  - 'stroke-width'
+  - 'stroke-linecap'
+  - 'stroke-dasharray'
+  - 'stroke-dashoffset'
+  - 'stroke'
 
   # Background
+  
+  - 'opacity'
 
   - 'background'
   - 'background-attachment'
@@ -116,6 +189,8 @@ order:
   - 'background-repeat'
   - 'background-position'
   - 'background-size'
+  - 'box-shadow'
+  - 'fill'
 
   # Text
 
@@ -124,41 +199,62 @@ order:
   - 'font'
   - 'font-family'
   - 'font-size'
+  - 'font-size-adjust'
+  - 'font-stretch'
+  - 'font-effect'
   - 'font-smoothing'
   - 'font-style'
   - 'font-variant'
   - 'font-weight'
+  
+  - 'font-emphasize'
+  - 'font-emphasize-position'
+  - 'font-emphasize-style'
 
   - 'letter-spacing'
   - 'line-height'
-  - 'list-style'
+  - 'word-spacing'
 
   - 'text-align'
+  - 'text-align-last'
   - 'text-decoration'
   - 'text-indent'
+  - 'text-justify'
   - 'text-overflow'
+  - 'text-overflow-ellipsis'
+  - 'text-overflow-mode'
   - 'text-rendering'
+  - 'text-outline'
   - 'text-shadow'
   - 'text-transform'
   - 'text-wrap'
+  - 'word-wrap'
+  - 'word-break'
 
+  - 'text-emphasis'
+  - 'text-emphasis-color'
+  - 'text-emphasis-style'
+  - 'text-emphasis-position'
+
+  - 'vertical-align'
   - 'white-space'
   - 'word-spacing'
+  - 'hyphens'
+
+  - 'src'
 
   # Other
 
-  - 'border-collapse'
-  - 'border-spacing'
-  - 'box-shadow'
-  - 'caption-side'
-  - 'content'
+  - 'tab-size'
+  - 'counter-reset'
+  - 'counter-increment'
+  - 'resize'
   - 'cursor'
-  - 'empty-cells'
-  - 'opacity'
-  - 'overflow'
-  - 'quotes'
+  - 'pointer-events'
   - 'speak'
-  - 'table-layout'
-  - 'vertical-align'
-  - 'visibility'
-  - 'z-index'
+  - 'user-select'
+  - 'nav-index'
+  - 'nav-up'
+  - 'nav-right'
+  - 'nav-down'
+  - 'nav-left'

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -114,7 +114,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -246,7 +246,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });


### PR DESCRIPTION
Update the list in smacss.yml to match https://github.com/brigade/scss-lint/blob/master/data/property-sort-orders/smacss.txt. This list also included 'transform-box', 'background-attachment', 'background-clip' and 'font-smoothing', so these are retained in the natural places.

This ensures that the property list and sort order applied when using the property-sort-order rule with order: smacss will use the latest sort order and include all relevant properties.

This PR includes an update to the tests, as the test file now produces 14 warnings when the smacss sort order is applied. It does not include documentation as it is a straight update of an existing behaviour.

Closes #1171 

`<DCO 1.1 Signed-off-by: Dave Clark dave.clark@uk.ibm.com>`
