### PR TITLE
Stop `property-sort-order` from throwing with css variables

### DIFF
--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -99,8 +99,14 @@ module.exports = {
 
       if (block) {
         block.forEach('declaration', function (dec) {
-          var prop = dec.first('property'),
-              name = prop.first('ident');
+          var prop = dec.first('property');
+
+          // CSS Variables will not contain any `property` nodes.
+          if (!prop) {
+            return;
+          }
+
+          var name = prop.first('ident');
 
           if (name) {
             if (parser.options['ignore-custom-properties']) {

--- a/tests/sass/property-sort-order.sass
+++ b/tests/sass/property-sort-order.sass
@@ -1,4 +1,5 @@
 .foo
+  --css-variable: 100vh;
   height: 100vh
   display: block
   width: 100vw

--- a/tests/sass/property-sort-order.scss
+++ b/tests/sass/property-sort-order.scss
@@ -1,4 +1,5 @@
 .foo {
+  --css-variable: 100vh;
   height: 100vh;
   display: block;
   width: 100vw;


### PR DESCRIPTION
**What do the changes you have made achieve?**

>Prevent the `property-sort-order` from throwing errors when css variables are present

**Are there any new warning messages?**

>No

**Have you written tests?**

>I haven't added a new test, but I've added css variable declarations to the test file to show it throwing before the fix and not throwing after.

**Have you included relevant documentation**

>N/A

**Which issues does this resolve?**

Fixes #1224 

`DCO 1.1 Signed-off-by: Justin Anastos <justin.anastos@gmail.com>`
