### PR TITLE
Fix error: cannot read property first of undefined

### DIFF
--- a/lib/rules/property-sort-order.js
+++ b/lib/rules/property-sort-order.js
@@ -99,7 +99,7 @@ module.exports = {
 
       if (block) {
         block.forEach('declaration', function (dec) {
-          var prop = dec.first('property'),
+          var prop = dec.first('property') || dec.first('customProperty'),
               name = prop.first('ident');
 
           if (name) {


### PR DESCRIPTION
## New Pull Request Information
When declaring a css variable an error is thrown while linting with sort properties because the declaration doesn't contain a property node but instead a customProperty node

## Reproduction
```sass
.columns.is-variable
  --columnGap: 0.75rem
```


## Log
```log
Node {
  type: 'declaration',
  content: [
    Node {
      type: 'customProperty',
      content: [Array],
      syntax: 'sass',
      start: [Object],
      end: [Object]
    },
    Node {
      type: 'propertyDelimiter',
      content: ':',
      syntax: 'sass',
      start: [Object],
      end: [Object]
    },
    Node {
      type: 'space',
      content: ' ',
      syntax: 'sass',
      start: [Object],
      end: [Object]
    },
    Node {
      type: 'value',
      content: [Array],
      syntax: 'sass',
      start: [Object],
      end: [Object]
    }
  ],
  syntax: 'sass',
  start: { line: 467, column: 5 },
  end: { line: 467, column: 24 }
}
@error     TypeError: Cannot read property 'first' of null
    at /home/tofandel/Desktop/bulma/node_modules/sass-lint/lib/rules/property-sort-order.js:110:27
    at Node.forEach (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:183:83)
    at Node.<anonymous> (/home/tofandel/Desktop/bulma/node_modules/sass-lint/lib/rules/property-sort-order.js:106:15)
    at /home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:312:41
    at Node.traverse (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:292:6)
    at Node.traverse (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:297:36)
    at Node.traverse (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:297:36)
    at Node.traverse (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:297:36)
    at Node.traverse (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:297:36)
    at Node.traverseByType (/home/tofandel/Desktop/bulma/node_modules/gonzales-pe-sl/lib/gonzales.js:311:11)

```

This fixes that error 

`<DCO 1.1 Signed-off-by: Adrien Foulon>`
