### PR TITLE
Fix #1189, accept CSS custom properties

### DIFF
--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -99,7 +99,7 @@ module.exports = {
 
       if (block) {
         block.forEach('declaration', function (dec) {
-          var prop = dec.first('property'),
+          var prop = dec.first('property') || dec.first('customProperty'),
               name = prop.first('ident');
 
           if (name) {


### PR DESCRIPTION
Fix the property-sort-order rule to accept CSS custom properties (e.g. `--my-var: 20px;`) by checking not only for `property` but also for `customProperty`.

`<DCO 1.1 Signed-off-by: David Enke <david.enke@zalari.de>>`
