### PR TITLE
🐛 Fix unhandled errors leading to stack trace on stdout (closes #1057)

### DIFF
--- a/bin/sass-lint.js
+++ b/bin/sass-lint.js
@@ -20,7 +20,12 @@ var detectPattern = function (pattern) {
   var detects = lint.lintFiles(pattern, configOptions, configPath);
 
   if (program.exit) {
-    lint.failOnError(detects, configOptions, configPath);
+    try {
+      lint.failOnError(detects, configOptions, configPath);
+    }
+    catch (e) {
+      console.error(e.message);
+    }
   }
   return detects;
 };

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -450,6 +450,20 @@ describe('cli', function () {
     });
   });
 
+  it('should not throw an error on program.exit', function (done) {
+    var command = 'node bin/sass-lint tests/cli/cli-error.scss -c tests/yml/.error-output.yml --verbose';
+
+    exec(command, function (err, stdout, stderr) {
+      if (!err) {
+        return done();
+      }
+
+      assert(stderr.indexOf('throw') < 0);
+
+      return done();
+    });
+  });
+
   /**
    * We disabled eslints handle callback err rule here as we are deliberately throwing errors that we don't care about
    */


### PR DESCRIPTION
This PR is a fix for issue #1057 where unhandled errors thrown from `index.js[303]:sassLint.failOnError()` were leaking out to stdout. This resulted in `--format json` to no longer outputting mere json but a stack trace, breaking functionality.

Example without fix:

```
$ node bin/sass-lint tests/cli/cli-error.scss -c tests/yml/.error-output.yml --verbose
/home/fili/Projects/forks/sass-lint/index.js:313
    throw new exceptions.SassLintFailureError(errorCount.count + ' errors were detected in \n- ' + errorCount.files.join('\n- '));
    ^
SassLintFailureError: 1 errors were detected in 
- tests/cli/cli-error.scss
    at Function.sassLint.failOnError (/home/fili/Projects/forks/sass-lint/index.js:313:11)
    at detectPattern (/home/fili/Projects/forks/sass-lint/bin/sass-lint.js:24:12)
    at /home/fili/Projects/forks/sass-lint/bin/sass-lint.js:83:32
    at Array.forEach (<anonymous>)
    at /home/fili/Projects/forks/sass-lint/bin/sass-lint.js:82:18
    at Object.<anonymous> (/home/fili/Projects/forks/sass-lint/bin/sass-lint.js:94:2)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
```

Example with fix:
```
$ node bin/sass-lint tests/cli/cli-error.scss -c tests/yml/.error-output.yml --verbose

```