### PR TITLE
Bring smacss sort order configuration up to date with scss-lint's

### DIFF
--- a/lib/config/property-sort-orders/smacss.yml
+++ b/lib/config/property-sort-orders/smacss.yml
@@ -5,14 +5,49 @@
 
 order:
 
+  # Heading
+
+  - 'content'
+  - 'quotes'
+
   # Box
 
   - 'display'
+  - 'visibility'
+
   - 'position'
+  - 'z-index'
   - 'top'
   - 'right'
   - 'bottom'
   - 'left'
+
+  - 'box-sizing'
+
+  - 'grid'
+  - 'grid-after'
+  - 'grid-area'
+  - 'grid-auto-columns'
+  - 'grid-auto-flow'
+  - 'grid-auto-rows'
+  - 'grid-before'
+  - 'grid-column'
+  - 'grid-column-end'
+  - 'grid-column-gap'
+  - 'grid-column-start'
+  - 'grid-columns'
+  - 'grid-end'
+  - 'grid-gap'
+  - 'grid-row'
+  - 'grid-row-end'
+  - 'grid-row-gap'
+  - 'grid-row-start'
+  - 'grid-rows'
+  - 'grid-start'
+  - 'grid-template'
+  - 'grid-template-areas'
+  - 'grid-template-columns'
+  - 'grid-template-rows'
 
   - 'flex'
   - 'flex-basis'
@@ -30,7 +65,6 @@ order:
   - 'width'
   - 'min-width'
   - 'max-width'
-
   - 'height'
   - 'min-height'
   - 'max-height'
@@ -50,6 +84,13 @@ order:
   - 'float'
   - 'clear'
 
+  - 'overflow'
+  - 'overflow-x'
+  - 'overflow-y'
+
+  - 'clip'
+  - 'zoom'
+
   - 'columns'
   - 'column-gap'
   - 'column-fill'
@@ -58,16 +99,39 @@ order:
   - 'column-count'
   - 'column-width'
 
+  - 'table-layout'
+  - 'empty-cells'
+  - 'caption-side'
+  - 'border-spacing'
+  - 'border-collapse'
+  - 'list-style'
+  - 'list-style-position'
+  - 'list-style-type'
+  - 'list-style-image'
+
+  # Animation
+
   - 'transform'
-  - 'transform-box'
   - 'transform-origin'
   - 'transform-style'
-  
+  - 'backface-visibility'
+  - 'perspective'
+  - 'perspective-origin'
+
   - 'transition'
-  - 'transition-delay'
-  - 'transition-duration'
   - 'transition-property'
+  - 'transition-duration'
   - 'transition-timing-function'
+  - 'transition-delay'
+
+  - 'animation'
+  - 'animation-name'
+  - 'animation-duration'
+  - 'animation-play-state'
+  - 'animation-timing-function'
+  - 'animation-delay'
+  - 'animation-iteration-count'
+  - 'animation-direction'
 
   # Border
 
@@ -106,16 +170,24 @@ order:
   - 'outline-style'
   - 'outline-width'
 
+  - 'stroke-width'
+  - 'stroke-linecap'
+  - 'stroke-dasharray'
+  - 'stroke-dashoffset'
+  - 'stroke'
+
   # Background
 
+  - 'opacity'
+
   - 'background'
-  - 'background-attachment'
-  - 'background-clip'
   - 'background-color'
   - 'background-image'
   - 'background-repeat'
   - 'background-position'
   - 'background-size'
+  - 'box-shadow'
+  - 'fill'
 
   # Text
 
@@ -124,41 +196,62 @@ order:
   - 'font'
   - 'font-family'
   - 'font-size'
-  - 'font-smoothing'
+  - 'font-size-adjust'
+  - 'font-stretch'
+  - 'font-effect'
   - 'font-style'
   - 'font-variant'
   - 'font-weight'
 
+  - 'font-emphasize'
+  - 'font-emphasize-position'
+  - 'font-emphasize-style'
+
   - 'letter-spacing'
   - 'line-height'
   - 'list-style'
+  - 'word-spacing'
 
   - 'text-align'
+  - 'text-align-last'
   - 'text-decoration'
   - 'text-indent'
+  - 'text-justify'
   - 'text-overflow'
+  - 'text-overflow-ellipsis'
+  - 'text-overflow-mode'
   - 'text-rendering'
+  - 'text-outline'
   - 'text-shadow'
   - 'text-transform'
   - 'text-wrap'
+  - 'word-wrap'
+  - 'word-break'
 
+  - 'text-emphasis'
+  - 'text-emphasis-color'
+  - 'text-emphasis-style'
+  - 'text-emphasis-position'
+
+  - 'vertical-align'
   - 'white-space'
   - 'word-spacing'
+  - 'hyphens'
+
+  - 'src'
 
   # Other
 
-  - 'border-collapse'
-  - 'border-spacing'
-  - 'box-shadow'
-  - 'caption-side'
-  - 'content'
+  - 'tab-size'
+  - 'counter-reset'
+  - 'counter-increment'
+  - 'resize'
   - 'cursor'
-  - 'empty-cells'
-  - 'opacity'
-  - 'overflow'
-  - 'quotes'
+  - 'pointer-events'
   - 'speak'
-  - 'table-layout'
-  - 'vertical-align'
-  - 'visibility'
-  - 'z-index'
+  - 'user-select'
+  - 'nav-index'
+  - 'nav-up'
+  - 'nav-right'
+  - 'nav-down'
+  - 'nav-left'

--- a/tests/rules/property-sort-order.js
+++ b/tests/rules/property-sort-order.js
@@ -114,7 +114,7 @@ describe('property sort order - scss', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });
@@ -246,7 +246,7 @@ describe('property sort order - sass', function () {
         }
       ]
     }, function (data) {
-      lint.assert.equal(12, data.warningCount);
+      lint.assert.equal(14, data.warningCount);
       done();
     });
   });


### PR DESCRIPTION
Quoting the lastest comment (@JWess's) in #1166:

> ... `sass-lint` is behind `scss-lint`, as `scss-lint` has now added the grid properties:
> 
> https://github.com/brigade/scss-lint/blob/master/data/property-sort-orders/smacss.txt

I updated the `smacss` sort order file according to the reference.

**What do the changes you have made achieve?**

Update `smacss` sort order to match that of other projects.

**Are there any new warning messages?**

Shouldn't be – will check out later on.

**Have you written tests?**

Yes. I updated the tests accordingly, just has it was done the last time we brought `smacss.yaml` up to date. The tests update are within their own separate commit (a7ce9ae).

**Have you included relevant documentation**

Deemed irrelevant.

**Which issues does this resolve?**

#1171 (sort of), once published. I didn't create an issue just for this.