### PR TITLE
Fix #1267 no support to #RRGGBBAA CSS 4 hex color

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -182,10 +182,7 @@ helpers.isHyphenatedBEM = function (str) {
 };
 
 helpers.isValidHex = function (str) {
-  if (str.match(/^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
-    return true;
-  }
-  return false;
+  return /^([a-f0-9]{8}|[a-f0-9]{6}|[a-f0-9]{4}|[a-f0-9]{3})$/i.test(str);
 };
 
 /**


### PR DESCRIPTION
<!--
## New Pull Request Information

Please make sure you have read through our [contribution guidelines](https://github.com/sasstools/sass-lint/blob/develop/CONTRIBUTING.md#pull-requests) before submitting a pull request.

Most importantly your pull request should provide information on what the changes do and they should reference an already created issue. e.g. 'Fixes #80' for bugs and 'Closes #90' for other issues.

Please use the headings below as guidance, you don't need to answer them point for point but the contents give you an idea of what we'd like to know about your PR.

You must also include your agreement to the developer certificate of origin below.

-->

**What do the changes you have made achieve?**
Fix no support to #RRGGBBAA CSS 4 hex color on sass lint files
**Have you included relevant documentation**
[https://drafts.csswg.org/css-color/#hex-notation](https://drafts.csswg.org/css-color/#hex-notation)
**Which issues does this resolve?**
#1267 
`<DCO 1.1 Signed-off-by: Gustavo Perenciolo contategustavoh@gmail.com>`
